### PR TITLE
ci: add workflow_dispatch to vibe-coded badge

### DIFF
--- a/.github/workflows/vibe-coded-badge.yml
+++ b/.github/workflows/vibe-coded-badge.yml
@@ -3,6 +3,7 @@ name: Update Vibe Coded Badge
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` trigger so the badge workflow can be run manually from the Actions UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)