### PR TITLE
ci: skip tests on docs-only changes, increase badge timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,27 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          fetch-depth: 0
+      - name: Check for code changes
+        id: changes
+        run: |
+          BASE_REF="${{ github.event.pull_request.base.sha || github.event.before }}"
+          if git diff --name-only "$BASE_REF"...HEAD | grep -qvE '\.md$|^docs/'; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "code=false" >> "$GITHUB_OUTPUT"
+          fi
+      - if: steps.changes.outputs.code == 'true'
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
-      - run: npm ci
-      - run: npm test
-      - run: npm run lint:api
+      - if: steps.changes.outputs.code == 'true'
+        run: npm ci
+      - if: steps.changes.outputs.code == 'true'
+        run: npm test
+      - if: steps.changes.outputs.code == 'true'
+        run: npm run lint:api
+      - if: steps.changes.outputs.code == 'false'
+        run: echo "Docs-only change -- skipping tests and lint."

--- a/.github/workflows/vibe-coded-badge.yml
+++ b/.github/workflows/vibe-coded-badge.yml
@@ -11,7 +11,7 @@ jobs:
   update-badge:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[skip vibe-badge]')"
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:


### PR DESCRIPTION
## Summary
- CI job always runs (satisfying the required `test` status check on main) but skips npm install/test/lint when only `.md` files and `docs/` changed
- Vibe-coded badge workflow timeout increased from 5 to 10 minutes

## Test plan
- [ ] Push a docs-only change — CI should pass with "Docs-only change" message, no npm install
- [ ] Push a code change — CI should run full test suite as before