### PR TITLE
fix: inline vibe-coded badge with composite action

### DIFF
--- a/.github/actions/vibe-badge/action.yml
+++ b/.github/actions/vibe-badge/action.yml
@@ -67,13 +67,16 @@ runs:
 
         echo "Updating badge: ${PERCENT}% vibe coded (${DOMINANT_AI}, logo: ${LOGO})"
 
-        # Build the new badge markdown
-        NEW_BADGE="[![Vibe Coded ${PERCENT}%](https://img.shields.io/badge/Vibe_Coded_${PERCENT}%25-${BADGE_COLOR}?logo=${LOGO}&logoColor=white)](https://github.com/ai-ecoverse/vibe-coded-badge-action)"
+        # Build the new badge markdown (two-part: grey left with logo+%, pink right with text)
+        NEW_BADGE="[![${PERCENT}% Vibe Coded](https://img.shields.io/badge/${PERCENT}%25-Vibe_Coded-${BADGE_COLOR}?style=flat&logo=${LOGO}&logoColor=white)](https://github.com/ai-ecoverse/vibe-coded-badge-action)"
         export NEW_BADGE
 
         # Replace any existing Vibe Coded badge (with or without percentage) inline
+        # Matches both formats:
+        #   [![Vibe Coded...](https://img.shields.io/badge/Vibe_Coded...)](...)
+        #   [![99% Vibe Coded](https://img.shields.io/badge/99%25-Vibe_Coded...)](...)
         perl -pi -e '
-          s/\[!\[(?:\d+%[ _])?Vibe[ _]Coded[^\]]*\]\(https:\/\/img\.shields\.io\/badge\/(?:\d+%25[-_])?Vibe_Coded[^)]*\)\]\([^)]*\)/$ENV{NEW_BADGE}/g
+          s/\[!\[(?:\d+%[ _])?Vibe[ _]Coded[^\]]*\]\(https:\/\/img\.shields\.io\/badge\/(?:\d+%25-)?Vibe_Coded[^)]*\)\]\([^)]*\)/$ENV{NEW_BADGE}/g
         ' "$README_PATH"
 
         # Check if anything changed

--- a/.github/actions/vibe-badge/action.yml
+++ b/.github/actions/vibe-badge/action.yml
@@ -1,7 +1,7 @@
 name: Vibe Coded Badge (Inline)
 description: >
-  Runs vibe-coded-badge-action for analysis, then updates the badge inline
-  in the README badge row instead of adding a standalone badge.
+  Runs vibe-coded-badge-action analysis script directly, then updates
+  the badge inline in the README badge row.
 
 inputs:
   github-token:
@@ -17,11 +17,30 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: ai-ecoverse/vibe-coded-badge-action@d5f3861ac5325ace00ae4ff2419d971c36b8d39c # main
-      id: analysis
+    - name: Restore vibe-badge cache
+      uses: actions/cache@v4
       with:
-        github-token: ${{ inputs.github-token }}
-        debug: 'true'
+        path: .vibe-cache.json
+        key: vibe-badge-${{ github.run_id }}
+        restore-keys: vibe-badge-
+
+    - name: Run vibe analysis
+      id: analysis
+      shell: bash
+      run: |
+        curl -sL https://raw.githubusercontent.com/ai-ecoverse/vibe-coded-badge-action/d5f3861ac5325ace00ae4ff2419d971c36b8d39c/update-vibe-badge.sh \
+          -o /tmp/vibe-analysis.sh
+        chmod +x /tmp/vibe-analysis.sh
+        bash /tmp/vibe-analysis.sh
+      env:
+        DEBUG: 'true'
+        README_PATH: ${{ inputs.readme-path }}
+        BADGE_STYLE: flat
+        BADGE_COLOR: ${{ inputs.badge-color }}
+        BADGE_TEXT: Vibe_Coded
+        COMMIT_MESSAGE: unused
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+        CACHE_FILE: .vibe-cache.json
 
     - name: Update inline badge
       shell: bash
@@ -31,6 +50,11 @@ runs:
         README_PATH: ${{ inputs.readme-path }}
         BADGE_COLOR: ${{ inputs.badge-color }}
       run: |
+        if [ -z "$PERCENT" ]; then
+          echo "::error::Analysis produced no percentage output"
+          exit 1
+        fi
+
         # Map dominant AI to logo
         case "$DOMINANT_AI" in
           Claude|Terragon|Cline) LOGO="claude" ;;
@@ -45,15 +69,12 @@ runs:
 
         # Build the new badge markdown
         NEW_BADGE="[![Vibe Coded ${PERCENT}%](https://img.shields.io/badge/Vibe_Coded_${PERCENT}%25-${BADGE_COLOR}?logo=${LOGO}&logoColor=white)](https://github.com/ai-ecoverse/vibe-coded-badge-action)"
+        export NEW_BADGE
 
         # Replace any existing Vibe Coded badge (with or without percentage) inline
-        # Matches: [![Vibe Coded...](https://img.shields.io/badge/Vibe_Coded...)](...)
-        # Also matches: [![99% Vibe_Coded...](https://img.shields.io/badge/99%25-Vibe_Coded...)](...)
         perl -pi -e '
           s/\[!\[(?:\d+%[ _])?Vibe[ _]Coded[^\]]*\]\(https:\/\/img\.shields\.io\/badge\/(?:\d+%25[-_])?Vibe_Coded[^)]*\)\]\([^)]*\)/$ENV{NEW_BADGE}/g
         ' "$README_PATH"
-
-        export NEW_BADGE
 
         # Check if anything changed
         if git diff --quiet "$README_PATH"; then

--- a/.github/actions/vibe-badge/action.yml
+++ b/.github/actions/vibe-badge/action.yml
@@ -1,0 +1,69 @@
+name: Vibe Coded Badge (Inline)
+description: >
+  Runs vibe-coded-badge-action for analysis, then updates the badge inline
+  in the README badge row instead of adding a standalone badge.
+
+inputs:
+  github-token:
+    description: PAT with contents:write to push to protected branches
+    required: true
+  readme-path:
+    description: Path to the README file
+    default: README.md
+  badge-color:
+    description: Badge color hex
+    default: ff69b4
+
+runs:
+  using: composite
+  steps:
+    - uses: ai-ecoverse/vibe-coded-badge-action@d5f3861ac5325ace00ae4ff2419d971c36b8d39c # main
+      id: analysis
+      with:
+        github-token: ${{ inputs.github-token }}
+        debug: 'true'
+
+    - name: Update inline badge
+      shell: bash
+      env:
+        PERCENT: ${{ steps.analysis.outputs.percentage }}
+        DOMINANT_AI: ${{ steps.analysis.outputs.dominant-ai }}
+        README_PATH: ${{ inputs.readme-path }}
+        BADGE_COLOR: ${{ inputs.badge-color }}
+      run: |
+        # Map dominant AI to logo
+        case "$DOMINANT_AI" in
+          Claude|Terragon|Cline) LOGO="claude" ;;
+          OpenAI|Aider|Kimi) LOGO="openai" ;;
+          Cursor|OpenCode|Copilot) LOGO="githubcopilot" ;;
+          Windsurf) LOGO="windsurf" ;;
+          Gemini|Jules) LOGO="google" ;;
+          *) LOGO="githubcopilot" ;;
+        esac
+
+        echo "Updating badge: ${PERCENT}% vibe coded (${DOMINANT_AI}, logo: ${LOGO})"
+
+        # Build the new badge markdown
+        NEW_BADGE="[![Vibe Coded ${PERCENT}%](https://img.shields.io/badge/Vibe_Coded_${PERCENT}%25-${BADGE_COLOR}?logo=${LOGO}&logoColor=white)](https://github.com/ai-ecoverse/vibe-coded-badge-action)"
+
+        # Replace any existing Vibe Coded badge (with or without percentage) inline
+        # Matches: [![Vibe Coded...](https://img.shields.io/badge/Vibe_Coded...)](...)
+        # Also matches: [![99% Vibe_Coded...](https://img.shields.io/badge/99%25-Vibe_Coded...)](...)
+        perl -pi -e '
+          s/\[!\[(?:\d+%[ _])?Vibe[ _]Coded[^\]]*\]\(https:\/\/img\.shields\.io\/badge\/(?:\d+%25[-_])?Vibe_Coded[^)]*\)\]\([^)]*\)/$ENV{NEW_BADGE}/g
+        ' "$README_PATH"
+
+        export NEW_BADGE
+
+        # Check if anything changed
+        if git diff --quiet "$README_PATH"; then
+          echo "Badge already up to date"
+          exit 0
+        fi
+
+        echo "Badge updated in $README_PATH"
+        git config user.name 'github-actions[bot]'
+        git config user.email 'github-actions[bot]@users.noreply.github.com'
+        git add "$README_PATH"
+        git commit -m "Update vibe-coded badge to ${PERCENT}% [skip vibe-badge]"
+        git push origin HEAD

--- a/.github/workflows/vibe-coded-badge.yml
+++ b/.github/workflows/vibe-coded-badge.yml
@@ -18,7 +18,6 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.BADGE_PAT }}
-      - uses: ai-ecoverse/vibe-coded-badge-action@d5f3861ac5325ace00ae4ff2419d971c36b8d39c # main
+      - uses: ./.github/actions/vibe-badge
         with:
           github-token: ${{ secrets.BADGE_PAT }}
-          badge-style: flat

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Web Resource Ledger (WRL)
 
-[![CI](https://github.com/benpeter/web-resource-ledger/actions/workflows/ci.yml/badge.svg)](https://github.com/benpeter/web-resource-ledger/actions/workflows/ci.yml) [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE) [![despicable](https://img.shields.io/badge/%E2%9A%97%EF%B8%8F-despicable-FFC107?style=flat&labelColor=FFF8E1)](https://github.com/benpeter/despicable-agents) 
+[![CI](https://github.com/benpeter/web-resource-ledger/actions/workflows/ci.yml/badge.svg)](https://github.com/benpeter/web-resource-ledger/actions/workflows/ci.yml) [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE) [![despicable](https://img.shields.io/badge/%E2%9A%97%EF%B8%8F-despicable-FFC107?style=flat&labelColor=FFF8E1)](https://github.com/benpeter/despicable-agents) [![Vibe Coded](https://img.shields.io/badge/Vibe_Coded-ff69b4?logo=claude&logoColor=white)](https://github.com/ai-ecoverse/vibe-coded-badge-action)
 
 Tamper-evident archival of web resources -- captures rendered screenshots, HTML snapshots, HTTP headers, and resource manifests as cryptographically signed, immutable bundles.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Web Resource Ledger (WRL)
 
-[![CI](https://github.com/benpeter/web-resource-ledger/actions/workflows/ci.yml/badge.svg)](https://github.com/benpeter/web-resource-ledger/actions/workflows/ci.yml) [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE) [![despicable](https://img.shields.io/badge/%E2%9A%97%EF%B8%8F-despicable-FFC107?style=flat&labelColor=FFF8E1)](https://github.com/benpeter/despicable-agents) [![Vibe Coded](https://img.shields.io/badge/Vibe_Coded-ff69b4?logo=claude&logoColor=white)](https://github.com/ai-ecoverse/vibe-coded-badge-action)
+[![CI](https://github.com/benpeter/web-resource-ledger/actions/workflows/ci.yml/badge.svg)](https://github.com/benpeter/web-resource-ledger/actions/workflows/ci.yml) [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE) [![despicable](https://img.shields.io/badge/%E2%9A%97%EF%B8%8F-despicable-FFC107?style=flat&labelColor=FFF8E1)](https://github.com/benpeter/despicable-agents) [![Vibe Coded 99%](https://img.shields.io/badge/Vibe_Coded_99%25-ff69b4?logo=claude&logoColor=white)](https://github.com/ai-ecoverse/vibe-coded-badge-action)
 
 Tamper-evident archival of web resources -- captures rendered screenshots, HTML snapshots, HTTP headers, and resource manifests as cryptographically signed, immutable bundles.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Web Resource Ledger (WRL)
 
-[![99% Vibe_Coded](https://img.shields.io/badge/99%25-Vibe_Coded-ff69b4?style=flat&logo=claude&logoColor=white)](https://github.com/ai-ecoverse/vibe-coded-badge-action)
-
 [![CI](https://github.com/benpeter/web-resource-ledger/actions/workflows/ci.yml/badge.svg)](https://github.com/benpeter/web-resource-ledger/actions/workflows/ci.yml) [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE) [![despicable](https://img.shields.io/badge/%E2%9A%97%EF%B8%8F-despicable-FFC107?style=flat&labelColor=FFF8E1)](https://github.com/benpeter/despicable-agents) [![Vibe Coded](https://img.shields.io/badge/Vibe_Coded-ff69b4?logo=claude&logoColor=white)](https://github.com/ai-ecoverse/vibe-coded-badge-action)
 
 Tamper-evident archival of web resources -- captures rendered screenshots, HTML snapshots, HTTP headers, and resource manifests as cryptographically signed, immutable bundles.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Web Resource Ledger (WRL)
 
-[![CI](https://github.com/benpeter/web-resource-ledger/actions/workflows/ci.yml/badge.svg)](https://github.com/benpeter/web-resource-ledger/actions/workflows/ci.yml) [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE) [![despicable](https://img.shields.io/badge/%E2%9A%97%EF%B8%8F-despicable-FFC107?style=flat&labelColor=FFF8E1)](https://github.com/benpeter/despicable-agents) [![Vibe Coded](https://img.shields.io/badge/Vibe_Coded-ff69b4?logo=claude&logoColor=white)](https://github.com/ai-ecoverse/vibe-coded-badge-action)
+[![CI](https://github.com/benpeter/web-resource-ledger/actions/workflows/ci.yml/badge.svg)](https://github.com/benpeter/web-resource-ledger/actions/workflows/ci.yml) [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE) [![despicable](https://img.shields.io/badge/%E2%9A%97%EF%B8%8F-despicable-FFC107?style=flat&labelColor=FFF8E1)](https://github.com/benpeter/despicable-agents) 
 
 Tamper-evident archival of web resources -- captures rendered screenshots, HTML snapshots, HTTP headers, and resource manifests as cryptographically signed, immutable bundles.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Web Resource Ledger (WRL)
 
-[![CI](https://github.com/benpeter/web-resource-ledger/actions/workflows/ci.yml/badge.svg)](https://github.com/benpeter/web-resource-ledger/actions/workflows/ci.yml) [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE) [![despicable](https://img.shields.io/badge/%E2%9A%97%EF%B8%8F-despicable-FFC107?style=flat&labelColor=FFF8E1)](https://github.com/benpeter/despicable-agents) [![Vibe Coded 99%](https://img.shields.io/badge/Vibe_Coded_99%25-ff69b4?logo=claude&logoColor=white)](https://github.com/ai-ecoverse/vibe-coded-badge-action)
+[![CI](https://github.com/benpeter/web-resource-ledger/actions/workflows/ci.yml/badge.svg)](https://github.com/benpeter/web-resource-ledger/actions/workflows/ci.yml) [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE) [![despicable](https://img.shields.io/badge/%E2%9A%97%EF%B8%8F-despicable-FFC107?style=flat&labelColor=FFF8E1)](https://github.com/benpeter/despicable-agents) [![99% Vibe Coded](https://img.shields.io/badge/99%25-Vibe_Coded-ff69b4?style=flat&logo=claude&logoColor=white)](https://github.com/ai-ecoverse/vibe-coded-badge-action)
 
 Tamper-evident archival of web resources -- captures rendered screenshots, HTML snapshots, HTTP headers, and resource manifests as cryptographically signed, immutable bundles.
 


### PR DESCRIPTION
## Summary
- Wraps `ai-ecoverse/vibe-coded-badge-action` in a local composite action that runs analysis only (`debug: true`), then replaces the vibe-coded badge inline in the README badge row
- Removes the standalone badge the upstream action added (it always inserts on its own line after the heading)
- Keeps all 4 badges on one line: CI, License, despicable, Vibe Coded

## Test plan
- [ ] Merge to main and verify the vibe-coded badge action triggers
- [ ] Check README shows `Vibe Coded NN%` inline with the other badges (not on a separate line)
- [ ] Verify the `[skip vibe-badge]` commit message prevents infinite loops

🤖 Generated with [Claude Code](https://claude.com/claude-code)
