### PR TITLE
docs: product roadmap and backlog restructure

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,117 +1,174 @@
 # Backlog
 
-Items deferred from MVP scope. Extracted from `docs/evolution/` and
-`docs/history/` after phases 0001-0003. Updated through 0012-open-source-readiness.
+Product roadmap produced by advisory orchestration (2026-03-15). See
+[advisory report](history/nefario-reports/2026-03-15-103905-prioritized-product-roadmap.md)
+and [synthesis](history/nefario-reports/2026-03-15-103905-prioritized-product-roadmap/phase3-synthesis.md)
+for full rationale, conflict resolutions, and specialist contributions.
 
-Tier definitions:
-- **[must]** -- explicitly committed to or "must add before production"
-- **[should]** -- strong specialist consensus it's needed, no hard commitment
-- **[consider]** -- mentioned as a possibility, may or may not be needed
+## Tier Definitions
 
-Sources are abbreviated: `kickoff` = 0001, `scaffold` = 0002, `urlval` = 0003.
-Agent names reference the specialist who raised the item.
+- **[must:condition]** -- required before a stated condition (e.g., `[must:multi-user]`
+  means "must ship before a second user touches WRL"). Not unconditionally urgent.
+- **[should]** -- strong consensus it's needed, no hard commitment yet
+- **[consider]** -- may or may not be needed; parked with activation trigger
+
+## Backlog Inflation Policy
+
+Only add items to the active backlog that the human explicitly deferred or that
+address a demonstrated (not theoretical) need. Agent-originated items go to the
+Parking Lot with a revisit condition. Backlog should not exceed ~25 active items;
+exceeding this triggers a cleanup pass.
 
 ---
 
-## Auth and Access Control
+## Act 1: Solid Foundation (near-term, next 1-3 phases)
 
-- [must] Per-tenant API keys -- single static key is MVP only; need per-tenant keys before second user (security-minion, kickoff)
-- [must] API key rotation without downtime -- support multiple active keys (security-minion, kickoff)
-- [must] Key scoping -- read vs write permissions per key (security-minion, kickoff)
-- [must] Audit logging of key usage (security-minion, kickoff)
-- [must] Tenant isolation / RBAC -- required before multi-user (security-minion, kickoff)
-- [consider] OAuth for web UI -- only if a web capture UI is built (security-minion, kickoff)
-- [consider] Social signup (GitHub first) -- YAGNI until multi-user (margo, kickoff)
+These close the trust gaps (recoverability, verifiability) and handle quick-win
+security hardening for the current single-operator use case.
 
-## API
+- #38 **R8: Auth identity enrichment** [S] -- internal refactor, prerequisite for R1
+- #31 **R1: List captures endpoint** [M] -- eliminates lost-ID problem; depends on R8
+- #32 **R2: Key versioning and public key archive** [M] -- must ship before any key rotation
+- #33 **R3: CORS for capture POST** [S] -- unblocks browser-based integrations
+- #34 **R4: HSTS preload submission** [XS] -- one header change + form submission
+- #35 **R5: X-RateLimit-Limit header** [XS] -- static ceiling header on rate-limited endpoints
+- #36 **R6: Hashed IP logging** [S] -- HMAC-SHA256 abuse correlation without PII
+- #37 **R7: Content moderation policy and ToS** [S] -- required before external promotion
+- #39 **R9: Staging environment** [S] -- automated deploy-to-staging on push to main
+- #40 **R10: Backlog cleanup and restructure** [S] -- this restructure; evolution log entry
 
-- [must] List/search captures (`GET /v1/captures`) -- "first addition post-MVP" (MVP.md, api-design-minion, kickoff)
-- [should] Rate limit headers in responses -- `Retry-After` implemented on 429 and 202/pending; `X-RateLimit-*` headers (limit, remaining, reset) still deferred (api-design-minion, kickoff; partial: capture-endpoint)
-- [should] CORS configuration -- retrieval GET endpoints use `*` (retrieval-endpoint); capture POST endpoint should restrict origins (security-minion, kickoff; partial: retrieval-endpoint)
-- [should] Queue migration for capture processing -- ctx.waitUntil() has 30s hard limit; Cloudflare Queue gives 15min processing budget; add when slow-page timeouts recur; session reuse eliminates ~2-5s browser launch overhead, freeing more budget for rendering (edge-minion, capture-endpoint)
-- [consider] Per-tenant rate limiting -- current rate limit keys on CF-Connecting-IP; should switch to tenant ID when per-tenant keys are added; with 10x capacity (300/min) the per-IP 10/min limit feels more constraining (edge-minion, capture-endpoint)
-- [consider] Webhooks / outbound callbacks -- additional notification channel alongside polling (api-design-minion, kickoff)
-- [consider] Batch capture -- multiple URLs in one request (api-design-minion, kickoff)
-- [consider] SSE / WebSocket -- alternative async notification for capture completion (api-design-minion, kickoff)
-- [consider] Pagination, filtering, sorting -- depends on list endpoint (api-design-minion, kickoff)
+## Act 2: Evidence-Grade (mid-term)
 
-## Signing and Legal Admissibility
+Upgrade integrity claims from self-asserted to independently verifiable. Make the
+word "evidence" defensible.
 
-- [should] RFC 3161 timestamps via TSA -- upgrade path designed (add entry to signatures array), requires ASN.1 parsing (gru vs security-minion conflict, resolved: deferred; kickoff)
-- [should] Key versioning / key ID in signature entries -- needed for key rotation; without it, verification returns false for captures signed with rotated keys (security-minion, kickoff; confirmed: verification-endpoint)
-- [should] Old public key archive endpoint -- needed for verifying captures signed with rotated keys (security-minion, kickoff; confirmed: verification-endpoint)
-- [consider] eIDAS Qualified TSA -- strategic for European customers, eIDAS 2.0 rollout by end 2026 (gru, kickoff)
-- [consider] WACZ-Auth signing spec -- full implementation, MVP uses simplified version (gru, kickoff)
-- [consider] Domain-ownership certificate -- identity proof component of WACZ-Auth (gru, kickoff)
-- [consider] Multiple TSAs for redundancy -- FreeTSA has no SLA (gru, kickoff)
-- [consider] HSM-backed key storage -- mentioned for production key management (security-minion, kickoff)
+- #41 **R11: RFC 3161 timestamp integration** [L] -- third-party temporal proof; depends on R2
+- #42 **R12: Per-tenant API keys and tenant isolation** [L] -- gated on multi-user decision; depends on R1, R8
+- #43 **R13: Audit logging** [S] -- full audit trail; depends on R12
+- #44 **R14: Production CD pipeline** [M] -- automated deploy with environment protection; depends on R9
 
-## Capture Fidelity
+## Act 3: Infrastructure (longer-horizon)
 
-- [should] Screenshot timing / wait-for-load -- pages with dynamic content, lazy loading, or CSR may not be fully rendered (process.md, kickoff; deliberately untested)
-- [consider] Screenshot height cap is 8000px -- pages taller than this produce capped screenshots; may need configurable viewport height (edge-minion, capture-endpoint)
-- [consider] Resource manifest (CSS/JS/images) -- captured individually; significant complexity escalation (MVP.md)
-- [consider] Full HTTP exchange capture -- Scoop-style proxy-based; forensic-grade (MVP.md, gru, kickoff)
-- [consider] Sub-resource archiving -- offline replay fidelity (gru, kickoff)
-- [consider] Certificate info capture -- not available via Browser Rendering REST API (gru, kickoff)
-- [consider] Network timing capture -- not available via Browser Rendering REST API (gru, kickoff)
+Expand WRL into a platform that other tools and agents build on.
 
-## Security
+- #45 **R15: MCP server for web evidence** [M] -- AI agent integration; depends on R1, R11 recommended
+- #46 **R16: Queue migration for capture processing** [M] -- data-driven: when timeouts >5%
+- #47 **R17: Web UI for capture submission** [M] -- browser-based capture; depends on R1, R3
+- #48 **R18: Batch capture endpoint** [M] -- bulk archival workflows; depends on R1, R5
 
-- [should] ~~TOCTOU gap mitigation~~ -- DONE (playwright-migration): cross-domain navigation blocking implemented via `browserContext.route()`; residual risk: same-domain DNS rebinding is an accepted risk (urlval decisions #3, security-minion; updated: capture-endpoint)
-- [should] ~~Puppeteer request interception for cross-domain navigation blocking~~ -- DONE (playwright-migration): `browserContext.route()` blocks navigations to origins other than the validated target URL; covers server-side redirects, client-side navigations, and popup first-requests; Service Workers blocked via context options (security-minion, capture-endpoint)
-- [should] ~~Captured HTML XSS prevention~~ -- DONE (retrieval-endpoint): HTML artifacts served as text/plain with Content-Disposition: attachment at both R2 write time and Worker serve time
-- [should] Content security scanning -- prevent WRL from being used as malware mirror; check against Safe Browsing (security-minion, kickoff)
-- [should] ~~Security event logging~~ -- PARTIAL (mvo-coralogix): auth failures, SSRF blocks, and rate limit hits logged to Coralogix; alerting rules and dashboards still needed (security-minion, kickoff)
-- [should] Content moderation policy and abuse reporting mechanism (security-minion, kickoff)
-- [should] Terms of service prohibiting illegal use (security-minion, kickoff)
-- [consider] Network namespace isolation for browser -- defense-in-depth; browser can only reach public internet (security-minion, kickoff)
-- [consider] DNS rebinding integration tests -- requires controlled DNS with TTL manipulation (urlval outcome)
-- [consider] Cloud metadata DNS alias tests -- only resolvable inside cloud VPCs (urlval outcome)
-- [consider] Coralogix Send Key IP allowlisting -- restrict to Cloudflare Worker egress IPs; reduces blast radius of key leak to log injection (security-minion, mvo-coralogix)
+---
 
-## Storage and Immutability
+## Parking Lot
 
-- [consider] S3 Object Lock (WORM-certified) -- for regulated customers (SEC 17a-4, FINRA) (gru, iac-minion, kickoff)
-- [consider] Database for metadata -- add when query-by-attribute needed (margo, iac-minion, kickoff)
-- [consider] D1 (edge SQLite) -- if KV becomes limiting for metadata queries (iac-minion, kickoff)
+Deferred items with explicit activation triggers. Revisit when condition is met.
 
-## Operations
+### Auth (revisit with multi-user decision)
 
-- ~~[must] CI/CD pipeline~~ -- CI added in 0012-open-source-readiness; CD (deployment automation) still deferred (MVP.md, iac-minion, kickoff)
-- ~~[should] Structured logging~~ -- DONE (mvo-coralogix): log() helper ships structured JSON to Coralogix at every pipeline outcome and security rejection point
-- [should] Hashed IP logging -- HMAC-SHA256 of CF-Connecting-IP with daily-rotating key for brute-force correlation; design from security-minion ready for implementation (security-minion, mvo-coralogix)
-- [consider] Additional security event types -- Content-Type 415, malformed JSON 400, missing URL 400, unmatched route 404 rejections; low signal-to-noise for MVP (security-minion, mvo-coralogix)
-- [consider] Auth reason codes -- refactor verifyApiKey() to return reason discriminant (missing_header, wrong_scheme, invalid_key, misconfigured); enables finer-grained auth failure logging (debugger-minion, mvo-coralogix)
-- [consider] R2 write try/catch granularity -- dedicated catch block around R2 Promise.all for stage-level failure logging; catch-all sufficient for MVP (observability-minion, mvo-coralogix)
-- [consider] 404 rate limiting -- unmatched routes have no rate limiter; potential log volume amplification vector under scanning attacks (security-minion, mvo-coralogix)
-- [consider] Coralogix alerting rules -- severity-based alerts, log volume anomaly detection, SSRF spike dashboards (observability-minion, mvo-coralogix)
-- [consider] Preview deployments on PRs -- CI/CD enhancement (iac-minion, kickoff)
-- [consider] Fastly CDN layer -- evaluate when verification traffic justifies it (iac-minion, kickoff)
-- [consider] Capture service container migration -- if Browser Rendering limits hit; session reuse pushes this further out: 30 reusable sessions at ~300 captures/min is sufficient for current scale (iac-minion, kickoff)
-- [consider] R2 artifact streaming -- switch `arrayBuffer()` to `obj.body` ReadableStream in artifact handler and verification endpoint when workerd test runner supports it or when large WACZ bundles (>10MB) become common; verification endpoint has 100MB hard limit (margo, retrieval-endpoint; updated: verification-endpoint)
+| Item | Condition | Source |
+|------|-----------|--------|
+| [must:multi-user] API key rotation without downtime | When R12 (per-tenant keys) ships | security-minion, kickoff |
+| [must:multi-user] Tenant isolation / RBAC | Folded into R12 | security-minion, kickoff |
+| [consider] Per-tenant rate limiting | When R12 ships; switch rate limit key from IP to tenantId | edge-minion, capture-endpoint |
+| [consider] OAuth for web UI | When R17 (web UI) is built and needs user auth | security-minion, kickoff |
 
-## Verification Page
+### Signing and Legal
 
-- ~~[should] HSTS header~~ -- [DONE] implemented in Step 8; affects all responses not just verification (security-minion, static-verification-page)
-- [should] HSTS preload submission -- add preload directive and submit to hstspreload.org after domain is finalized
-- [consider] HTML error pages for 404/429/503 -- browsers currently display JSON problem responses; acceptable for MVP (margo, static-verification-page)
-- [consider] Nonce-based CSP -- upgrade from unsafe-inline if template ever needs server-side dynamic data in script blocks (security-minion, static-verification-page)
+| Item | Condition | Source |
+|------|-----------|--------|
+| [consider] eIDAS Qualified TSA | 3+ QTSPs with published pricing and APIs; not before 2027 | gru, kickoff |
+| [consider] WACZ-Auth full spec compliance | When a production toolchain consumes WACZ-Auth signatures | gru, kickoff |
+| [consider] Multiple TSAs for redundancy | 6+ months after R11 ships; based on observed TSA reliability | gru, kickoff |
+| [consider] HSM-backed key storage | When FIPS 140-2 Level 3 explicitly required or multi-tenant key management at scale | security-minion, kickoff |
 
-## Product Features
+### Capture Fidelity
 
-- [consider] Scheduled captures (cron-style) -- additional trigger method (MVP.md)
-- [consider] MCP / AI-agent triggers -- layers on top of API (MVP.md)
-- [consider] Watch lists / bulk monitoring -- requires scheduling (also deferred) (MVP.md)
-- [consider] Change detection / diffing -- requires multiple captures over time (MVP.md)
-- [consider] Notifications -- event system, channel integrations (MVP.md)
-- [consider] Billing and quotas -- no monetization for MVP (MVP.md)
-- [consider] Web UI for capture submission -- curl/API sufficient for MVP (margo, kickoff)
-- [consider] Capture ID recovery -- no list endpoint means lost ID = lost capture (ux-strategy-minion, kickoff)
+| Item | Condition | Source |
+|------|-----------|--------|
+| [should] Screenshot timing / wait-for-load | When a user reports incomplete renders | kickoff |
+| [consider] Screenshot height cap configurability | When a user reports capped screenshots as a problem | edge-minion, capture-endpoint |
 
-## Scaling Beyond Session Reuse
+### API Enhancements
 
-- [consider] Session pre-warming via cron trigger -- keep sessions alive between bursts to reduce cold-start latency on low-traffic deployments
-- [consider] Queue-based backpressure with Cloudflare Queues -- decouple capture requests from Worker execution; absorb traffic spikes without dropping requests
-- [consider] Durable Object session coordinator -- centralize session lifecycle management across Workers; enables finer-grained concurrency control and session affinity
-- [consider] Cloudflare Containers -- escape Browser Rendering limits entirely; full Chromium with unrestricted network and storage; evaluate when container pricing and availability stabilize
+| Item | Condition | Source |
+|------|-----------|--------|
+| [consider] Webhooks / outbound callbacks | When per-tenant keys exist and async notification demand demonstrated | api-design-minion, kickoff |
+| [consider] Pagination filtering and sorting | URL filter and sorting require D1; cursor pagination in R1 | api-design-minion, kickoff |
+
+### Security
+
+| Item | Condition | Source |
+|------|-----------|--------|
+| [should] Content security scanning (Safe Browsing) | When WRL serves text/html content or multi-user opens public submission | security-minion, kickoff |
+
+### Storage
+
+| Item | Condition | Source |
+|------|-----------|--------|
+| [consider] D1 (edge SQLite) | When KV list latency >300ms at observed capture counts | iac-minion, kickoff |
+| [consider] R2 artifact streaming | When WACZ bundles >10MB become common | margo, retrieval-endpoint |
+
+### Operations
+
+| Item | Condition | Source |
+|------|-----------|--------|
+| [consider] Session pre-warming via cron | When Coralogix shows cold-start latency is measurable | iac-minion |
+| [consider] Coralogix alerting rules | When operational load justifies alerting | observability-minion, mvo-coralogix |
+| [consider] Fastly CDN layer | When verification traffic justifies CDN | iac-minion, kickoff |
+| [consider] Preview deployments on PRs | When team size > 1 | iac-minion, kickoff |
+| [consider] Durable Object session coordinator | When session contention >1% capture failures | iac-minion |
+| [consider] Cloudflare Containers | When Browser Rendering limits exhausted AND Queues insufficient; monitor for GA | iac-minion, kickoff |
+
+### Product Features
+
+| Item | Condition | Source |
+|------|-----------|--------|
+| [consider] Scheduled captures (cron-style) | When a user requests recurring capture | MVP.md |
+| [consider] Watch lists / bulk monitoring | Requires scheduling (also parked) | MVP.md |
+| [consider] Change detection / diffing | Requires multiple captures over time; no demand | MVP.md |
+| [consider] Notifications | When event-driven workflows needed | MVP.md |
+| [consider] Billing and quotas | When monetization actively planned | MVP.md |
+| [consider] Capture ID recovery | Solved by R1; remove after R1 ships | ux-strategy-minion, kickoff |
+
+---
+
+## Dropped Items
+
+Removed from active backlog. Rationale preserved here and in
+[evolution log](evolution/0016-roadmap-backlog-cleanup/).
+
+| Item | Rationale |
+|------|-----------|
+| SSE / WebSocket | Explicitly rejected during kickoff; polling works for 5-30s lifecycle |
+| Database for metadata (generic) | Rejected during kickoff; D1 is the specific option if needed |
+| Domain-ownership certificate | Architecturally problematic; .well-known/signing-key already ties key to domain |
+| Social signup (GitHub first) | No identity system, no users; self-acknowledged YAGNI |
+| Network namespace isolation | Over-engineering; Cloudflare manages the browser sandbox |
+| DNS rebinding integration tests | Untestable in current environment; residual risk accepted in Phase 0014 |
+| Cloud metadata DNS alias tests | Only resolvable inside cloud VPCs; untestable on Cloudflare Workers |
+| Additional security event types | Self-acknowledged "low signal-to-noise for MVP" |
+| Auth reason codes | Finer-grained logging with no demonstrated need |
+| R2 write try/catch granularity | Self-acknowledged "catch-all sufficient for MVP" |
+| 404 rate limiting | Theoretical log amplification with no evidence of scanning |
+| Coralogix Send Key IP allowlisting | Blast radius reduction for a key that hasn't leaked |
+| Nonce-based CSP | Template doesn't use server-side dynamic data in scripts |
+| HTML error pages for 404/429/503 | "Acceptable for MVP"; fix opportunistically |
+| S3 Object Lock (WORM-certified) | For regulated customers who don't exist |
+| Full HTTP exchange capture | Forensic-grade; far beyond current scope |
+| Sub-resource archiving | Significant complexity for offline replay; not core to evidence |
+| Certificate info capture | Not available via Playwright API; forensic nicety |
+| Network timing capture | Not available via Playwright API; forensic nicety |
+| Resource manifest (CSS/JS/images) | Significant complexity; HTML + screenshot prove content state |
+
+---
+
+## Done
+
+Completed items removed from active tracking:
+
+- ~~CI/CD pipeline~~ -- CI added in 0012-open-source-readiness
+- ~~Structured logging~~ -- DONE (mvo-coralogix)
+- ~~TOCTOU gap mitigation~~ -- DONE (playwright-migration)
+- ~~Cross-domain navigation blocking~~ -- DONE (playwright-migration)
+- ~~Captured HTML XSS prevention~~ -- DONE (retrieval-endpoint)
+- ~~Security event logging~~ -- PARTIAL (mvo-coralogix): auth failures, SSRF blocks, rate limit hits logged
+- ~~HSTS header~~ -- DONE (static-verification-page)

--- a/docs/history/nefario-reports/2026-03-15-103905-prioritized-product-roadmap.md
+++ b/docs/history/nefario-reports/2026-03-15-103905-prioritized-product-roadmap.md
@@ -1,0 +1,144 @@
+---
+task: Review backlog and produce a prioritized product roadmap
+date: 2026-03-15
+slug: prioritized-product-roadmap
+mode: advisory
+task-count: 0
+gate-count: 0
+compaction-events: 0
+---
+
+## Summary
+
+Seven specialists analyzed WRL's 70+ item backlog and produced a three-act product roadmap: "Solid Foundation" (10 near-term items), "Evidence-Grade" (4 mid-term items), and "Infrastructure" (4 longer-horizon items). 13 items dropped, 28 parked with activation triggers. The backlog shrinks from 70+ active items to ~18. Key consensus: list endpoint is #1 priority, key versioning must ship before any key rotation, ~85% of [consider] items are YAGNI, and multi-tenancy should wait for a real second user.
+
+## Original Prompt
+
+Review backlog and produce a prioritized product roadmap
+
+**Outcome**: The existing backlog (`docs/backlog.md`) is transformed into a sequenced product roadmap that defines a meaningful evolution path for WRL. Each roadmap item is scoped and described well enough to become a GitHub issue without further research, so that issue creation is a mechanical follow-up step rather than a planning session.
+
+**Success criteria**:
+- Every backlog item is explicitly addressed (prioritized, deferred, or dropped with rationale)
+- Roadmap items are sequenced with dependency reasoning (what enables what)
+- Each item has a one-line summary, outcome statement, and rough scope — sufficient to seed a GitHub issue title + body
+- The roadmap distinguishes between near-term (next 1-3 phases), mid-term, and longer-horizon work
+- Product coherence: the sequence tells a story of incremental value, not a grab-bag of tasks
+
+## Key Design Decisions
+
+1. **Three-act narrative structure** -- "Solid Foundation" → "Evidence-Grade" → "Infrastructure". Sequence builds credibility before expanding capability. Rejected: technical dependency sort (no product coherence), feature-first approach (builds on shaky foundation).
+2. **Conditional [must] tier** -- Reframe [must] as "must before multi-user, not must now". The multi-user decision is a gate, not a deadline. Rejected: downgrade all to [consider] (loses importance signal), keep as unconditional [must] (creates false urgency).
+3. **Aggressive backlog pruning** -- 13 items dropped, 28 parked. Active backlog target: ~15-20 items. Rejected: keeping all items as options (backlog inflation), removing only DONE items (leaves noise).
+4. **"Evidence" over "archival" positioning** -- Archival competes with archive.org (free, massive). Evidence competes with manual screenshots and notarization (expensive, slow). WRL wins the evidence comparison. Rejected: dual positioning (confusing), archival-only (wrong competitive set).
+5. **MCP in Act 3, not Act 2** -- Market opportunity is real (gru) but foundation must be solid first (product-marketing). Thin adapter, so opportunity cost of waiting is low. Rejected: immediate elevation to [should] (YAGNI until foundation ships), permanent deferral (misses market window).
+
+## Phases
+
+### Phase 1: Meta-Plan
+Identified 7 specialists: ux-strategy-minion (user journey), security-minion (auth sequencing), api-design-minion (API evolution), iac-minion (infrastructure prerequisites), gru (strategic calibration), product-marketing-minion (positioning narrative), lucy (intent drift audit). Initial team of 5 was adjusted to 7 at user request (+product-marketing-minion, +lucy). Phase 1 re-run produced revised planning questions for all 7 agents.
+
+### Phase 2: Specialist Planning
+All 7 specialists contributed domain plans. Key findings:
+- **ux-strategy**: Five natural capability clusters; trust gap (recoverability → verifiability → reliability) is the real problem
+- **security**: 4 of 8 [must] are hard gates; HSTS/hashed-IP/ToS are quick wins; key versioning before any rotation
+- **api-design**: Cursor-based KV pagination; X-RateLimit-Limit only; CORS is highest-impact API item; 3-phase per-tenant evolution
+- **iac**: KV sufficient for auth; D1 only for queries; session pre-warming is only scaling item worth planning; CD alongside multi-user
+- **gru**: RFC 3161 is the one signing investment; MCP should elevate; don't chase forensic fidelity
+- **product-marketing**: Five launch moments; three-act narrative; reframe to "evidence"; minimum second-user package identified
+- **lucy**: 85% [consider] items are YAGNI; 17 items exist only because agents raised them; actionable backlog is ~10 items
+
+Two specialists recommended additional agents (api-design → data-minion/devx-minion; iac → observability-minion). Gaps adequately covered by existing contributions; no second round spawned.
+
+### Phase 3: Synthesis
+Nefario synthesized 7 specialist contributions into a three-act advisory roadmap. Resolved 5 conflicts (TSA timing, MCP priority, [must] tier validity, backlog cleanup scope, CORS priority). Produced 18 roadmap items, 28 parked items, 13 dropped items. Every backlog entry explicitly addressed.
+
+### Phases 3.5-8
+Skipped (advisory-only orchestration).
+
+## Agent Contributions
+
+<details>
+<summary>Planning agents (7)</summary>
+
+| Agent | Phase | Key Contribution |
+|-------|-------|-----------------|
+| ux-strategy-minion | planning | Three-gap trust model; five capability clusters; value cliff identification |
+| security-minion | planning | Auth staging analysis (4 hard gates vs 4 stageable); quick-win security items; signing chain depth |
+| api-design-minion | planning | List endpoint design (cursor+envelope); rate limit scope guard; per-tenant API evolution path |
+| iac-minion | planning | KV vs D1 decision (KV sufficient for auth); scaling threshold analysis; CD timing |
+| gru | planning | TSA as sole near-term signing investment; MCP elevation argument; Browser Rendering limitations assessment |
+| product-marketing-minion | planning | Launch moment identification; "evidence" vs "archival" reframe; three-act narrative arc |
+| lucy | planning | YAGNI audit (85% [consider] items); [must] tier challenge; agent-enthusiasm detection (17 items) |
+
+</details>
+
+## Team Recommendation
+
+### Executive Summary
+
+The team recommends a three-act roadmap that transforms WRL's 70+ item backlog into ~18 sequenced items across three horizons. Act 1 ("Solid Foundation") closes the trust gaps for the current single operator. Act 2 ("Evidence-Grade") makes the "evidence" claim defensible with RFC 3161 timestamps and prepares for multi-tenancy. Act 3 ("Infrastructure") expands the audience via MCP, web UI, and batch capture. The multi-user decision is the single most important strategic choice -- the roadmap sequences work so it can be made deliberately rather than forced by premature investment.
+
+### Team Consensus
+
+1. List endpoint is the #1 priority (unanimous)
+2. Key versioning must ship before first key rotation (4/7 flagged independently)
+3. RFC 3161 timestamps are the one signing upgrade worth investment (5/7 agree, 1 defers)
+4. ~85% of [consider] items are YAGNI (lucy audit, no dissent)
+5. Multi-tenancy should wait for real demand (5/7 agree)
+6. HSTS preload, hashed IP, ToS are quick wins (security-minion, no dissent)
+7. "Evidence" framing stronger than "archival" (2/7 argued, no dissent)
+8. KV sufficient for auth; D1 only for queries (2/7 agreed, no dissent)
+
+### Dissenting Views
+
+- **TSA timing**: security-minion wants demand-driven trigger; ux-strategy wants Phase 3 (soon); gru says Trial/H2 2026. Resolution: mid-term, triggered by key versioning completion.
+- **MCP priority**: gru argues for [should] elevation; lucy flags as unvalidated. Resolution: Act 3, but acknowledged as real opportunity with low implementation cost.
+- **[must] tier**: lucy argues downgrade all; security-minion defends conditional accuracy. Resolution: reframe as conditional ("must before multi-user").
+
+### The Roadmap
+
+See the full roadmap in the [advisory synthesis](./2026-03-15-103905-prioritized-product-roadmap/phase3-synthesis.md) -- 18 items (R1-R18) across three acts, with every backlog item addressed.
+
+**Act 1 "Solid Foundation" (near-term, next 1-3 phases)**:
+R1. List captures endpoint, R2. Key versioning, R3. CORS for capture POST, R4. HSTS preload, R5. Rate limit header, R6. Hashed IP logging, R7. ToS/abuse policy, R8. Auth identity enrichment, R9. Staging environment, R10. Backlog cleanup
+
+**Act 2 "Evidence-Grade" (mid-term)**:
+R11. RFC 3161 timestamps, R12. Per-tenant keys (demand-gated), R13. Audit logging, R14. Production CD pipeline
+
+**Act 3 "Infrastructure" (longer-horizon)**:
+R15. MCP server, R16. Queue migration (data-driven), R17. Web UI, R18. Batch capture
+
+### Conditions to Revisit
+
+1. A second user wants access → accelerate R12
+2. Capture timeout failures >5% → trigger R16
+3. KV list latency >300ms → trigger D1 evaluation
+4. Legal evidence request → accelerate R11/eIDAS
+5. Cloudflare Containers GA → capture fidelity upgrade path
+6. Backlog >25 active items → cleanup pass
+7. 3+ QTSPs with pricing → eIDAS evaluation
+8. Phase count >25 without Act 1 complete → scope creep signal
+
+## Session Resources
+
+<details>
+<summary>Skills Invoked</summary>
+
+- `/nefario` (this orchestration)
+
+</details>
+
+<details>
+<summary>Compaction</summary>
+
+0 compaction events during this session.
+
+</details>
+
+## Working Files
+
+All specialist contributions, prompts, and synthesis outputs:
+[`docs/history/nefario-reports/2026-03-15-103905-prioritized-product-roadmap/`](./2026-03-15-103905-prioritized-product-roadmap/)
+
+Files: prompt.md, phase1-metaplan.md, phase1-metaplan-rerun.md, phase2-{ux-strategy-minion,security-minion,api-design-minion,iac-minion,gru,product-marketing-minion,lucy}.md, phase3-synthesis.md (+ corresponding -prompt.md files for each)

--- a/docs/history/nefario-reports/2026-03-15-103905-prioritized-product-roadmap/phase1-metaplan-prompt.md
+++ b/docs/history/nefario-reports/2026-03-15-103905-prioritized-product-roadmap/phase1-metaplan-prompt.md
@@ -1,0 +1,39 @@
+MODE: META-PLAN
+
+You are creating a meta-plan — a plan for who should help plan.
+
+## Task
+Review backlog and produce a prioritized product roadmap
+
+**Outcome**: The existing backlog (`docs/backlog.md`) is transformed into a sequenced product roadmap that defines a meaningful evolution path for WRL. Each roadmap item is scoped and described well enough to become a GitHub issue without further research, so that issue creation is a mechanical follow-up step rather than a planning session.
+
+**Success criteria**:
+- Every backlog item is explicitly addressed (prioritized, deferred, or dropped with rationale)
+- Roadmap items are sequenced with dependency reasoning (what enables what)
+- Each item has a one-line summary, outcome statement, and rough scope — sufficient to seed a GitHub issue title + body
+- The roadmap distinguishes between near-term (next 1-3 phases), mid-term, and longer-horizon work
+- Product coherence: the sequence tells a story of incremental value, not a grab-bag of tasks
+
+**Scope**:
+- In: Reviewing `docs/backlog.md`, evolution log context, current codebase state; producing a prioritized roadmap document
+- Out: Creating GitHub issues (tracked separately), writing code, changing architecture, modifying existing backlog format
+
+## Working Directory
+/Users/ben/github/benpeter/web-resource-ledger
+
+## External Skill Discovery
+Before analyzing the task, scan for project-local skills. If skills are discovered, include an "External Skill Integration" section in your meta-plan (see your Core Knowledge for the output format).
+
+## Instructions
+1. Read relevant files to understand the codebase context
+2. Discover external skills:
+   a. Scan .claude/skills/ and .skills/ in the working directory for SKILL.md files
+   b. Read frontmatter (name, description) for each discovered skill
+   c. For skills whose description matches the task domain, classify as ORCHESTRATION or LEAF (see External Skill Integration in your Core Knowledge)
+   d. Check the project's CLAUDE.md for explicit skill preferences
+   e. Include discovered skills in your meta-plan output
+3. Analyze the task against your delegation table
+4. Identify which specialists should be CONSULTED FOR PLANNING (not execution — planning). These are agents whose domain expertise is needed to create a good plan.
+5. For each specialist, write a specific planning question that draws on their unique expertise.
+6. Return the meta-plan in the structured format.
+7. Write your complete meta-plan to `/var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-oZkd87/prioritized-product-roadmap/phase1-metaplan.md`

--- a/docs/history/nefario-reports/2026-03-15-103905-prioritized-product-roadmap/phase1-metaplan-rerun-prompt.md
+++ b/docs/history/nefario-reports/2026-03-15-103905-prioritized-product-roadmap/phase1-metaplan-rerun-prompt.md
@@ -1,0 +1,48 @@
+MODE: META-PLAN
+
+You are creating a revised meta-plan after a team adjustment.
+
+## Task
+Review backlog and produce a prioritized product roadmap
+
+**Outcome**: The existing backlog (`docs/backlog.md`) is transformed into a sequenced product roadmap that defines a meaningful evolution path for WRL. Each roadmap item is scoped and described well enough to become a GitHub issue without further research, so that issue creation is a mechanical follow-up step rather than a planning session.
+
+**Success criteria**:
+- Every backlog item is explicitly addressed (prioritized, deferred, or dropped with rationale)
+- Roadmap items are sequenced with dependency reasoning (what enables what)
+- Each item has a one-line summary, outcome statement, and rough scope — sufficient to seed a GitHub issue title + body
+- The roadmap distinguishes between near-term (next 1-3 phases), mid-term, and longer-horizon work
+- Product coherence: the sequence tells a story of incremental value, not a grab-bag of tasks
+
+**Scope**:
+- In: Reviewing `docs/backlog.md`, evolution log context, current codebase state; producing a prioritized roadmap document
+- Out: Creating GitHub issues (tracked separately), writing code, changing architecture, modifying existing backlog format
+
+## Working Directory
+/Users/ben/github/benpeter/web-resource-ledger
+
+## Original Meta-Plan
+The following meta-plan was produced for the original team. Use it as context for the revised plan, not as a template to minimally edit.
+
+Read the original meta-plan from: /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-oZkd87/prioritized-product-roadmap/phase1-metaplan.md
+
+## Team Adjustment
+Added: product-marketing-minion, lucy. Removed: none.
+
+## Revised Team
+ux-strategy-minion, security-minion, api-design-minion, iac-minion, gru, product-marketing-minion, lucy
+
+## Constraints
+- Keep the same scope and task description
+- Preserve external skill integration decisions unless the team change removes all agents relevant to a skill's domain
+- Generate planning consultations for ALL agents in the revised team (all 7)
+- Re-evaluate the cross-cutting checklist against the new team
+- Produce output at the same depth and format as the original
+- Do NOT change the fundamental scope of the task
+- Do NOT add agents the user did not request (beyond cross-cutting requirements)
+- Design planning questions as a coherent set — each question should address aspects that no other agent on the team covers, and questions should reference cross-cutting boundaries where relevant
+
+## Instructions
+1. Read relevant files to understand the codebase context
+2. Revise the meta-plan with the adjusted team
+3. Write your complete revised meta-plan to `/var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-oZkd87/prioritized-product-roadmap/phase1-metaplan-rerun.md`

--- a/docs/history/nefario-reports/2026-03-15-103905-prioritized-product-roadmap/phase1-metaplan-rerun.md
+++ b/docs/history/nefario-reports/2026-03-15-103905-prioritized-product-roadmap/phase1-metaplan-rerun.md
@@ -1,0 +1,134 @@
+# Meta-Plan: Prioritized Product Roadmap (Revised)
+
+## Task Summary
+
+Transform the existing backlog (`docs/backlog.md`) into a sequenced product roadmap. The backlog contains ~60 items across 10 categories, accumulated from 15 evolution phases (0001-0015). The MVP is complete, 3 post-MVP phases are done (open-source readiness, session reuse, Coralogix logging), and all 11 GitHub issues are closed. The roadmap must sequence every backlog item into a coherent evolution path that tells a story of incremental value.
+
+## Context
+
+WRL is a tamper-evident web archival service running on Cloudflare Workers. Current state:
+- **Core pipeline complete**: URL -> browser render -> WACZ bundle -> R2 storage -> KV metadata -> public verification
+- **Security layer**: SSRF prevention, API key auth, rate limiting, cross-domain navigation blocking
+- **Observability**: Structured logging to Coralogix (no alerting/dashboards yet)
+- **Performance**: Playwright session reuse gives ~300 captures/min capacity
+- **No open issues**, no list endpoint, single static API key, single-operator deployment
+- **Dual purpose**: real product AND despicable-agents showcase
+
+Key backlog characteristics:
+- 8 `[must]` items (mostly auth/access control -- required before multi-user)
+- ~12 `[should]` items (signing upgrades, operational hardening, capture fidelity)
+- ~40 `[consider]` items (product features, scaling, advanced security)
+- Some items already marked DONE/PARTIAL with strikethrough
+- Several items have inter-dependencies (e.g., list endpoint enables pagination; per-tenant keys enable per-tenant rate limiting; TSA requires key versioning)
+
+## Team Adjustment
+
+**Added**: product-marketing-minion, lucy
+**Removed**: none
+**Revised team**: ux-strategy-minion, security-minion, api-design-minion, iac-minion, gru, product-marketing-minion, lucy
+
+### Why the additions matter
+
+- **product-marketing-minion**: WRL serves a dual purpose -- real product AND despicable-agents showcase. The roadmap needs to tell two stories: one for potential adopters (what value does WRL deliver, in what order?) and one for the despicable-agents audience (what does this demonstrate about agent-built software?). product-marketing-minion can identify which roadmap sequences create the strongest positioning narrative and which items, when shipped, constitute meaningful "launch moments" worth communicating.
+- **lucy**: Normally a Phase 3.5 governance reviewer, lucy is promoted to planning because intent alignment is critical for a roadmap exercise. The backlog was accumulated from 15 phases of specialist recommendations -- some items may have drifted from the project's actual goals. lucy can evaluate whether the backlog itself is internally consistent with CLAUDE.md's engineering philosophy (YAGNI, KISS, Helix Manifesto) and flag items that were added speculatively by agents but never validated against human intent.
+
+## Planning Consultations
+
+### Consultation 1: Product & User Journey Strategy
+- **Agent**: ux-strategy-minion
+- **Planning question**: Given WRL's current single-operator/API-only state and the backlog of ~60 items, what is the most coherent user journey evolution? Specifically: (1) What capabilities does a real user need next to go from "I can capture a URL" to "I rely on WRL for evidence"? (2) Which backlog items form natural clusters that deliver meaningful capability jumps vs. incremental polish? (3) The backlog has items ranging from "list endpoint" to "eIDAS qualified TSA" -- where is the value cliff where we're building for hypothetical users rather than actual need? Focus on the user value sequencing; product-marketing-minion will separately address positioning and launch narratives, and lucy will evaluate YAGNI alignment -- so concentrate on the journey coherence and capability clustering that are uniquely your domain.
+- **Context to provide**: `docs/backlog.md`, `docs/MVP.md` (What's Out section), `README.md` (usage flow showing the lost-ID problem)
+- **Why this agent**: The roadmap must tell a story of incremental user value, not just a technical dependency sort. ux-strategy-minion can identify which capabilities unlock real usage patterns vs. which are speculative infrastructure.
+
+### Consultation 2: Security Sequencing
+- **Agent**: security-minion
+- **Planning question**: The backlog has 8 `[must]` items in Auth/Access Control, all flagged as "required before multi-user." (1) What is the minimum viable security posture upgrade needed before a second user touches WRL -- is it all 8, or can some be staged? (2) Among the `[should]` security items (content scanning, content moderation, hashed IP logging, HSTS preload), which have the highest risk-to-effort ratio and should move earlier? (3) The signing/legal section has a chain: key versioning -> old key archive -> RFC 3161 TSA -> eIDAS. What is the right depth to commit to in the near-term vs. deferring? Note: api-design-minion will address how per-tenant keys affect the API contract, and iac-minion will assess infrastructure prerequisites (e.g., D1 vs. KV for key storage) -- focus your analysis on the security sequencing and threat model aspects.
+- **Context to provide**: `docs/backlog.md` (Auth, Security, Signing sections), current auth implementation in `src/index.js` (single static API key), current signing in `src/signing.js`
+- **Why this agent**: Security items dominate the `[must]` tier. Getting the sequencing wrong means either shipping insecure multi-user support or over-investing in security before there are users. security-minion can distinguish "blocker" from "hardening."
+
+### Consultation 3: API & Developer Experience Evolution
+- **Agent**: api-design-minion
+- **Planning question**: The MVP has 4 endpoints and the backlog's #1 API item is `GET /v1/captures` (list/search). (1) What should the list endpoint look like to be useful without over-engineering (filtering, pagination, sorting are all separate backlog items)? (2) Rate limit headers (`X-RateLimit-*`) are partially done -- what's the right scope for completing them? (3) Among the `[consider]` API items (webhooks, batch capture, SSE/WebSocket, CORS for capture POST), which would most improve the developer experience for realistic integration patterns? (4) How does the API need to evolve to support per-tenant keys without breaking the existing v1 contract? Note: security-minion covers the threat model for per-tenant auth, and iac-minion covers infrastructure prerequisites -- keep your focus on the API contract, developer experience, and backward compatibility dimensions.
+- **Context to provide**: `docs/backlog.md` (API section), `openapi.yaml`, current endpoint implementations
+- **Why this agent**: API surface changes are hard to reverse and have cascading effects on documentation, SDKs, and client code. The list endpoint in particular is called out as "first addition post-MVP" and needs careful design.
+
+### Consultation 4: Infrastructure & Scaling Assessment
+- **Agent**: iac-minion
+- **Planning question**: The backlog has operational items spanning CI/CD enhancements, queue migration, scaling options, and storage considerations. (1) What infrastructure changes are prerequisites for other roadmap items (e.g., does per-tenant auth need D1 for key storage, or can KV handle it)? (2) The "Scaling Beyond Session Reuse" section lists 4 options (pre-warming, Queues, DO, Containers) -- at what scale threshold do these become relevant, and should any be planned proactively? (3) CD (deployment automation) is deferred -- when should it become a priority relative to other work? (4) Preview deployments on PRs -- worth it for a single-developer project? Note: security-minion owns the auth sequencing and api-design-minion owns the API contract evolution -- focus on the infrastructure enablement and operational readiness that other agents' plans depend on.
+- **Context to provide**: `docs/backlog.md` (Operations, Storage, Scaling sections), `wrangler.toml`, current CI setup
+- **Why this agent**: Infrastructure decisions constrain what product features are feasible. Knowing whether KV is sufficient for per-tenant keys vs. needing D1 changes the sequencing of auth work.
+
+### Consultation 5: Technology Landscape & Strategic Direction
+- **Agent**: gru
+- **Planning question**: WRL occupies a niche between legal-tech evidence platforms and web archiving tools. (1) Looking at the `[consider]` items around eIDAS, WACZ-Auth, domain-ownership certificates, and HSM-backed keys -- which of these represent genuine market differentiation vs. over-investment for a single-operator tool? (2) The MCP/AI-agent trigger item is tagged `[consider]` -- given the current trajectory of AI agent tooling, should this move up? (3) Cloudflare's Browser Rendering API has limitations (no cert info, no network timing) -- are there emerging alternatives or Cloudflare roadmap items that change the capture fidelity calculus? Note: product-marketing-minion will evaluate these same items through a positioning lens (which items create compelling launch moments); your focus is on technology viability, timing, and strategic staying power.
+- **Context to provide**: `docs/backlog.md` (Signing, Product Features, Capture Fidelity sections), `docs/MVP.md` (technology stack rationale)
+- **Why this agent**: gru provides the strategic lens on which investments have staying power. The backlog has items spanning "next month" to "maybe never" -- gru can help calibrate which `[consider]` items deserve roadmap placement vs. being explicitly parked.
+
+### Consultation 6: Product Positioning & Launch Sequencing
+- **Agent**: product-marketing-minion
+- **Planning question**: WRL is both a real product (tamper-evident web archival) and a showcase for the despicable-agents framework. The roadmap needs to serve both narratives. (1) Looking at the backlog items, which ones -- when shipped -- create meaningful "launch moments" worth announcing (blog post, README update, social mention)? Not every roadmap item is a launch moment; identify the 3-5 that most change WRL's positioning. (2) For the adopter audience: what is the current value proposition gap? Today WRL is "capture a URL and verify it." What is the smallest set of additions that upgrades the pitch to something an independent adopter would use? (3) For the despicable-agents audience: which roadmap items best demonstrate multi-agent orchestration capability? (4) Does the roadmap sequence -- as a narrative arc -- build credibility, or does it feel like random feature accretion? Note: ux-strategy-minion covers user journey coherence and gru covers technology viability -- your focus is on the external communication value and positioning impact of the sequencing decisions.
+- **Context to provide**: `docs/backlog.md`, `README.md`, `docs/evolution/README.md` (to see the build story so far), `docs/MVP.md` (What's Out section for context on what was deliberately deferred)
+- **Why this agent**: A roadmap that makes technical sense but tells no story externally is a missed opportunity. product-marketing-minion identifies which items move the positioning needle and ensures the sequencing creates a coherent narrative arc for both audiences.
+
+### Consultation 7: Intent Alignment & YAGNI Audit
+- **Agent**: lucy
+- **Planning question**: The backlog was accumulated from 15 phases of specialist agent recommendations. Some items may reflect agent enthusiasm rather than genuine human intent. (1) Review the backlog against the project's stated philosophy (CLAUDE.md: YAGNI, KISS, Helix Manifesto, "prefer lightweight vanilla solutions"). Which items appear to violate these principles -- things that were added speculatively by agents and never validated by the human? (2) The project's CLAUDE.md says WRL is both a real product AND a despicable-agents showcase. Does the backlog balance these goals, or has one side accumulated disproportionate scope? (3) Are there items in the `[must]` tier that should be downgraded? The `[must]` items were all flagged by security-minion during kickoff -- is "must before multi-user" the right framing when multi-user isn't even on the near-term horizon? (4) Are there backlog items that exist solely because an agent raised them during planning, with no evidence the human operator actually needs them? Note: margo will review the final plan for over-engineering in Phase 3.5; your role here is earlier -- auditing the backlog inputs before they become roadmap items, catching intent drift at the source rather than at the output.
+- **Context to provide**: `docs/backlog.md`, `CLAUDE.md`, `CLAUDE.local.md`, `docs/MVP.md` (constraints section showing original philosophy), `docs/evolution/README.md` (to trace where items originated)
+- **Why this agent**: Intent drift is the #1 failure mode in multi-phase orchestration. The backlog has been shaped by agent recommendations across 15 phases -- lucy can catch items that drifted in without human validation. This is especially important for a roadmap exercise: prioritizing agent-generated noise wastes the roadmap's most valuable real estate.
+
+### Cross-Cutting Checklist
+
+- **Testing** (test-minion): NOT included for planning. This is a roadmap/planning exercise that produces a document, not code. test-minion adds no planning value here. Testing strategy for individual roadmap items will be addressed when those items are executed.
+- **Security** (security-minion): INCLUDED as Consultation 2. Security items dominate the `[must]` tier and their sequencing is a core planning question.
+- **Usability -- Strategy** (ux-strategy-minion): INCLUDED as Consultation 1. The roadmap is fundamentally a user value sequencing problem.
+- **Usability -- Design** (ux-design-minion / accessibility-minion): NOT included for planning. No UI design decisions are being made in this roadmap exercise. The verification page and any future web UI will be addressed when those items are executed.
+- **Documentation** (software-docs-minion / user-docs-minion): NOT included for planning. The roadmap itself is the document being produced. Documentation needs for individual roadmap items will be scoped within those items. Neither docs agent has unique planning insight for "which backlog items come first."
+- **Observability** (observability-minion / sitespeed-minion): NOT included for planning. Coralogix integration is done. The backlog has alerting/dashboard items that are straightforward to sequence without specialist planning input. These will be placed in the roadmap based on the operational maturity story.
+
+### Anticipated Approval Gates
+
+1. **Roadmap document** (single gate): The entire roadmap is a single deliverable that determines the project's evolution path. This is HIGH blast radius (all future work depends on it) and HARD to reverse (re-sequencing after work has started is expensive). This is a MUST gate. The gate should present: the proposed sequencing with dependency reasoning, any items proposed for dropping, and the near-term vs. mid-term vs. horizon classification.
+
+No other gates are expected -- this is a planning/document-production task, not a multi-deliverable execution.
+
+### Rationale
+
+Seven specialists were chosen because the roadmap requires five technical/strategic perspectives (unchanged from the original) plus two new dimensions that strengthen the output:
+
+**Original five (unchanged)**:
+- **ux-strategy-minion** provides the user-value lens that prevents the roadmap from becoming a technical dependency graph with no product coherence.
+- **security-minion** is essential because auth/security items are the primary gate between "single operator tool" and "multi-user product" -- getting this sequencing wrong is the highest-risk planning mistake.
+- **api-design-minion** owns the API surface, which is WRL's primary interface. The list endpoint design and per-tenant auth integration are contract decisions that constrain everything downstream.
+- **iac-minion** identifies infrastructure prerequisites that could re-sequence product features (e.g., if per-tenant keys need D1, that infrastructure work must precede the auth work).
+- **gru** provides strategic calibration on which investments have staying power. The backlog has items spanning "next month" to "maybe never" -- gru can help calibrate which `[consider]` items deserve roadmap placement vs. being explicitly parked.
+
+**Added two**:
+- **product-marketing-minion** ensures the roadmap sequence tells a coherent story externally, not just internally. WRL's dual-purpose nature (product + showcase) means sequencing decisions have communication implications. product-marketing-minion identifies which items create launch moments and whether the arc builds credibility.
+- **lucy** audits the backlog inputs before they become roadmap items. With 15 phases of agent-generated recommendations, intent drift is a real risk. lucy evaluates whether the `[must]` tier is genuinely must, whether `[consider]` items reflect human intent or agent enthusiasm, and whether the backlog's balance matches the project's stated philosophy.
+
+**Agents NOT included in planning**:
+- **margo** is a governance reviewer who will review the final plan in Phase 3.5, not a planning contributor. Her concerns (YAGNI, scope creep, over-engineering) are complementary to lucy's but best applied as review of the proposed roadmap rather than input to its construction. lucy catches intent drift in the inputs; margo catches over-engineering in the output.
+- **observability-minion**, **test-minion**, **software-docs-minion**, **user-docs-minion** have no unique planning expertise for a roadmap prioritization exercise. Their domains will be scoped within individual roadmap items.
+
+### Scope
+
+**In scope**:
+- Reviewing all ~60 backlog items and their sources/rationale
+- Classifying each item into near-term (next 1-3 phases), mid-term, or longer-horizon
+- Sequencing with explicit dependency reasoning
+- Scoping each roadmap item to be issue-ready (title, outcome, rough scope)
+- Dropping items with explicit rationale where appropriate
+- Identifying natural phase boundaries that deliver coherent capability jumps
+- Evaluating backlog items for intent alignment and YAGNI compliance
+- Identifying which roadmap milestones serve as external communication moments
+
+**Out of scope**:
+- Creating GitHub issues (mechanical follow-up, not part of this task)
+- Writing code or changing architecture
+- Modifying the backlog document format
+- Detailed technical design of individual roadmap items
+- Execution timeline estimates (phases are sequenced, not calendared)
+
+### External Skill Integration
+
+No external skills detected in project. Neither `.claude/skills/` nor `.skills/` directories exist in the working directory. User-global skills (`~/.claude/skills/`) are framework skills (nefario, despicable-prompter) or unrelated domain skills (obsidian-tasks, transcribe, juli, etc.) -- none are relevant to product roadmap planning.

--- a/docs/history/nefario-reports/2026-03-15-103905-prioritized-product-roadmap/phase1-metaplan.md
+++ b/docs/history/nefario-reports/2026-03-15-103905-prioritized-product-roadmap/phase1-metaplan.md
@@ -1,0 +1,104 @@
+# Meta-Plan: Prioritized Product Roadmap
+
+## Task Summary
+
+Transform the existing backlog (`docs/backlog.md`) into a sequenced product roadmap. The backlog contains ~60 items across 10 categories, accumulated from 15 evolution phases (0001-0015). The MVP is complete, 3 post-MVP phases are done (open-source readiness, session reuse, Coralogix logging), and all 11 GitHub issues are closed. The roadmap must sequence every backlog item into a coherent evolution path that tells a story of incremental value.
+
+## Context
+
+WRL is a tamper-evident web archival service running on Cloudflare Workers. Current state:
+- **Core pipeline complete**: URL -> browser render -> WACZ bundle -> R2 storage -> KV metadata -> public verification
+- **Security layer**: SSRF prevention, API key auth, rate limiting, cross-domain navigation blocking
+- **Observability**: Structured logging to Coralogix (no alerting/dashboards yet)
+- **Performance**: Playwright session reuse gives ~300 captures/min capacity
+- **No open issues**, no list endpoint, single static API key, single-operator deployment
+- **Dual purpose**: real product AND despicable-agents showcase
+
+Key backlog characteristics:
+- 8 `[must]` items (mostly auth/access control -- required before multi-user)
+- ~12 `[should]` items (signing upgrades, operational hardening, capture fidelity)
+- ~40 `[consider]` items (product features, scaling, advanced security)
+- Some items already marked DONE/PARTIAL with strikethrough
+- Several items have inter-dependencies (e.g., list endpoint enables pagination; per-tenant keys enable per-tenant rate limiting; TSA requires key versioning)
+
+## Planning Consultations
+
+### Consultation 1: Product & User Journey Strategy
+- **Agent**: ux-strategy-minion
+- **Planning question**: Given WRL's current single-operator/API-only state and the backlog of ~60 items, what is the most coherent user journey evolution? Specifically: (1) What capabilities does a real user need next to go from "I can capture a URL" to "I rely on WRL for evidence"? (2) Which backlog items form natural clusters that deliver meaningful capability jumps vs. incremental polish? (3) The backlog has items ranging from "list endpoint" to "eIDAS qualified TSA" -- where is the value cliff where we're building for hypothetical users rather than actual need?
+- **Context to provide**: `docs/backlog.md`, `docs/MVP.md` (What's Out section), `README.md` (usage flow showing the lost-ID problem)
+- **Why this agent**: The roadmap must tell a story of incremental user value, not just a technical dependency sort. ux-strategy-minion can identify which capabilities unlock real usage patterns vs. which are speculative infrastructure.
+
+### Consultation 2: Security Sequencing
+- **Agent**: security-minion
+- **Planning question**: The backlog has 8 `[must]` items in Auth/Access Control, all flagged as "required before multi-user." (1) What is the minimum viable security posture upgrade needed before a second user touches WRL -- is it all 8, or can some be staged? (2) Among the `[should]` security items (content scanning, content moderation, hashed IP logging, HSTS preload), which have the highest risk-to-effort ratio and should move earlier? (3) The signing/legal section has a chain: key versioning -> old key archive -> RFC 3161 TSA -> eIDAS. What is the right depth to commit to in the near-term vs. deferring?
+- **Context to provide**: `docs/backlog.md` (Auth, Security, Signing sections), current auth implementation in `src/index.js` (single static API key), current signing in `src/signing.js`
+- **Why this agent**: Security items dominate the `[must]` tier. Getting the sequencing wrong means either shipping insecure multi-user support or over-investing in security before there are users. security-minion can distinguish "blocker" from "hardening."
+
+### Consultation 3: API & Developer Experience Evolution
+- **Agent**: api-design-minion
+- **Planning question**: The MVP has 4 endpoints and the backlog's #1 API item is `GET /v1/captures` (list/search). (1) What should the list endpoint look like to be useful without over-engineering (filtering, pagination, sorting are all separate backlog items)? (2) Rate limit headers (`X-RateLimit-*`) are partially done -- what's the right scope for completing them? (3) Among the `[consider]` API items (webhooks, batch capture, SSE/WebSocket, CORS for capture POST), which would most improve the developer experience for realistic integration patterns? (4) How does the API need to evolve to support per-tenant keys without breaking the existing v1 contract?
+- **Context to provide**: `docs/backlog.md` (API section), `openapi.yaml`, current endpoint implementations
+- **Why this agent**: API surface changes are hard to reverse and have cascading effects on documentation, SDKs, and client code. The list endpoint in particular is called out as "first addition post-MVP" and needs careful design.
+
+### Consultation 4: Infrastructure & Scaling Assessment
+- **Agent**: iac-minion
+- **Planning question**: The backlog has operational items spanning CI/CD enhancements, queue migration, scaling options, and storage considerations. (1) What infrastructure changes are prerequisites for other roadmap items (e.g., does per-tenant auth need D1 for key storage, or can KV handle it)? (2) The "Scaling Beyond Session Reuse" section lists 4 options (pre-warming, Queues, DO, Containers) -- at what scale threshold do these become relevant, and should any be planned proactively? (3) CD (deployment automation) is deferred -- when should it become a priority relative to other work? (4) Preview deployments on PRs -- worth it for a single-developer project?
+- **Context to provide**: `docs/backlog.md` (Operations, Storage, Scaling sections), `wrangler.toml`, current CI setup
+- **Why this agent**: Infrastructure decisions constrain what product features are feasible. Knowing whether KV is sufficient for per-tenant keys vs. needing D1 changes the sequencing of auth work.
+
+### Consultation 5: Technology Landscape & Strategic Direction
+- **Agent**: gru
+- **Planning question**: WRL occupies a niche between legal-tech evidence platforms and web archiving tools. (1) Looking at the `[consider]` items around eIDAS, WACZ-Auth, domain-ownership certificates, and HSM-backed keys -- which of these represent genuine market differentiation vs. over-investment for a single-operator tool? (2) The MCP/AI-agent trigger item is tagged `[consider]` -- given the current trajectory of AI agent tooling, should this move up? (3) Cloudflare's Browser Rendering API has limitations (no cert info, no network timing) -- are there emerging alternatives or Cloudflare roadmap items that change the capture fidelity calculus?
+- **Context to provide**: `docs/backlog.md` (Signing, Product Features, Capture Fidelity sections), `docs/MVP.md` (technology stack rationale)
+- **Why this agent**: gru provides the strategic lens on which investments have staying power. The backlog has items spanning "next month" to "maybe never" -- gru can help calibrate which `[consider]` items deserve roadmap placement vs. being explicitly parked.
+
+### Cross-Cutting Checklist
+
+- **Testing** (test-minion): NOT included for planning. This is a roadmap/planning exercise that produces a document, not code. test-minion adds no planning value here. Testing strategy for individual roadmap items will be addressed when those items are executed.
+- **Security** (security-minion): INCLUDED as Consultation 2. Security items dominate the `[must]` tier and their sequencing is a core planning question.
+- **Usability -- Strategy** (ux-strategy-minion): INCLUDED as Consultation 1. The roadmap is fundamentally a user value sequencing problem.
+- **Usability -- Design** (ux-design-minion / accessibility-minion): NOT included for planning. No UI design decisions are being made in this roadmap exercise. The verification page and any future web UI will be addressed when those items are executed.
+- **Documentation** (software-docs-minion): NOT included for planning. The roadmap itself is the document being produced. Documentation needs for individual roadmap items will be scoped within those items. software-docs-minion has no unique planning insight for "which backlog items come first."
+- **Observability** (observability-minion): NOT included for planning. Coralogix integration is done. The backlog has alerting/dashboard items that are straightforward to sequence without specialist planning input. These will be placed in the roadmap based on the operational maturity story.
+
+### Anticipated Approval Gates
+
+1. **Roadmap document** (single gate): The entire roadmap is a single deliverable that determines the project's evolution path. This is HIGH blast radius (all future work depends on it) and HARD to reverse (re-sequencing after work has started is expensive). This is a MUST gate. The gate should present: the proposed sequencing with dependency reasoning, any items proposed for dropping, and the near-term vs. mid-term vs. horizon classification.
+
+No other gates are expected -- this is a planning/document-production task, not a multi-deliverable execution.
+
+### Rationale
+
+Five specialists were chosen because the roadmap requires four distinct expert perspectives plus strategic calibration:
+
+- **ux-strategy-minion** provides the user-value lens that prevents the roadmap from becoming a technical dependency graph with no product coherence.
+- **security-minion** is essential because auth/security items are the primary gate between "single operator tool" and "multi-user product" -- getting this sequencing wrong is the highest-risk planning mistake.
+- **api-design-minion** owns the API surface, which is WRL's primary interface. The list endpoint design and per-tenant auth integration are contract decisions that constrain everything downstream.
+- **iac-minion** identifies infrastructure prerequisites that could re-sequence product features (e.g., if per-tenant keys need D1, that infrastructure work must precede the auth work).
+- **gru** provides strategic calibration on which `[consider]` items represent real investment vs. speculative scope, particularly around legal-tech positioning and emerging platform capabilities.
+
+Agents NOT included in planning:
+- **margo** and **lucy** are governance reviewers who will review the plan in Phase 3.5, not plan contributors. Their concerns (YAGNI, scope creep, intent alignment) are best applied as review of the proposed roadmap rather than input to its construction.
+- **observability-minion**, **test-minion**, **software-docs-minion** have no unique planning expertise for a roadmap prioritization exercise. Their domains will be scoped within individual roadmap items.
+
+### Scope
+
+**In scope**:
+- Reviewing all ~60 backlog items and their sources/rationale
+- Classifying each item into near-term (next 1-3 phases), mid-term, or longer-horizon
+- Sequencing with explicit dependency reasoning
+- Scoping each roadmap item to be issue-ready (title, outcome, rough scope)
+- Dropping items with explicit rationale where appropriate
+- Identifying natural phase boundaries that deliver coherent capability jumps
+
+**Out of scope**:
+- Creating GitHub issues (mechanical follow-up, not part of this task)
+- Writing code or changing architecture
+- Modifying the backlog document format
+- Detailed technical design of individual roadmap items
+- Execution timeline estimates (phases are sequenced, not calendared)
+
+### External Skill Integration
+
+No external skills detected in project. Neither `.claude/skills/` nor `.skills/` directories exist in the working directory. User-global skills (`~/.claude/skills/`) are framework skills (nefario, despicable-prompter) or unrelated domain skills (obsidian-tasks, transcribe, juli, etc.) -- none are relevant to product roadmap planning.

--- a/docs/history/nefario-reports/2026-03-15-103905-prioritized-product-roadmap/phase2-api-design-minion-prompt.md
+++ b/docs/history/nefario-reports/2026-03-15-103905-prioritized-product-roadmap/phase2-api-design-minion-prompt.md
@@ -1,0 +1,49 @@
+You are contributing to the PLANNING phase of a multi-agent project.
+You are NOT executing yet — you are providing your domain expertise to help build a comprehensive plan.
+
+## Advisory Context
+This is an advisory-only orchestration. Your contribution will feed into a team recommendation, not an execution plan. Focus on analysis, trade-offs, and recommendations rather than implementation tasks.
+
+## Project Task
+Review backlog and produce a prioritized product roadmap for WRL (Web Resource Ledger), a tamper-evident web archival service on Cloudflare Workers.
+
+## Your Planning Question
+The MVP has 4 endpoints and the backlog's #1 API item is `GET /v1/captures` (list/search).
+
+1. What should the list endpoint look like to be useful without over-engineering (filtering, pagination, sorting are all separate backlog items)?
+2. Rate limit headers (`X-RateLimit-*`) are partially done -- what's the right scope for completing them?
+3. Among the `[consider]` API items (webhooks, batch capture, SSE/WebSocket, CORS for capture POST), which would most improve the developer experience for realistic integration patterns?
+4. How does the API need to evolve to support per-tenant keys without breaking the existing v1 contract?
+
+Note: security-minion covers the threat model for per-tenant auth, and iac-minion covers infrastructure prerequisites -- keep your focus on the API contract, developer experience, and backward compatibility dimensions.
+
+## Context
+Read these files for context:
+- `docs/backlog.md` -- API section
+- `openapi.yaml` -- current API spec
+- `src/index.js` -- current endpoint implementations
+
+## Instructions
+1. Read relevant files to understand the current state
+2. Apply your domain expertise to the planning question
+3. Identify risks, dependencies, and requirements from your perspective
+4. If you believe additional specialists should be involved that aren't already part of the planning, say so and explain why
+5. Return your contribution in this format:
+
+## Domain Plan Contribution: api-design-minion
+
+### Recommendations
+<your expert recommendations for this aspect of the task>
+
+### Proposed Tasks
+<specific tasks that should be in the execution plan>
+For each task: what to do, deliverables, dependencies
+
+### Risks and Concerns
+<things that could go wrong from your domain perspective>
+
+### Additional Agents Needed
+<any specialists not yet involved who should be, and why>
+(or "None" if the current team is sufficient)
+
+6. Write your complete contribution to `/var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-oZkd87/prioritized-product-roadmap/phase2-api-design-minion.md`

--- a/docs/history/nefario-reports/2026-03-15-103905-prioritized-product-roadmap/phase2-api-design-minion.md
+++ b/docs/history/nefario-reports/2026-03-15-103905-prioritized-product-roadmap/phase2-api-design-minion.md
@@ -1,0 +1,225 @@
+## Domain Plan Contribution: api-design-minion
+
+### Recommendations
+
+#### 1. GET /v1/captures -- List Endpoint Design
+
+**The core constraint: KV is not a database.** Cloudflare KV supports `list()` with a prefix and cursor, but has no filtering, no sorting, and no secondary indexes. Every capture is stored under `capture:{captureId}`, and captureIds are random (UUID-based), so there is no natural time ordering in key space. This shapes everything.
+
+**Recommended MVP list endpoint:**
+
+```
+GET /v1/captures?limit=20&cursor={opaque}
+```
+
+Response shape:
+
+```json
+{
+  "data": [ /* array of CaptureRecord-like objects */ ],
+  "pagination": {
+    "cursor": "eyJrZXkiOiJjYXB0dXJlOmNhcF8uLi4ifQ==",
+    "hasMore": true,
+    "limit": 20
+  }
+}
+```
+
+**What to include in v1, and what to defer:**
+
+| Feature | Decision | Rationale |
+|---------|----------|-----------|
+| Cursor-based pagination | Include | KV.list() natively supports cursors. Offset is impossible without a sorted index. Cursor-based is the correct choice -- it aligns with the storage layer and scales. |
+| `limit` parameter | Include | KV.list() supports `limit`. Cap at 100, default 20. |
+| `status` filter | Include | Cheap client-side filter on the KV list results. Three values: `pending`, `complete`, `failed`. Most callers want only `complete`. |
+| `url` filter | Defer | Requires scanning all values (KV list returns keys, not values). Unacceptable at scale. Needs D1 or a secondary index. |
+| Sorting | Defer | KV has no sort order other than lexicographic key order. Since keys are random UUIDs, sorting by `createdAt` requires fetching and sorting values -- O(n) memory. Needs D1. |
+| Full-text search | Defer | Far beyond KV capabilities. Needs D1 at minimum. |
+
+**Critical implementation detail:** KV's `list()` returns keys only (no values). To populate the response, each key requires a separate `kv.get()`. This means listing 20 captures requires 21 KV operations (1 list + 20 gets). At current scale (single-digit tenants, low hundreds of captures) this is fine. At scale, this is the forcing function for D1 migration.
+
+**Workaround for time-based access without D1:** Introduce a secondary KV key pattern. When a capture completes, also write a key like `tenant:{tenantId}:ts:{ISO8601}:{captureId}` with an empty value (or minimal metadata). This gives lexicographic ordering by timestamp under a tenant prefix. KV `list()` with prefix `tenant:{tenantId}:ts:` then returns captures in time order. This is a common KV pattern but adds write amplification. I recommend this only if D1 is deferred past the list endpoint -- it is a bridge, not the destination.
+
+**Response shape recommendation -- use an envelope:** This is the first endpoint that returns a collection. Establish the envelope pattern now because every future collection endpoint will follow it. The `{ data, pagination }` shape is composable (add `meta` later for rate limit info or query echo) and the `pagination` object is reusable.
+
+**Authentication:** The list endpoint MUST require Bearer auth (like `POST /v1/captures`). Currently, individual capture retrieval uses the capture ID as an access secret (no auth header). The list endpoint cannot follow this pattern -- it would expose all captures to anyone who can authenticate. When per-tenant keys arrive, the list endpoint naturally scopes to "captures belonging to this tenant."
+
+**operationId:** `listCaptures` (following the existing pattern: `createCapture`, `getCapture`, `getCaptureStatus`).
+
+**What the response items should look like:** Use the same `CaptureRecord` schema for each item, minus the `note` field. Do not invent a separate "summary" schema -- consistency trumps bandwidth optimization at this scale.
+
+#### 2. Rate Limit Headers -- Scope for Completion
+
+**Current state:**
+- `Retry-After` header is returned on 429 responses and on 202 (pending capture). This is correct.
+- `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset` are not implemented.
+
+**What Cloudflare's rate limiter binding gives us:** The `limit()` call returns `{ success: boolean }`. That is it. No remaining count, no reset timestamp. The `simple` config defines `limit` and `period`, but the binding does not expose how many tokens remain or when the window resets.
+
+**Recommendation: Do the minimum that is honest.**
+
+1. Return `X-RateLimit-Limit` on every response from rate-limited endpoints. This is a static value from config (10/min for capture, 60/min for verify). Easy to add, useful for clients to know what they are working with.
+
+2. Do NOT return `X-RateLimit-Remaining` or `X-RateLimit-Reset` unless the rate limiter binding starts exposing that data. Fabricating these values (e.g., decrementing a counter in KV) adds write amplification, races under concurrency, and will be inaccurate. An inaccurate `Remaining` header is worse than no header -- it trains clients to trust a lie.
+
+3. Continue returning `Retry-After: 60` on 429 responses. This is already implemented and correct.
+
+**Scope:** Add `X-RateLimit-Limit` to `handleCreateCapture`, `handleVerifyCapture`, and `handleGetSigningKey` responses. Three code changes, one new header, no new infrastructure. That is the right scope.
+
+**If Cloudflare later exposes remaining/reset data** (or WRL migrates to a custom token-bucket on D1/Durable Objects), add the remaining headers then. Design the response envelope to accommodate them (`meta.rateLimit` in list endpoint responses, headers on all endpoints).
+
+#### 3. [consider] API Items -- Prioritized by Developer Experience Impact
+
+Ranked by impact-to-effort ratio for realistic integration patterns:
+
+**1st: CORS for capture POST (should, not consider -- upgrade priority)**
+
+The retrieval GET endpoints already return `Access-Control-Allow-Origin: *`. The capture POST endpoint does not. This means browser-based clients cannot submit captures. For a web archival service, "capture this page from a browser extension or web UI" is a core integration pattern. Blocking it at the CORS level is a sharp edge.
+
+Implementation: Add a preflight handler for `OPTIONS /v1/captures` and return `Access-Control-Allow-Origin` with a configurable allowlist (not `*` -- the POST endpoint requires auth, so wildcard CORS exposes the auth flow to any origin). Add `Access-Control-Allow-Headers: Authorization, Content-Type` and `Access-Control-Allow-Methods: POST`. This is a few lines of code with significant DX impact.
+
+**2nd: Batch capture**
+
+Realistic integration: monitoring services, legal teams archiving multiple pages, CI pipelines. Without batch, clients loop over single POST calls and manage N independent polling flows. With batch, one request returns N capture IDs and one polling strategy.
+
+Design sketch:
+
+```
+POST /v1/captures/batch
+{ "urls": ["https://a.com", "https://b.com"] }
+```
+
+Response:
+
+```json
+{
+  "captures": [
+    { "url": "https://a.com", "id": "cap_...", "statusUrl": "..." },
+    { "url": "https://b.com", "id": "cap_...", "statusUrl": "..." }
+  ],
+  "errors": [
+    { "url": "ftp://bad.com", "status": 400, "detail": "URL scheme 'ftp' is not allowed" }
+  ]
+}
+```
+
+Cap batch size at 10-20 URLs. Each URL goes through the same validation pipeline. Rate limit counts each URL individually (a batch of 10 counts as 10 against the per-IP limit). Return 207 Multi-Status if the batch has mixed results, 202 if all succeed, 400 if all fail.
+
+This is a meaningful DX improvement but needs careful rate limit interaction design. Defer until after the list endpoint and rate limit headers.
+
+**3rd: Webhooks**
+
+Webhooks eliminate the polling loop entirely. For integrations that process captures asynchronously (Slack bots, legal workflow systems, monitoring dashboards), webhooks are the natural pattern. However, they require:
+- Webhook registration endpoint (CRUD for webhook URLs)
+- Payload signing (HMAC-SHA256)
+- Retry logic with exponential backoff
+- Dead letter handling
+- Per-tenant webhook configuration (entangled with per-tenant keys)
+
+This is significant infrastructure. Defer until per-tenant keys exist -- webhooks without tenant isolation are a non-starter for multi-user.
+
+**4th: SSE/WebSocket**
+
+These solve the same problem as webhooks (notification without polling) but require persistent connections. Cloudflare Workers support WebSockets via Durable Objects, which adds infrastructure complexity. SSE is simpler but Workers do not natively support long-lived SSE streams without Durable Objects either. The current polling pattern (status endpoint + Retry-After) works well for the capture lifecycle (typically 5-30 seconds). SSE/WebSocket are over-engineering until capture volume justifies the infrastructure.
+
+**Verdict:** CORS for POST is the clear winner -- highest DX impact, lowest implementation cost, and it is already half-done. Batch capture is second. Webhooks and SSE/WebSocket should wait for per-tenant keys and higher traffic.
+
+#### 4. Per-Tenant Keys -- API Contract Evolution
+
+**Current state:** Single static `CAPTURE_API_KEY` in env. Auth returns `{ ok: true }` with no identity information. Rate limiting keys on `CF-Connecting-IP`.
+
+**The contract change is smaller than it looks.** The v1 API contract does not need to break. Here is the migration path:
+
+**Phase 1: Make auth return identity (internal only, no API change)**
+
+`verifyApiKey()` currently returns `{ ok: true }`. Change it to return `{ ok: true, tenantId: 'tenant_xxx' }`. This is an internal refactor -- no API contract change. The `tenantId` flows into:
+- KV key prefix (captures scoped to tenant)
+- Rate limiter key (switch from IP to tenantId)
+- Log context (which tenant did what)
+
+The existing single key maps to a "default" tenant. No external behavior changes.
+
+**Phase 2: Key lookup (internal, minor API change)**
+
+Replace `env.CAPTURE_API_KEY` static comparison with a key lookup. Options:
+- KV namespace for key-to-tenant mapping (simplest, fits Cloudflare Workers)
+- D1 table (if D1 is added for the list endpoint, co-locate key storage)
+
+The API contract change: the `Authorization: Bearer {key}` header works identically. The only visible difference is that the list endpoint now returns only captures belonging to the authenticated tenant. This is not a breaking change -- it is a narrowing of scope that clients expect.
+
+**Phase 3: Key management endpoints (new API surface)**
+
+```
+POST   /v1/keys          -- create a new key (requires admin scope)
+GET    /v1/keys           -- list keys for tenant (redacted)
+DELETE /v1/keys/{keyId}   -- revoke a key
+POST   /v1/keys/{keyId}/rotate -- generate replacement, return new key, old key has grace period
+```
+
+These are new endpoints, not modifications to existing ones. No v1 breakage.
+
+**What MUST NOT change in v1:**
+- `POST /v1/captures` request/response shape stays identical
+- Capture ID format (`cap_{hex32}`) stays identical
+- Unauthenticated retrieval by capture ID stays identical (the ID is still the secret for individual capture access)
+- All error response shapes stay RFC 9457
+
+**What changes visibly:**
+- `GET /v1/captures` (list endpoint) returns only the authenticated tenant's captures
+- The `note` field in the 202 response can drop the "no list endpoint" warning once the list endpoint ships
+- Rate limit headers reflect per-tenant limits instead of per-IP limits
+
+**Backward compatibility guarantee:** Any client that works with the current single-key v1 API will continue to work after per-tenant keys ship, because the single key becomes the first tenant's key. No code changes required on the client side.
+
+**One risk: the unauthenticated retrieval pattern.** Currently, `GET /v1/captures/{captureId}` and `GET /v1/captures/{captureId}/status` require no auth -- the capture ID is the secret. This pattern works in single-tenant but becomes a tenant isolation question in multi-tenant: can tenant A access tenant B's capture if they somehow obtain the ID? The current design says yes (the ID is the secret, not the tenant boundary). This is a conscious design decision, not a bug -- it enables share-by-link workflows. But it should be explicitly documented as a design choice when per-tenant keys ship, and security-minion should validate this in their threat model.
+
+### Proposed Tasks
+
+**Task 1: GET /v1/captures list endpoint (MVP version)**
+- What: Implement `GET /v1/captures` with cursor-based pagination and optional `status` filter. Requires Bearer auth. Returns `{ data, pagination }` envelope.
+- Deliverables: Handler function, route registration, KV list integration, OpenAPI spec update, tests.
+- Dependencies: None (can use existing auth and KV infrastructure).
+- Scope guard: No sorting, no URL filter, no full-text search. These need D1.
+
+**Task 2: Collection response envelope schema**
+- What: Define the reusable `{ data, pagination }` envelope in `openapi.yaml` components. Define `PaginationInfo` schema with `cursor`, `hasMore`, `limit`. This sets the pattern for all future collection endpoints.
+- Deliverables: OpenAPI schema components.
+- Dependencies: Should be defined alongside Task 1.
+
+**Task 3: X-RateLimit-Limit header on rate-limited endpoints**
+- What: Add `X-RateLimit-Limit` header to all responses from `handleCreateCapture`, `handleVerifyCapture`, `handleGetSigningKey`. Value is the static limit from config (10, 60, 60 respectively).
+- Deliverables: Code changes in handlers, OpenAPI spec header component, tests.
+- Dependencies: None.
+
+**Task 4: CORS for POST /v1/captures**
+- What: Add OPTIONS preflight handler for `/v1/captures`. Return `Access-Control-Allow-Origin` from a configurable allowlist (env var), `Access-Control-Allow-Headers: Authorization, Content-Type`, `Access-Control-Allow-Methods: POST`. Update OpenAPI spec.
+- Deliverables: Preflight handler, CORS header injection, env var for allowed origins, tests.
+- Dependencies: None. Can be done in parallel with Tasks 1-3.
+
+**Task 5: Auth identity enrichment (prerequisite for per-tenant)**
+- What: Refactor `verifyApiKey()` to return `{ ok: true, tenantId: string }`. For now, the single static key maps to a hardcoded default tenant ID. Update all call sites to thread `tenantId` into logging and KV operations. This is a pure refactor with no external behavior change.
+- Deliverables: Updated auth module, updated handler call sites, updated log calls, tests.
+- Dependencies: None, but should happen before the list endpoint ships to avoid scoping the list endpoint incorrectly.
+
+**Task 6: Batch capture endpoint design**
+- What: Design `POST /v1/captures/batch` contract (request schema, 207 vs 202 response, per-URL error reporting, rate limit interaction). Produce API design document and OpenAPI spec addition. Do not implement yet.
+- Deliverables: API design document, OpenAPI spec draft.
+- Dependencies: Task 1 (list endpoint) and Task 3 (rate limit headers) should ship first to validate patterns.
+
+### Risks and Concerns
+
+**1. KV list performance ceiling.** KV `list()` + N `get()` calls is O(n) in KV operations per list request. At 1000+ captures per tenant, this will hit both latency and cost ceilings. The mitigation is D1, but D1 is listed as `[consider]` in the backlog. The list endpoint design should be KV-compatible today but D1-ready tomorrow -- the cursor and envelope shape should not need to change when the storage backend changes.
+
+**2. Tenant scoping before per-tenant keys.** If the list endpoint ships before per-tenant keys, it must scope to "all captures" (since there is only one tenant). When per-tenant keys arrive, the list endpoint must scope to "this tenant's captures." If KV keys are not already prefixed by tenant, this migration is painful. Task 5 (auth identity enrichment) should happen before or alongside the list endpoint to ensure KV keys include tenant scope from the start.
+
+**3. The capture-ID-as-secret pattern and multi-tenancy.** This is a design-level tension, not a bug. The current model says "knowing the ID grants access." Per-tenant keys say "your key scopes your access." These are compatible (the list endpoint scopes by tenant, individual access is by ID) but the interaction must be explicitly documented. Risk: a user expects per-tenant keys to prevent cross-tenant access to individual captures, but that is not what the current design provides.
+
+**4. CORS allowlist maintenance.** A configurable origin allowlist for the POST endpoint is more secure than `*`, but it requires operators to update the list when new clients are deployed. If the allowlist is empty or misconfigured, browser clients silently fail (CORS errors are notoriously opaque). The env var should have a sensible default and the deployment docs should call it out.
+
+**5. Batch capture rate limit interaction.** A batch of 10 URLs should count as 10 against the per-IP rate limit (not 1). If the rate limit is 10/min and a client sends a batch of 10, they have used their entire budget. This must be enforced server-side before validation begins, not after. If the limiter binding only supports `limit({ key })` without a "count" parameter, this may require multiple `limit()` calls or a switch to a different rate limiting approach.
+
+### Additional Agents Needed
+
+**data-minion** -- The list endpoint design is entangled with the storage layer. KV vs D1 is not just an infrastructure decision; it determines what query patterns the API can support. A data-minion should weigh in on whether to introduce a secondary KV index pattern (write amplification) or accelerate D1 adoption (infrastructure complexity). This decision shapes the API roadmap more than any other single factor.
+
+**devx-minion** -- Once the list endpoint and collection envelope are designed, a devx-minion should evaluate the SDK generation story. The `{ data, pagination }` envelope, operationId conventions, and error schemas should produce clean SDK code. Catching DX issues at design time is cheaper than fixing them after the spec is published.

--- a/docs/history/nefario-reports/2026-03-15-103905-prioritized-product-roadmap/phase2-gru-prompt.md
+++ b/docs/history/nefario-reports/2026-03-15-103905-prioritized-product-roadmap/phase2-gru-prompt.md
@@ -1,0 +1,47 @@
+You are contributing to the PLANNING phase of a multi-agent project.
+You are NOT executing yet — you are providing your domain expertise to help build a comprehensive plan.
+
+## Advisory Context
+This is an advisory-only orchestration. Your contribution will feed into a team recommendation, not an execution plan. Focus on analysis, trade-offs, and recommendations rather than implementation tasks.
+
+## Project Task
+Review backlog and produce a prioritized product roadmap for WRL (Web Resource Ledger), a tamper-evident web archival service on Cloudflare Workers.
+
+## Your Planning Question
+WRL occupies a niche between legal-tech evidence platforms and web archiving tools.
+
+1. Looking at the `[consider]` items around eIDAS, WACZ-Auth, domain-ownership certificates, and HSM-backed keys -- which of these represent genuine market differentiation vs. over-investment for a single-operator tool?
+2. The MCP/AI-agent trigger item is tagged `[consider]` -- given the current trajectory of AI agent tooling, should this move up?
+3. Cloudflare's Browser Rendering API has limitations (no cert info, no network timing) -- are there emerging alternatives or Cloudflare roadmap items that change the capture fidelity calculus?
+
+Note: product-marketing-minion will evaluate these same items through a positioning lens (which items create compelling launch moments); your focus is on technology viability, timing, and strategic staying power.
+
+## Context
+Read these files for context:
+- `docs/backlog.md` -- Signing, Product Features, Capture Fidelity sections
+- `docs/MVP.md` -- technology stack rationale
+
+## Instructions
+1. Read relevant files to understand the current state
+2. Apply your domain expertise to the planning question
+3. Identify risks, dependencies, and requirements from your perspective
+4. If you believe additional specialists should be involved that aren't already part of the planning, say so and explain why
+5. Return your contribution in this format:
+
+## Domain Plan Contribution: gru
+
+### Recommendations
+<your expert recommendations for this aspect of the task>
+
+### Proposed Tasks
+<specific tasks that should be in the execution plan>
+For each task: what to do, deliverables, dependencies
+
+### Risks and Concerns
+<things that could go wrong from your domain perspective>
+
+### Additional Agents Needed
+<any specialists not yet involved who should be, and why>
+(or "None" if the current team is sufficient)
+
+6. Write your complete contribution to `/var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-oZkd87/prioritized-product-roadmap/phase2-gru.md`

--- a/docs/history/nefario-reports/2026-03-15-103905-prioritized-product-roadmap/phase2-gru.md
+++ b/docs/history/nefario-reports/2026-03-15-103905-prioritized-product-roadmap/phase2-gru.md
@@ -1,0 +1,144 @@
+## Domain Plan Contribution: gru
+
+### Recommendations
+
+#### Question 1: Signing/Legal `[consider]` items -- differentiation vs. over-investment
+
+**TL;DR**: RFC 3161 timestamps are the only signing upgrade worth near-term investment. eIDAS Qualified TSA is premature. WACZ-Auth full compliance, domain-ownership certs, and HSM are over-investment for where WRL is today.
+
+| Item | Ring | Verdict | Rationale |
+|------|------|---------|-----------|
+| RFC 3161 timestamps (basic TSA) | **Trial** | Build in H2 2026 | The single most impactful signing upgrade. Moves WRL from "self-asserted time" to "independently verifiable time." Multiple free/cheap TSAs exist (FreeTSA, rfc3161.ai.moda, DigiCert, GlobalSign). The `signedData` object in `datapackage-digest.json` was explicitly designed for this. ASN.1 parsing is the main complexity -- manageable with a focused implementation sprint. |
+| Multiple TSAs for redundancy | **Assess** | Defer 6+ months past first TSA | FreeTSA has no SLA and its reliability is inconsistent (recent certificate rotation, endpoint confusion). But solving redundancy before having a single TSA working is premature. Ship one TSA integration first, then evaluate whether failover is needed based on observed reliability. |
+| eIDAS Qualified TSA | **Hold** | Not before 2027 | eIDAS 2.0 Qualified TSA implementing acts (Article 42(2)) had a September 2025 deadline for technical specs, but the priority-sector compliance deadline is end of 2026, and production QTSP launches are expected Q4 2026 at earliest. The ecosystem is still forming. WRL would be building against a moving target. More critically: eIDAS Qualified TSA only matters if WRL targets European legal proceedings as a core use case. For a single-operator tool, a standard RFC 3161 timestamp from a reputable CA (DigiCert, GlobalSign) carries sufficient evidentiary weight in most jurisdictions. eIDAS qualification is a differentiator for a multi-tenant legal-tech SaaS, not for WRL's current form. **Re-evaluate when**: WRL has paying European customers asking for it, or when at least 3 QTSPs offer timestamp services with published pricing and APIs. |
+| WACZ-Auth full spec compliance | **Assess** | Low priority | WRL already follows WACZ-Auth 0.1.0 structure (separate `datapackage-digest.json` with `signedData`). The gap to full compliance is the domain-ownership certificate component. The spec itself (January 2022) has not seen significant revision activity -- the Webrecorder GitHub repo shows minimal spec evolution since 2023. Starling Lab produced one experimental signed WACZ with AP News, but there is no production toolchain that consumes WACZ-Auth signatures for verification. Building full compliance produces a technically correct artifact that no tool in the ecosystem can validate. |
+| Domain-ownership certificate | **Hold** | Over-investment | This is the identity-proof component of WACZ-Auth: proving the signer controls the domain via a TLS certificate. It requires WRL to use the same private key for both TLS and WACZ signing -- architecturally problematic (coupling TLS identity to application signing, key rotation complexity, certificate lifecycle management). The evidentiary value is marginal: WRL's `.well-known/signing-key` endpoint already provides a public key tied to the service's domain. The forensic chain is: DNS -> domain -> Worker -> signing key. A domain-ownership certificate adds a cryptographic proof of what is already inferrable. Not worth the complexity. |
+| HSM-backed key storage | **Hold** | Wait for Cloudflare native solution | Cloudflare Workers have no native HSM integration. The Keyless SSL + HSM path exists but is designed for TLS termination, not application-level signing. Integrating an external HSM (AWS CloudHSM, Azure Managed HSM) from a Worker means adding a network hop to an external cloud for every signing operation -- this adds latency (30-100ms per sign), introduces a cross-cloud dependency, and complicates the "zero-ops Cloudflare-native" architecture. The current approach (Ed25519 key as a Wrangler secret) is acceptable for a single-operator deployment. HSM becomes relevant only when: (a) WRL handles keys for multiple tenants, or (b) a compliance requirement (e.g., FIPS 140-2 Level 3) explicitly mandates it. Neither condition exists today. |
+
+**Bottom line on Question 1**: Invest in RFC 3161 basic timestamping. It is the one upgrade that materially changes WRL's evidentiary value (from self-asserted to third-party-attested time). Everything else is either premature (eIDAS), architecturally questionable (domain-ownership certs, HSM via cross-cloud), or building for a consumer that does not yet exist (full WACZ-Auth compliance).
+
+---
+
+#### Question 2: MCP/AI-agent trigger -- should it move up?
+
+**Ring: Trial. Yes, it should move up from `[consider]` to `[should]`.**
+
+The MCP ecosystem has undergone a phase transition since the kickoff backlog was written. Key signals:
+
+1. **Production adoption is real, not speculative.** MCP was donated to the Linux Foundation. OpenAI, Google DeepMind, Microsoft, and Salesforce all adopted it by early 2026. Tens of thousands of MCP servers exist. This is not a "watch" technology -- it is the de facto standard for agent-to-tool integration.
+
+2. **Cloudflare itself ships MCP-native Browser Rendering.** As of May 2025, you can deploy Playwright MCP directly on Cloudflare Browser Rendering. WRL's own infrastructure provider is betting on MCP as the agent-to-tool interface. This reduces the impedance mismatch to near-zero.
+
+3. **WRL's API is already MCP-shaped.** The existing REST API (POST to capture, GET to poll, GET to verify) maps cleanly to MCP tool definitions. An MCP server for WRL would be a thin adapter over the existing API -- not a new architecture. Estimated effort: days, not weeks.
+
+4. **The use case is compelling and immediate.** AI agents performing research, compliance monitoring, fact-checking, or legal evidence gathering need a way to capture web state as part of their workflow. "Capture this URL and give me a tamper-evident record" is a natural tool call for agents doing any kind of web-evidence work. Gartner's projection that 40% of enterprise applications embed AI agents by end of 2026 means the addressable integration surface is expanding rapidly.
+
+5. **EU AI Act compliance creates demand.** The August 2026 enforcement date for high-risk AI system transparency requirements means AI systems need auditable evidence trails. An MCP-accessible web capture tool that produces tamper-evident records fits directly into this compliance narrative.
+
+6. **Market positioning upside.** Being "the MCP server for web evidence" is a niche that currently has zero occupants. No existing web archival tool (Wayback Machine, Stillio, Webrecorder, Archive-It) offers an MCP interface. First-mover advantage in this intersection is achievable with minimal effort.
+
+**Recommended timeline**: Build in Q2 2026. Ship immediately after the list/search endpoint (`GET /v1/captures`), since agents need to be able to retrieve their captures. The dependency chain is: list endpoint -> MCP server. The MCP server itself is a weekend project given the existing API.
+
+**Implementation note**: The MCP server should expose three tools: `capture_url` (wraps POST), `get_capture` (wraps GET), `verify_capture` (wraps GET verify). It should also expose a resource for listing captures once that endpoint exists. This is a natural candidate for the mcp-minion to implement.
+
+---
+
+#### Question 3: Capture fidelity -- Cloudflare Browser Rendering limitations and alternatives
+
+**Ring for the fidelity gap: Assess. The limitations are real but the alternatives are worse than the workarounds.**
+
+**Current state of Browser Rendering (March 2026):**
+- REST API rate limits increased 3x (now 600/min on paid plans)
+- Playwright GA at v1.57.0 via `@cloudflare/playwright`
+- New `/crawl` endpoint in beta (site-level crawling)
+- Full CDP protocol access via WebSocket (Network, Page, Runtime, DOM, Input, Emulation domains confirmed)
+- No changelog entries mentioning certificate info or response.securityDetails
+- No changelog entries mentioning network timing metrics beyond `X-Browser-Ms-Used` header
+
+**The certificate info gap:**
+
+Playwright upstream does not expose `response.securityDetails()` -- this is a Puppeteer-only API (via CDP `Security.securityStateChanged`). There is an [open feature request](https://github.com/microsoft/playwright-python/issues/629) for it in Playwright, but it has not been implemented. Since WRL migrated to Playwright in phase 0014, the certificate info gap is a Playwright limitation, not just a Cloudflare limitation.
+
+However, Cloudflare Browser Rendering does support CDP protocol access via WebSocket. This means it is *technically possible* to open a CDP session alongside Playwright and use the `Security` and `Network` CDP domains to capture certificate details. This would be a custom integration -- not a first-class Playwright API -- but it is achievable within the current platform constraints.
+
+**Practical assessment of workarounds:**
+
+| Gap | Workaround | Feasibility | Priority |
+|-----|-----------|-------------|----------|
+| TLS certificate info | CDP `Security.securityStateChanged` via WebSocket alongside Playwright | Medium -- requires dual-protocol management, adds complexity | Low for MVP+1. Certificate info is forensic-grade evidence, not needed for basic web state capture. |
+| Network timing | CDP `Network.requestWillBeSent` + `Network.responseReceived` via WebSocket | Medium -- same dual-protocol approach | Low. Timing is a bonus signal, not core to WRL's value prop. |
+| Full HTTP exchange | CDP `Network.enable` with full request/response interception | Medium-High -- significant data volume, storage implications | Medium-term. This is the path to Scoop-level capture fidelity without leaving Cloudflare. |
+| Sub-resource archiving | Page resource enumeration via CDP + individual fetch | High complexity -- CORS issues, storage multiplication, deduplication | Low priority. The backlog correctly identifies this as a significant complexity escalation. |
+
+**Alternatives to Cloudflare Browser Rendering:**
+
+| Alternative | Pros | Cons | Verdict |
+|------------|------|------|---------|
+| Cloudflare Containers + full Chromium | Unrestricted CDP, full network stack, certificate access, no API limits | Still in preview (not GA), pricing model uncertain, adds ops complexity, breaks "zero-ops" architecture | **Assess** -- monitor for GA and stable pricing. This is the escape hatch if Browser Rendering limits become blocking. |
+| External browser service (Browserless, BrowserStack, etc.) | Full CDP, mature APIs | Adds external dependency, egress costs, latency, breaks Cloudflare-native constraint | **Hold** -- defeats WRL's architectural advantage. |
+| Cloudflare Queue + Container hybrid | Use Queue to dispatch to Container-based Chromium for high-fidelity captures | Best of both worlds architecturally, but doubles infrastructure complexity | **Assess** -- viable design pattern once Containers reach GA. |
+
+**Recommendation on capture fidelity:**
+
+Do not chase forensic-grade capture fidelity now. The current approach (rendered HTML + screenshot + HTTP headers) serves the core value proposition. RFC 3161 timestamps add more evidentiary value than certificate info does.
+
+If forensic capture becomes a stated requirement, the path is:
+1. First: try CDP via WebSocket within Browser Rendering (cheapest, stays Cloudflare-native)
+2. If that hits walls: evaluate Cloudflare Containers when they reach GA
+3. Last resort: external browser service
+
+Monitor Cloudflare Containers for GA announcement and stable pricing -- this is the most likely unlock for the full capture fidelity story.
+
+---
+
+### Proposed Tasks
+
+**Task 1: RFC 3161 Timestamp Integration**
+- What: Integrate a single RFC 3161 TSA (recommend DigiCert or GlobalSign over FreeTSA for reliability). Add timestamp response to `signedData` in `datapackage-digest.json`. Update verification endpoint to validate the timestamp.
+- Deliverables: TSA integration module, updated WACZ bundling, updated verification pipeline, tests
+- Dependencies: None (current signing infrastructure supports extension)
+- Timeline: Q2 2026
+- Handoff: Implementation to edge-minion + security-minion
+
+**Task 2: MCP Server for WRL**
+- What: Build an MCP server exposing `capture_url`, `get_capture`, and `verify_capture` tools. Use Streamable HTTP transport for remote deployment.
+- Deliverables: MCP server package, documentation, example agent integration
+- Dependencies: List/search endpoint (`GET /v1/captures`) should ship first or concurrently
+- Timeline: Q2 2026, after or alongside list endpoint
+- Handoff: Implementation to mcp-minion
+
+**Task 3: CDP Capture Fidelity Spike**
+- What: Proof-of-concept: open CDP WebSocket session alongside Playwright within Browser Rendering. Attempt to capture TLS certificate details and network timing via `Security` and `Network` CDP domains. Determine what is possible within Cloudflare's sandboxed CDP environment.
+- Deliverables: Spike report documenting what works, what does not, and performance impact
+- Dependencies: None
+- Timeline: Q3 2026 (lower priority than Tasks 1-2)
+- Handoff: Implementation to edge-minion
+
+**Task 4: Cloudflare Containers Monitoring**
+- What: Track Cloudflare Containers for GA announcement and stable pricing. When GA, evaluate as escape hatch for capture fidelity constraints.
+- Deliverables: Technology assessment when GA is announced (gru produces this)
+- Dependencies: External -- Cloudflare product roadmap
+- Timeline: Ongoing, check quarterly
+
+---
+
+### Risks and Concerns
+
+1. **RFC 3161 TSA reliability risk.** FreeTSA has documented reliability issues and no SLA. Using a commercial TSA (DigiCert, GlobalSign) adds a cost but removes the reliability concern. Recommendation: start with a commercial TSA that offers a free tier or low-cost tier; FreeTSA as fallback only.
+
+2. **MCP spec velocity risk.** MCP is evolving rapidly (2025-11-25 spec added Tasks, Streamable HTTP, OAuth). Building now means potentially adapting to spec changes. Mitigation: the WRL MCP server is thin enough (3 tools over REST) that spec changes have minimal impact. Use the stable core of MCP (tools + resources), not bleeding-edge features (Tasks, server discovery).
+
+3. **CDP within Browser Rendering -- untested territory.** The spike (Task 3) may reveal that Cloudflare's sandboxed CDP environment blocks `Security` domain events or filters network details. If so, the certificate/timing capture path is blocked until Containers reach GA. This is an acceptable risk for a spike.
+
+4. **eIDAS over-investment temptation.** The eIDAS narrative is compelling for positioning ("EU-compliant tamper-evident archival") but the implementation reality is: QTSPs are not ready, the ecosystem is forming, and WRL would be building against draft implementing acts. The risk is spending engineering time on compliance theater rather than product value. A standard RFC 3161 timestamp from DigiCert carries more practical evidentiary weight today than a promise of future eIDAS qualification.
+
+5. **Capture fidelity scope creep.** Certificate info and network timing are forensic niceties, not core to WRL's value proposition. The risk is that pursuing these diverts focus from the items that actually move the product forward (list endpoint, MCP, timestamps, multi-tenancy). Contain capture fidelity work to a time-boxed spike, not an open-ended implementation.
+
+---
+
+### Additional Agents Needed
+
+- **mcp-minion** -- Required for Task 2 (MCP server implementation). MCP server design and implementation is explicitly in mcp-minion's domain.
+- **edge-minion** -- Required for Tasks 1 and 3 (TSA integration within Workers, CDP spike within Browser Rendering). Both tasks involve Cloudflare Worker internals and Browser Rendering platform constraints.
+- **security-minion** -- Should review Task 1 (TSA integration touches the signing/verification chain, which is security-critical) and provide input on whether the CDP spike reveals any new attack surface.
+- **legal/compliance specialist** (if available) -- The eIDAS and RFC 3161 decisions would benefit from someone who understands evidentiary standards in specific jurisdictions. If no legal specialist exists in the agent team, this is a gap that should be filled by human domain expertise, not agent speculation. Flag this to the human operator.

--- a/docs/history/nefario-reports/2026-03-15-103905-prioritized-product-roadmap/phase2-iac-minion-prompt.md
+++ b/docs/history/nefario-reports/2026-03-15-103905-prioritized-product-roadmap/phase2-iac-minion-prompt.md
@@ -1,0 +1,49 @@
+You are contributing to the PLANNING phase of a multi-agent project.
+You are NOT executing yet — you are providing your domain expertise to help build a comprehensive plan.
+
+## Advisory Context
+This is an advisory-only orchestration. Your contribution will feed into a team recommendation, not an execution plan. Focus on analysis, trade-offs, and recommendations rather than implementation tasks.
+
+## Project Task
+Review backlog and produce a prioritized product roadmap for WRL (Web Resource Ledger), a tamper-evident web archival service on Cloudflare Workers.
+
+## Your Planning Question
+The backlog has operational items spanning CI/CD enhancements, queue migration, scaling options, and storage considerations.
+
+1. What infrastructure changes are prerequisites for other roadmap items (e.g., does per-tenant auth need D1 for key storage, or can KV handle it)?
+2. The "Scaling Beyond Session Reuse" section lists 4 options (pre-warming, Queues, DO, Containers) -- at what scale threshold do these become relevant, and should any be planned proactively?
+3. CD (deployment automation) is deferred -- when should it become a priority relative to other work?
+4. Preview deployments on PRs -- worth it for a single-developer project?
+
+Note: security-minion owns the auth sequencing and api-design-minion owns the API contract evolution -- focus on the infrastructure enablement and operational readiness that other agents' plans depend on.
+
+## Context
+Read these files for context:
+- `docs/backlog.md` -- Operations, Storage, Scaling sections
+- `wrangler.toml` -- current Cloudflare configuration
+- `.github/workflows/` -- current CI setup
+
+## Instructions
+1. Read relevant files to understand the current state
+2. Apply your domain expertise to the planning question
+3. Identify risks, dependencies, and requirements from your perspective
+4. If you believe additional specialists should be involved that aren't already part of the planning, say so and explain why
+5. Return your contribution in this format:
+
+## Domain Plan Contribution: iac-minion
+
+### Recommendations
+<your expert recommendations for this aspect of the task>
+
+### Proposed Tasks
+<specific tasks that should be in the execution plan>
+For each task: what to do, deliverables, dependencies
+
+### Risks and Concerns
+<things that could go wrong from your domain perspective>
+
+### Additional Agents Needed
+<any specialists not yet involved who should be, and why>
+(or "None" if the current team is sufficient)
+
+6. Write your complete contribution to `/var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-oZkd87/prioritized-product-roadmap/phase2-iac-minion.md`

--- a/docs/history/nefario-reports/2026-03-15-103905-prioritized-product-roadmap/phase2-iac-minion.md
+++ b/docs/history/nefario-reports/2026-03-15-103905-prioritized-product-roadmap/phase2-iac-minion.md
@@ -1,0 +1,213 @@
+# Domain Plan Contribution: iac-minion
+
+## Current Infrastructure State
+
+WRL is a pure Cloudflare Workers application with:
+- **Compute**: Single Worker (`wrl`) using `@cloudflare/playwright` for Browser Rendering
+- **Storage**: R2 bucket (`wrl-captures`) for artifacts, KV namespace for capture status/metadata
+- **Auth**: Single static API key via `CAPTURE_API_KEY` env secret (timing-safe comparison)
+- **Rate limiting**: Three `unsafe.bindings` rate limiters (per-IP capture at 10/min, per-IP verify at 60/min, global capture at 200/min)
+- **Observability**: Structured JSON logs shipped to Coralogix via HTTP ingestion
+- **CI**: GitHub Actions running tests + OpenAPI lint on code changes; no CD (manual `wrangler deploy`)
+- **No D1, no Queues, no Durable Objects, no Cron Triggers** -- minimal binding surface
+
+---
+
+## Recommendations
+
+### Question 1: Infrastructure Prerequisites for Roadmap Items
+
+**Per-tenant auth: KV is sufficient; D1 is not needed yet.**
+
+The current auth model is a single `CAPTURE_API_KEY` environment secret compared with `crypto.subtle.timingSafeEqual`. Per-tenant keys require storing multiple keys with metadata (tenant ID, scopes, creation date, rotation state). The question is whether this needs D1 or can stay in KV.
+
+KV handles this fine for the foreseeable scale:
+- Key count will be low (tens of tenants, not thousands) -- KV list operations are practical at this scale
+- Key lookups are by exact key value (hash the API key, use hash as KV key) -- O(1) lookup, no query needed
+- Key metadata (tenant ID, scopes, created/rotated dates) fits in KV's value field as JSON
+- KV's eventual consistency is acceptable for auth: key rotation has a propagation window of ~60s globally, which is fine when you support overlapping active keys (the backlog already requires this)
+
+The pattern: `kv.get("apikey:<sha256-of-bearer-token>")` returns `{ tenantId, scopes: ["capture", "read"], createdAt, ... }`. This is a hash-based lookup, not a query -- KV is designed for exactly this.
+
+**D1 becomes relevant only when the list/search captures endpoint needs query-by-attribute** (filter by tenant, date range, URL pattern). The backlog already identifies this (`[consider] D1 (edge SQLite) -- if KV becomes limiting for metadata queries`). The trigger is the `GET /v1/captures` list endpoint, not per-tenant auth.
+
+**Dependency chain**: Per-tenant auth keys (KV) --> List endpoint with tenant-scoped results (may trigger D1) --> Per-tenant rate limiting (switches rate limit key from IP to tenant ID, no new infrastructure needed)
+
+**Audit logging for key usage**: Also fits in KV or Coralogix. Each capture already logs to Coralogix with structured fields -- adding `tenantId` to log entries gives audit trail without new infrastructure. KV-based audit logs would only be needed if you need to query audit data from the Worker itself (e.g., "show me my last 10 captures"). That's the list endpoint again, which may drive D1.
+
+### Question 2: Scaling Beyond Session Reuse -- Threshold Analysis
+
+The current system handles **~300 captures/min** (global rate limit) with **30 reusable browser sessions** and a 2-minute keep-alive. Here is when each scaling option becomes relevant:
+
+**Session pre-warming via cron trigger** -- Relevant now (low effort, low risk)
+
+This is the only scaling item I would recommend planning proactively. The backlog frames it as a scaling optimization, but its primary value is **latency reduction on low-traffic deployments**. During traffic lulls, all 30 sessions expire after KEEP_ALIVE_MS (120s). The next capture pays a cold-start penalty for `acquire()`. A cron trigger every 90 seconds that calls `sessions()` and `acquire()` to maintain a minimum warm pool (e.g., 2-3 sessions) is trivial to implement:
+
+```toml
+# wrangler.toml addition
+[triggers]
+crons = ["*/2 * * * *"]  # every 2 minutes
+```
+
+Implementation: ~30 lines of code in `index.js` adding a `scheduled` event handler. No new bindings, no new cost (cron triggers are free on Workers, browser sessions are billed per-use regardless of pre-warming).
+
+This should be planned for the phase after session reuse is battle-tested with real traffic.
+
+**Cloudflare Queues** -- Relevant at ~150-200 sustained captures/min OR when slow-page timeouts recur
+
+The backlog correctly identifies the trigger: `ctx.waitUntil()` has a 30-second hard limit. The current capture pipeline uses ~25s for navigation timeout + 5s headroom. Queues give 15 minutes per message. Queues become necessary when:
+1. Slow pages regularly hit the 25s navigation timeout (signal: `capture.stage.fail` events with `errorCategory: "Page did not finish loading"` in Coralogix)
+2. Sustained throughput approaches the 200/min global limit and you need to absorb bursts without dropping requests
+
+Queues cost: $0.40/million operations (publish + consume). At 200/min sustained, that is ~8.6M operations/month = ~$3.44/month. Negligible.
+
+**Do not plan proactively.** The signal is in Coralogix logs. When timeout-related failures exceed an acceptable threshold (e.g., >5% of captures), Queues should move to [should].
+
+**Durable Object session coordinator** -- Relevant only at multi-worker concurrency problems
+
+DOs would centralize session lifecycle across Workers, preventing the race condition in `getOrCreateSession()` where two Workers both see a free session and one fails to connect. The current code handles this gracefully (catch + fallback to acquire). DOs become relevant only if:
+- Session contention causes measurable capture failures (>1% of attempts)
+- You need session affinity (route specific tenants to specific sessions)
+
+Current architecture handles contention fine through random selection + fallback. **Do not plan proactively.** This is over-engineering for current scale.
+
+**Cloudflare Containers** -- Not relevant until Browser Rendering limits are a blocking concern
+
+Containers escape Browser Rendering's 30-session limit and gVisor sandbox constraints entirely. But they introduce: container image management, cold start latency (seconds, not milliseconds), networking complexity, and a fundamentally different deployment model. The backlog correctly notes "session reuse pushes this further out."
+
+**Do not plan.** This is a topology escalation (per Step 0 framework) that requires a documented blocking concern. The blocking concern would be: Browser Rendering session limits are consistently exhausted AND Queues cannot absorb the overflow. That is at least two scaling thresholds away from current state.
+
+### Question 3: CD (Deployment Automation) Timing
+
+CD should become a priority **after per-tenant auth and before the first external user onboarding**. Here is the reasoning:
+
+**Current state**: `wrangler deploy` is manual. For a single developer, this is fine. The CI pipeline validates code quality; deployment is a conscious human act.
+
+**Why CD matters for multi-tenant**: When per-tenant keys exist and external users depend on the service, deployment velocity and reliability become operational requirements. A bad deploy with no automated rollback capability could leave paying/dependent users without service. The cost of manual deployment goes up (must coordinate with users, can't deploy on a schedule without friction).
+
+**Recommended CD approach** (Cloudflare Workers-specific):
+
+1. **Phase 1 -- Staging environment**: Add a `wrangler.toml` environment for staging (`[env.staging]`) with separate KV namespace and R2 bucket. Deploy to staging on every push to `main`. This is 15 minutes of wrangler.toml config + a workflow file.
+
+2. **Phase 2 -- Production deploy with approval**: GitHub Actions workflow triggered by Git tags or manual `workflow_dispatch`. Uses GitHub environment protection rules (`production` environment with required reviewers). Runs smoke test against staging before deploying to production.
+
+3. **Phase 3 -- Rollback capability**: `wrangler rollback` support (Cloudflare keeps previous deployments). Add a manual workflow_dispatch for rollback.
+
+**Sequence recommendation**: CD Phase 1 (staging env) can be done as part of any infrastructure phase -- it is low effort and immediately useful for testing. CD Phase 2 (production with approval) should be done alongside or immediately after per-tenant auth. CD Phase 3 (rollback) should be done before onboarding external users who depend on uptime.
+
+### Question 4: Preview Deployments on PRs
+
+**Not worth it for the current single-developer setup.** Here is the analysis:
+
+**Cost**: Cloudflare Workers preview deployments require either:
+- `wrangler deploy --env preview-{PR_NUMBER}` with dynamically created KV namespaces, R2 buckets, and secrets -- significant wrangler.toml complexity for a disposable environment
+- Cloudflare Pages (which supports preview deployments natively but is designed for static sites, not Workers)
+
+**Benefit for single developer**: You can `wrangler dev` locally with the preview KV/R2 namespaces already configured. The feedback loop is already short.
+
+**When it becomes worth it**:
+- Second developer (code review with live preview)
+- External contributors (can't run `wrangler dev` without secrets access)
+- Integration testing that requires the Cloudflare runtime (Browser Rendering binding is not available in local dev)
+
+**Recommendation**: Keep at [consider]. Revisit when team size > 1.
+
+---
+
+## Proposed Tasks
+
+### Task 1: KV Key Schema for Per-Tenant Auth (Infrastructure Enablement)
+
+**What**: Design and document the KV key schema that per-tenant auth will use. This is infrastructure prep that security-minion's auth implementation depends on.
+
+**Deliverables**:
+- KV key schema document: key naming convention (`apikey:<sha256>`, `tenant:<tenantId>`), value shapes, TTL strategy
+- Migration path from single `CAPTURE_API_KEY` env secret to KV-based key lookup
+- Backward compatibility plan (support both old and new auth during migration)
+
+**Dependencies**: None. This is a design task that unblocks security-minion's per-tenant auth implementation.
+
+### Task 2: Staging Environment Configuration
+
+**What**: Add a staging environment to `wrangler.toml` with isolated KV and R2 bindings.
+
+**Deliverables**:
+- `wrangler.toml` `[env.staging]` section with separate KV namespace and R2 bucket
+- GitHub Actions workflow (`deploy-staging.yml`) that deploys to staging on push to `main`
+- Smoke test script that hits `/health` and a basic capture flow against staging
+
+**Dependencies**: None. Can be done in any phase.
+
+### Task 3: Session Pre-Warming Cron Trigger
+
+**What**: Add a cron trigger that maintains a minimum warm session pool during low-traffic periods.
+
+**Deliverables**:
+- `[triggers]` section in `wrangler.toml` with cron schedule
+- `scheduled` event handler in `index.js` that checks `sessions()` and `acquire()`s if below minimum
+- Coralogix log entry for pre-warming events (for capacity monitoring)
+
+**Dependencies**: Requires observability data showing cold-start latency impact. Can be implemented speculatively (low risk, low cost) or data-driven after monitoring shows the pattern.
+
+### Task 4: Production CD Pipeline with Environment Protection
+
+**What**: Automated deployment to production triggered by Git tags, with GitHub environment protection.
+
+**Deliverables**:
+- GitHub Actions workflow (`deploy-production.yml`) with `workflow_dispatch` and tag triggers
+- GitHub `production` environment with required reviewers
+- `CLOUDFLARE_API_TOKEN` secret scoped to `production` environment
+- Post-deploy health check step
+- Rollback documentation (manual `wrangler rollback` procedure)
+
+**Dependencies**: Task 2 (staging environment should exist first so the deploy pipeline can run smoke tests against staging before promoting to production).
+
+### Task 5: Queues Migration (Triggered by Data, Not Calendar)
+
+**What**: Replace `ctx.waitUntil()` capture processing with Cloudflare Queue consumer.
+
+**Deliverables**:
+- Queue binding in `wrangler.toml`
+- Producer: `handleCreateCapture` publishes to queue instead of `ctx.waitUntil()`
+- Consumer: Queue handler calls `performCapture()`
+- Retry policy configuration (dead-letter after N failures)
+- Updated rate limiting strategy (queue depth as backpressure signal)
+
+**Dependencies**: This task is data-driven. It should move from [consider] to [should] when Coralogix data shows either: (a) timeout-related capture failures >5% of attempts, or (b) traffic regularly approaches 200/min sustained. **Not calendar-scheduled.**
+
+---
+
+## Risks and Concerns
+
+### Risk 1: KV Eventual Consistency Window During Key Rotation
+
+When per-tenant auth moves to KV, key rotation creates a window where a newly-rotated key may not be visible at all edge locations. KV's propagation is typically <60 seconds but can be longer under load. Mitigation: the backlog already requires "API key rotation without downtime -- support multiple active keys." This means old keys remain valid during propagation. The auth implementation must check both old and new keys during rotation.
+
+### Risk 2: Browser Rendering Billing Opacity
+
+Cloudflare Browser Rendering pricing has changed multiple times. Session reuse reduces costs significantly, but there is no cost-per-capture visibility in the current setup. Before scaling beyond current traffic, instrument Coralogix logs with session lifecycle data (acquire vs. reuse, session age, session count at time of capture) to build a cost model. Without this, scaling decisions are blind.
+
+### Risk 3: Single-Region State Concentration
+
+KV and R2 are globally distributed, but the `wrangler secret` values (CAPTURE_API_KEY, CORALOGIX_SEND_KEY, SIGNING_KEY) are managed through a single Cloudflare account with no infrastructure-as-code backing. Loss of account access or accidental secret deletion has no recovery path beyond re-creating secrets manually. Mitigation: document all secrets and their rotation procedures. Consider `wrangler.toml` secret references with values stored in a secrets manager (Cloudflare has no native secrets manager, so this would be external -- but even a documented list in a secure location is better than nothing).
+
+### Risk 4: No Terraform / IaC for Cloudflare Resources
+
+KV namespaces, R2 buckets, rate limiters, and DNS records are managed manually or via `wrangler.toml` declarative config. `wrangler.toml` is a form of IaC, but it lacks: state tracking, drift detection, plan/apply workflow, and multi-resource orchestration. For a single-developer project, this is acceptable. For multi-tenant production, consider Cloudflare Terraform provider for resources that `wrangler.toml` does not manage (DNS records, WAF rules, custom domains, account-level settings). This is not urgent but should be on the radar when operational complexity grows.
+
+### Risk 5: ctx.waitUntil() Budget Fragility
+
+The 30-second `ctx.waitUntil()` budget is the single most constraining infrastructure limit. Navigation timeout (25s) + R2 writes + KV updates + WACZ bundling + Coralogix logging must all complete within 30s. WACZ bundling involves cryptographic signing and ZIP creation in-memory. If page complexity increases (larger screenshots, more artifacts), this budget will be the first thing to break. The Queues migration (Task 5) is the escape valve, but until then, monitoring `capture.success` durations in Coralogix is critical for early warning.
+
+---
+
+## Additional Agents Needed
+
+**observability-minion**: The scaling threshold decisions (Questions 2 and 3) depend on having actionable Coralogix dashboards and alerts. The backlog lists `[consider] Coralogix alerting rules` -- this should be elevated. Specifically, the following signals need dashboards before scaling decisions can be data-driven:
+- Capture duration distribution (P50, P95, P99)
+- Timeout failure rate as percentage of total captures
+- Session pool utilization (free sessions vs. total sessions at time of capture)
+- Global rate limiter hit rate
+- Browser Rendering cost proxy metrics (acquires vs. reuses per hour)
+
+Without these dashboards, scaling decisions are guesswork. The observability-minion should define the monitoring requirements that make Task 5 (Queues migration) trigger-able by data rather than by calendar or gut feel.

--- a/docs/history/nefario-reports/2026-03-15-103905-prioritized-product-roadmap/phase2-lucy-prompt.md
+++ b/docs/history/nefario-reports/2026-03-15-103905-prioritized-product-roadmap/phase2-lucy-prompt.md
@@ -1,0 +1,51 @@
+You are contributing to the PLANNING phase of a multi-agent project.
+You are NOT executing yet — you are providing your domain expertise to help build a comprehensive plan.
+
+## Advisory Context
+This is an advisory-only orchestration. Your contribution will feed into a team recommendation, not an execution plan. Focus on analysis, trade-offs, and recommendations rather than implementation tasks.
+
+## Project Task
+Review backlog and produce a prioritized product roadmap for WRL (Web Resource Ledger), a tamper-evident web archival service on Cloudflare Workers.
+
+The backlog was accumulated from 15 phases of specialist agent recommendations. Some items may reflect agent enthusiasm rather than genuine human intent.
+
+## Your Planning Question
+1. Review the backlog against the project's stated philosophy (CLAUDE.md: YAGNI, KISS, Helix Manifesto, "prefer lightweight vanilla solutions"). Which items appear to violate these principles -- things that were added speculatively by agents and never validated by the human?
+2. The project's CLAUDE.md says WRL is both a real product AND a despicable-agents showcase. Does the backlog balance these goals, or has one side accumulated disproportionate scope?
+3. Are there items in the `[must]` tier that should be downgraded? The `[must]` items were all flagged by security-minion during kickoff -- is "must before multi-user" the right framing when multi-user isn't even on the near-term horizon?
+4. Are there backlog items that exist solely because an agent raised them during planning, with no evidence the human operator actually needs them?
+
+Note: margo will review the final plan for over-engineering in Phase 3.5; your role here is earlier -- auditing the backlog inputs before they become roadmap items, catching intent drift at the source rather than at the output.
+
+## Context
+Read these files for context:
+- `docs/backlog.md` -- the full backlog to audit
+- `CLAUDE.md` -- engineering philosophy and project constraints
+- `CLAUDE.local.md` -- additional project constraints
+- `docs/MVP.md` -- original scope and philosophy
+- `docs/evolution/README.md` -- trace where items originated
+
+## Instructions
+1. Read relevant files to understand the current state
+2. Apply your domain expertise to the planning question
+3. Identify risks, dependencies, and requirements from your perspective
+4. If you believe additional specialists should be involved that aren't already part of the planning, say so and explain why
+5. Return your contribution in this format:
+
+## Domain Plan Contribution: lucy
+
+### Recommendations
+<your expert recommendations for this aspect of the task>
+
+### Proposed Tasks
+<specific tasks that should be in the execution plan>
+For each task: what to do, deliverables, dependencies
+
+### Risks and Concerns
+<things that could go wrong from your domain perspective>
+
+### Additional Agents Needed
+<any specialists not yet involved who should be, and why>
+(or "None" if the current team is sufficient)
+
+6. Write your complete contribution to `/var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-oZkd87/prioritized-product-roadmap/phase2-lucy.md`

--- a/docs/history/nefario-reports/2026-03-15-103905-prioritized-product-roadmap/phase2-lucy.md
+++ b/docs/history/nefario-reports/2026-03-15-103905-prioritized-product-roadmap/phase2-lucy.md
@@ -1,0 +1,159 @@
+# Domain Plan Contribution: lucy
+
+## Recommendations
+
+### 1. CLAUDE.md Philosophy Violations in the Backlog
+
+The project's engineering philosophy is explicit: YAGNI, KISS, Lean and Mean, Helix Manifesto. The human's kickoff prompt reinforced this: "the smallest thing that delivers the core value prop." MVP.md further declares: "Every feature traces to R1, R2, or R3. No speculative additions."
+
+Against these principles, the following backlog items are suspect:
+
+**DRIFT: Speculative items with no evidence of human need**
+
+| Item | Tier | Violation | Source |
+|------|------|-----------|--------|
+| eIDAS Qualified TSA | consider | Pre-optimization for "European customers" that do not exist. No user has asked for legal admissibility. | gru, kickoff |
+| WACZ-Auth signing spec (full) | consider | Standards completionism. MVP's simplified version works. No user has requested full compliance. | gru, kickoff |
+| Domain-ownership certificate | consider | Depends on WACZ-Auth full spec, which is itself speculative. Two layers of YAGNI. | gru, kickoff |
+| Multiple TSAs for redundancy | consider | Optimizing for TSA reliability before implementing a single TSA. Classic pre-optimization. | gru, kickoff |
+| HSM-backed key storage | consider | Enterprise-grade key management for a single-operator $5/month service. Disproportionate. | security-minion, kickoff |
+| S3 Object Lock (WORM-certified) | consider | "For regulated customers" who do not exist and are not targeted. | gru, iac-minion, kickoff |
+| D1 (edge SQLite) | consider | "If KV becomes limiting" -- speculative scaling that contradicts the KV choice made in MVP. | iac-minion, kickoff |
+| Fastly CDN layer | consider | "Evaluate when verification traffic justifies it" -- no traffic data exists to justify this. | iac-minion, kickoff |
+| Capture service container migration | consider | Escape hatch from Browser Rendering that was further deferred by session reuse success (phase 0014). | iac-minion, kickoff |
+| SSE / WebSocket | consider | Explicitly rejected during kickoff decisions ("overkill"). Remains in backlog anyway. | api-design-minion, kickoff |
+| Batch capture | consider | No user has needed this. Single-URL capture is the stated value prop. | api-design-minion, kickoff |
+| Webhooks / outbound callbacks | consider | Explicitly rejected during kickoff ("callback complexity"). Remains in backlog. | api-design-minion, kickoff |
+| Scheduled captures (cron-style) | consider | Explicitly listed under "What's Out" in MVP.md with a clear rationale. | MVP.md |
+| Watch lists / bulk monitoring | consider | Requires scheduling (which is also deferred). Two-deep dependency chain on unvalidated need. | MVP.md |
+| Change detection / diffing | consider | Requires multiple captures over time. No evidence anyone wants this. | MVP.md |
+| Notifications | consider | "API 202 response is the notification" per MVP.md. No user has complained. | MVP.md |
+| Billing and quotas | consider | "No monetization for MVP" per MVP.md. Premature. | MVP.md |
+| MCP / AI-agent triggers | consider | "Layers on top of API" per MVP.md. Interesting to agents, unvalidated by users. | MVP.md |
+| Network namespace isolation | consider | Defense-in-depth for a browser sandbox that is already managed by Cloudflare. | security-minion, kickoff |
+| DNS rebinding integration tests | consider | Requires controlled DNS with TTL manipulation -- infrastructure for an edge case test. | urlval outcome |
+| Cloud metadata DNS alias tests | consider | Only resolvable inside cloud VPCs. Untestable in the current Cloudflare environment. | urlval outcome |
+| Session pre-warming via cron | consider | Scaling optimization added in phase 0014. No evidence of cold-start problems. | playwright-migration |
+| Durable Object session coordinator | consider | Significant architectural complexity for a concurrency problem that hasn't materialized. | playwright-migration |
+
+**Observation**: 23 of the 27 `[consider]` items (85%) show no evidence that the human operator has ever expressed a need for them. They originate from agent specialists systematically cataloging what *could* be built, not what *should* be built. This is textbook scope creep via thoroughness.
+
+**DRIFT: Items that contradict explicit kickoff rejections**
+
+Three items were explicitly rejected during the 0001-kickoff decisions phase but appear in the backlog as `[consider]`:
+
+1. **SSE / WebSocket** -- Rejected as "overkill" in `0001-kickoff/decisions.md`. Still in the backlog.
+2. **Webhooks / outbound callbacks** -- Rejected as "callback complexity" in `0001-kickoff/decisions.md`. Still in the backlog.
+3. **Database for metadata** -- D1/database was rejected as "overkill for key-value" in `0001-kickoff/decisions.md`. Still in the backlog.
+
+These should not be in an active backlog. They were evaluated, rejected with rationale, and their presence implies they are still under consideration. The "What's Out" table in MVP.md is the proper place for rejected items; the backlog should contain only items that *might* be built.
+
+### 2. Dual-Purpose Balance Assessment
+
+The project states two goals: (1) a real product, and (2) a despicable-agents showcase.
+
+**Product side**: 70+ items across 10 domains. The feature surface implied by the full backlog is that of a mature SaaS platform (multi-tenancy, RBAC, billing, webhooks, scheduled captures, change detection, CDN layer, WORM storage). This is not a single-operator archival service -- it's a full product roadmap for a business that does not yet have its first external user.
+
+**Showcase side**: Zero backlog items relate to improving the despicable-agents showcase experience. No items for documentation of the agent process, improving evolution log quality, or making the build story more accessible. The showcase goal is served entirely by the evolution log convention, which is a process requirement rather than a product feature. This is appropriate -- the showcase value comes from the build process, not from additional product scope.
+
+**Verdict**: The imbalance is *correct*. The showcase goal does not need backlog items; it needs disciplined process documentation (which CLAUDE.md already mandates). The risk is the opposite: the product side has accumulated enterprise-grade scope that would take years to build and would bury the showcase story under feature development. The showcase is best served by a focused, complete, well-documented product -- not an expansive one.
+
+### 3. [must] Tier Reassessment
+
+All 5 remaining `[must]` items are in Auth and Access Control, all from security-minion during kickoff:
+
+| Item | Current framing | Assessment |
+|------|-----------------|------------|
+| Per-tenant API keys | "before second user" | Correctly scoped. Genuinely gates multi-user. But multi-user is not on the near-term horizon. This is a `[should]` until multi-user is actively planned. |
+| API key rotation without downtime | "support multiple active keys" | The MVP already has a rotation mechanism: `wrangler secret update` + deploy (30s). "Without downtime" implies zero-downtime rotation for a service with one user. This is a `[should]`. |
+| Key scoping (read vs write) | "permissions per key" | With one key and one user, scoping is meaningless. YAGNI. This is a `[consider]` until multi-user is actively planned. |
+| Audit logging of key usage | "must before multi-user" | Coralogix already logs auth failures (phase 0015). Full audit logging of *successful* key usage adds value only when there are multiple keys to audit. This is a `[should]` until multi-user. |
+| Tenant isolation / RBAC | "required before multi-user" | RBAC for a single-operator service is building a user management system for one user. This is a `[consider]` until multi-user is actively planned. |
+
+**The framing "must before multi-user" is correct but misleading.** It implies these items are imminent blockers. Multi-user is not on the near-term horizon -- there is no user management system, no billing, no signup flow, and no external users. The entire `[must]` tier is gated on a decision (go multi-user) that has not been made.
+
+**Recommendation**: Downgrade the `[must]` tier to `[should]` for per-tenant API keys, key rotation, and audit logging. Downgrade key scoping and tenant isolation/RBAC to `[consider]`. Add a clear note that these items activate when a multi-user decision is made. This makes the `[must]` tier empty, which accurately reflects the project's current state: the MVP is built, and there are no mandatory next steps -- only choices about direction.
+
+### 4. Items That Exist Solely Because an Agent Raised Them
+
+The following items have no traceable human need. They were surfaced during agent planning phases and have never been validated by the human operator:
+
+**High confidence (agent-only provenance, no human validation)**
+
+- **Content security scanning / Safe Browsing** (security-minion, kickoff): Prevents WRL from being "used as malware mirror." This is a legitimate concern for a public service with many users. For a single-operator service, the operator is the only one who can submit URLs. This solves a problem that requires multi-user to exist.
+- **Content moderation policy and abuse reporting** (security-minion, kickoff): Same as above -- single-operator service cannot be abused by third parties who cannot submit captures.
+- **Terms of service** (security-minion, kickoff): Legal boilerplate for a service with no users, no signup, and no public submission interface.
+- **OAuth for web UI** (security-minion, kickoff): The web UI itself is `[consider]`. Building auth for a UI that might not exist is two-deep YAGNI.
+- **Social signup** (margo, kickoff): Explicitly flagged as "YAGNI until multi-user" by the agent that raised it.
+- **Screenshot height cap configurability** (edge-minion, capture-endpoint): An edge case (pages >8000px) with no reported user complaint.
+- **Additional security event types** (security-minion, mvo-coralogix): "Low signal-to-noise for MVP" per the agent that raised them.
+- **Auth reason codes** (debugger-minion, mvo-coralogix): Refactoring for finer-grained logging. No operational need demonstrated.
+- **R2 write try/catch granularity** (observability-minion, mvo-coralogix): "Catch-all sufficient for MVP" per the agent that raised it.
+- **404 rate limiting** (security-minion, mvo-coralogix): Theoretical log volume amplification. No evidence of scanning attacks.
+- **Coralogix alerting rules** (observability-minion, mvo-coralogix): Useful eventually, but premature before there is operational load to alert on.
+- **Coralogix Send Key IP allowlisting** (security-minion, mvo-coralogix): Blast radius reduction for a key that has not been leaked.
+- **Nonce-based CSP** (security-minion, static-verification-page): "If template ever needs server-side dynamic data" -- it currently does not.
+- **HTML error pages** (margo, static-verification-page): "Acceptable for MVP" per the agent that raised them.
+- **Preview deployments on PRs** (iac-minion, kickoff): CI/CD enhancement for a single-developer project.
+- **Capture ID recovery** (ux-strategy-minion, kickoff): Solved by the list endpoint (which is already in the backlog separately).
+- **Web UI for capture submission** (margo, kickoff): "curl/API sufficient for MVP" per the agent that raised it.
+
+**Pattern**: Many of these items were self-acknowledged as premature by the very agents that raised them. The backlog has become a repository of "things that could theoretically matter someday" rather than "things we need to build." This is the natural output of thorough specialist agents operating under "flag everything" norms -- each agent optimizes for completeness in their domain, and the aggregate is scope explosion.
+
+### 5. What the Backlog Should Look Like
+
+After filtering for YAGNI/KISS compliance and human-validated need, the backlog that reflects actual project priorities is much smaller:
+
+**Genuinely next items (human-originated or human-validated)**
+
+1. **List/search captures** (`GET /v1/captures`) -- Explicitly called "first addition post-MVP" in MVP.md. Human-originated priority.
+2. **HSTS preload submission** -- Concrete, low-effort security hardening with no complexity cost.
+3. **Key versioning / key ID in signatures** -- Needed before the first key rotation, which is a real operational event.
+4. **Old public key archive endpoint** -- Companion to key versioning.
+5. **Queue migration** -- Only when slow-page timeouts actually recur. Trigger condition is stated.
+
+**Reasonable to keep as `[should]`**
+
+6. **RFC 3161 timestamps** -- Upgrade path is designed. Adds genuine value (temporal proof from third party). Implement when the product needs to demonstrate legal defensibility.
+7. **Rate limit headers** (remaining `X-RateLimit-*`) -- Standard API hygiene.
+8. **CORS on capture POST** -- Concrete security hardening.
+9. **Hashed IP logging** -- Privacy-respecting correlation capability. Design is ready.
+10. **Screenshot timing / wait-for-load** -- Known fidelity gap. Address when a user reports it.
+
+**Everything else** should either be moved to an "ideas" or "parking lot" document, or deleted from the backlog with a note in the evolution log about the cleanup rationale.
+
+
+## Proposed Tasks
+
+### Task 1: Backlog Triage and Cleanup
+
+**What**: Review and restructure `docs/backlog.md` per the findings above. Downgrade all `[must]` items to `[should]` or `[consider]` with a "activates when multi-user is decided" qualifier. Remove items that contradict explicit kickoff rejections (SSE/WebSocket, webhooks, database). Move agent-acknowledged-premature items to a "Parking Lot" section or remove them entirely.
+
+**Deliverable**: Updated `docs/backlog.md` with a focused, philosophy-compliant item list. The backlog should be under 30 items, with zero `[must]` items (reflecting that the MVP is complete and there are no mandatory next steps).
+
+**Dependencies**: Human approval of the tier reassessment and removal recommendations above. This is a prioritization decision, not a technical one.
+
+### Task 2: Evolution Log Entry for the Triage
+
+**What**: Create `docs/evolution/NNNN-backlog-triage/` documenting the rationale for every item removed, downgraded, or retained. This preserves the audit trail required by CLAUDE.md.
+
+**Deliverable**: `prompt.md`, `decisions.md`, `outcome.md` in the phase directory.
+
+**Dependencies**: Task 1 completion.
+
+
+## Risks and Concerns
+
+1. **Backlog as social contract**: If the human has been using the backlog as a "things I might want" list rather than a "things I intend to build" list, removing items could discard implicit intent. The cleanup should preserve removed items somewhere accessible (evolution log, "parking lot" section, or a separate archive file) rather than deleting them.
+
+2. **Agent trust signal**: The `[must]` tier was set by security-minion, which the human chose to include in the kickoff team. Downgrading security-minion's recommendations could be read as dismissing security concerns. The framing should be clear: the security analysis is correct (these things ARE needed before multi-user), but the tier assignment conflates "important when triggered" with "important now."
+
+3. **Scope creep re-entry**: Without a clear policy, agents will continue adding items to the backlog during every phase. Phase 0015 (Coralogix) added 7 new `[consider]` items in a single phase. The backlog will re-inflate unless there is a gating criterion for new entries (e.g., "only add items that the human explicitly deferred, not items that agents wish existed").
+
+4. **Dual-purpose tension**: Cleaning the backlog aggressively makes the product more focused but may reduce the showcase value of showing how agent-generated scope accumulates and is managed. The cleanup itself could be narrated as a showcase moment: "here is what happens when you let specialists catalog everything, and here is how you prune."
+
+
+## Additional Agents Needed
+
+- **margo** should review the final roadmap for over-engineering (already planned for Phase 3.5 per the task description -- confirming this is correct and sufficient).
+- No additional agents needed beyond what is already planned. The core issue here is intent alignment, not technical or architectural -- it falls squarely within lucy's scope.

--- a/docs/history/nefario-reports/2026-03-15-103905-prioritized-product-roadmap/phase2-product-marketing-minion-prompt.md
+++ b/docs/history/nefario-reports/2026-03-15-103905-prioritized-product-roadmap/phase2-product-marketing-minion-prompt.md
@@ -1,0 +1,50 @@
+You are contributing to the PLANNING phase of a multi-agent project.
+You are NOT executing yet — you are providing your domain expertise to help build a comprehensive plan.
+
+## Advisory Context
+This is an advisory-only orchestration. Your contribution will feed into a team recommendation, not an execution plan. Focus on analysis, trade-offs, and recommendations rather than implementation tasks.
+
+## Project Task
+Review backlog and produce a prioritized product roadmap for WRL (Web Resource Ledger), a tamper-evident web archival service on Cloudflare Workers.
+
+WRL is both a real product (tamper-evident web archival) and a showcase for the despicable-agents framework. The roadmap needs to serve both narratives.
+
+## Your Planning Question
+1. Looking at the backlog items, which ones -- when shipped -- create meaningful "launch moments" worth announcing (blog post, README update, social mention)? Not every roadmap item is a launch moment; identify the 3-5 that most change WRL's positioning.
+2. For the adopter audience: what is the current value proposition gap? Today WRL is "capture a URL and verify it." What is the smallest set of additions that upgrades the pitch to something an independent adopter would use?
+3. For the despicable-agents audience: which roadmap items best demonstrate multi-agent orchestration capability?
+4. Does the roadmap sequence -- as a narrative arc -- build credibility, or does it feel like random feature accretion?
+
+Note: ux-strategy-minion covers user journey coherence and gru covers technology viability -- your focus is on the external communication value and positioning impact of the sequencing decisions.
+
+## Context
+Read these files for context:
+- `docs/backlog.md` -- the full backlog
+- `README.md` -- current product presentation
+- `docs/evolution/README.md` -- the build story so far (phases 0001-0015)
+- `docs/MVP.md` -- What's Out section for context on deliberate deferrals
+
+## Instructions
+1. Read relevant files to understand the current state
+2. Apply your domain expertise to the planning question
+3. Identify risks, dependencies, and requirements from your perspective
+4. If you believe additional specialists should be involved that aren't already part of the planning, say so and explain why
+5. Return your contribution in this format:
+
+## Domain Plan Contribution: product-marketing-minion
+
+### Recommendations
+<your expert recommendations for this aspect of the task>
+
+### Proposed Tasks
+<specific tasks that should be in the execution plan>
+For each task: what to do, deliverables, dependencies
+
+### Risks and Concerns
+<things that could go wrong from your domain perspective>
+
+### Additional Agents Needed
+<any specialists not yet involved who should be, and why>
+(or "None" if the current team is sufficient)
+
+6. Write your complete contribution to `/var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-oZkd87/prioritized-product-roadmap/phase2-product-marketing-minion.md`

--- a/docs/history/nefario-reports/2026-03-15-103905-prioritized-product-roadmap/phase2-product-marketing-minion.md
+++ b/docs/history/nefario-reports/2026-03-15-103905-prioritized-product-roadmap/phase2-product-marketing-minion.md
@@ -1,0 +1,224 @@
+## Domain Plan Contribution: product-marketing-minion
+
+### Current Positioning Assessment
+
+Before addressing the planning questions, a brief diagnosis of where WRL sits today.
+
+**Current core message (implicit):** "Capture a URL, get a signed archive, let anyone verify it."
+
+**Current market category:** Tamper-evident web archival -- a category most potential users don't know exists. This is effectively a new-category play, which means WRL must educate the market on the problem before pitching the solution.
+
+**Competitive alternatives today:**
+1. Wayback Machine / archive.org (free, no integrity proof, no self-hosting)
+2. Manual screenshots + notarization (slow, expensive, not machine-verifiable)
+3. Webrecorder/ArchiveWeb.page (browser extension, local capture, no server-side API)
+4. "Do nothing" + pray the evidence survives (the most common alternative)
+5. Build it yourself with headless Chrome + S3 (no signing, no verification UX, no standard format)
+
+**Unique attributes WRL has vs. all of the above:**
+- Cryptographic signing with Ed25519 on every capture
+- Public verification endpoint anyone can use without an account
+- Self-hosted / own-infrastructure deployment
+- WACZ standard format (interoperable, legal pedigree)
+- Single API call produces five artifacts (screenshot, HTML, headers, WACZ, verification URL)
+
+**Value proposition gap (honest):** WRL today is a working proof-of-concept that one person can deploy and use via curl. It is not yet something a second person would adopt independently. The README says "Store the capture ID. There is no listing endpoint to recover it." That sentence alone communicates "not ready for real use" louder than any feature list communicates readiness.
+
+---
+
+### Question 1: Launch Moments (3-5 Backlog Items Worth Announcing)
+
+Not every shipped item deserves a blog post. A "launch moment" requires: (a) a before/after story that is easy to tell, (b) a change in what the product can credibly claim, and (c) relevance to at least one target audience. Here are the items that qualify, ranked by positioning impact:
+
+**Launch Moment 1: List/Search Captures Endpoint + Per-Tenant API Keys (shipped together)**
+
+This is the single most important launch moment because it changes WRL's category claim from "a demo you can run" to "a service you can operate." Today, losing a capture ID means losing the capture forever. Today, there is one static API key. Shipping these two together lets you credibly say: "WRL is ready for its first real users beyond the builder." This is the "open for business" moment.
+
+- **Before/After story:** "Previously, WRL was a single-operator tool where losing a capture ID meant losing the capture. Now multiple users can manage their own captures and keys."
+- **Positioning shift:** From "technical proof-of-concept" to "self-hosted service you can actually rely on."
+- **Announcement channels:** Blog post (detailed), README update (remove the "no list endpoint" warning), social (short).
+
+**Launch Moment 2: RFC 3161 Timestamps (TSA Integration)**
+
+This upgrades WRL's integrity claim from "we signed it" (self-asserted) to "a third party can prove when it existed" (independently verifiable temporal proof). For the legal/compliance use case -- which is the strongest natural wedge -- this is table stakes. Without TSA, WRL's "tamper-evident" claim is weaker than it needs to be: anyone can generate a self-signed timestamp and backdate it.
+
+- **Before/After story:** "WRL captures were signed but self-timestamped. Now every capture includes an RFC 3161 timestamp from an independent authority, creating evidence that holds up to scrutiny."
+- **Positioning shift:** From "integrity tool" to "evidence tool." The word "evidence" requires temporal proof.
+- **Announcement channels:** Blog post (deep technical dive on why self-asserted timestamps are insufficient), comparison with alternatives, potential crosspost to legal-tech communities.
+
+**Launch Moment 3: Key Versioning + Rotation Without Downtime**
+
+Today, rotating the signing key breaks verification of all prior captures. The README explicitly warns about this. Fixing it is not glamorous, but it removes a dealbreaker for anyone considering production use. This is a trust-building moment, not a feature moment.
+
+- **Before/After story:** "Previously, rotating your signing key meant all old captures showed 'Verification Failed.' Now WRL maintains a key history, and old captures verify against the key that signed them."
+- **Positioning shift:** Removes a credibility-destroying caveat from the README. Signals operational maturity.
+- **Announcement channels:** Changelog entry (detailed), README update (remove the warning block), brief social mention.
+
+**Launch Moment 4: MCP / AI-Agent Triggers**
+
+This is a positioning play for the despicable-agents audience and for developer mindshare more broadly. "Your AI agent can capture and verify web pages" is a novel, timely pitch that differentiates WRL from every archival alternative. None of the competitive alternatives have an AI-agent integration story.
+
+- **Before/After story:** "WRL captures required curl or custom API calls. Now any MCP-compatible AI agent can capture web pages as part of its workflow."
+- **Positioning shift:** From "archival tool" to "web evidence infrastructure for AI workflows." This is a big-fish-small-pond play targeting AI-agent builders.
+- **Announcement channels:** Blog post framed around use cases (AI agent that monitors regulatory pages, agent that archives sources before summarizing them), demo video, potential Product Hunt / Hacker News moment.
+
+**Launch Moment 5: Web UI for Capture Submission**
+
+This is the moment WRL becomes demonstrable without a terminal. Every launch moment above is curl-first. A web UI lets you send someone a link and say "try it." This dramatically reduces time-to-first-value for evaluation and creates a visual artifact for social sharing.
+
+- **Before/After story:** "WRL required curl to use. Now anyone with a browser can capture and verify a web page."
+- **Positioning shift:** From "developer tool" to "tool developers can show to non-developers." Expands the social proof surface.
+- **Announcement channels:** Visual-first social post, GIF/video demo, README update with screenshot.
+
+---
+
+### Question 2: Value Proposition Gap -- Smallest Addition Set for Independent Adopters
+
+The current pitch is "capture a URL and verify it." That is technically accurate but fails the Jobs-to-be-Done test: no one's job is "capture a URL." People's jobs are:
+
+- "Prove what was on a webpage at a specific time" (legal, compliance, journalism)
+- "Archive web content I need to reference later" (research, due diligence)
+- "Monitor a page for changes with proof" (regulatory, competitive intelligence)
+
+The smallest set of additions that upgrades the pitch from "demo" to "tool an independent adopter would use":
+
+1. **List/Search captures** [must] -- Without this, WRL is a write-only system. You cannot browse, search, or recover your captures. This is the single biggest blocker to adoption. No one will trust a system where data loss is one lost ID away.
+
+2. **Per-tenant API keys** [must] -- Without this, there is no safe way to let a second person use the instance. The first adopter beyond the builder hits this wall immediately.
+
+3. **Key versioning** [should] -- The README warning about key rotation breaking all old captures is a dealbreaker for anyone planning to use WRL for more than a week. Production use requires key rotation; key rotation currently destroys the value of every prior capture.
+
+4. **Content moderation / abuse policy** [should] -- Before WRL can be offered to anyone else, it needs terms of service and an abuse reporting mechanism. Without this, the operator is legally exposed.
+
+These four items -- list endpoint, per-tenant keys, key versioning, and abuse policy -- are the minimum viable "second user" package. They transform the pitch from "capture a URL and verify it" to "run a tamper-evident archival service for your team."
+
+Note what is NOT in this minimum set: TSA timestamps, web UI, scheduled captures, WORM storage. Those are valuable but not blocking for a first independent adopter who is comfortable with curl.
+
+---
+
+### Question 3: Best Despicable-Agents Showcase Items
+
+For the despicable-agents audience, the interesting question is not "what was built" but "how was it built, and why was multi-agent orchestration better than a single developer?" The roadmap items that best demonstrate this:
+
+1. **RFC 3161 TSA Integration** -- This involved a genuine specialist conflict (gru vs. security-minion on complexity vs. necessity). The resolution is documented. This is the kind of decision where multiple expert perspectives genuinely produce a better outcome than one person guessing. Blog post title: "When your security agent and your architect disagree: how we resolved the TSA timestamp debate."
+
+2. **Browser Session Reuse / Playwright Migration (Phase 0014, already shipped)** -- A performance optimization that required coordinating security review (TOCTOU analysis), performance engineering, and testing. The categorizeError bug found by test-minion is a perfect anecdote: a specialist caught a real bug that a generalist might have missed. This is already shipped but has not been written up as a despicable-agents showcase piece.
+
+3. **Per-Tenant Auth System** -- Designing an auth system involves security, API design, and UX tradeoffs simultaneously. The multi-agent approach should surface tensions (e.g., security-minion wanting maximum isolation vs. margo wanting minimal friction) that produce a better design than either perspective alone.
+
+4. **Observability Layer (Phase 0015, already shipped)** -- Six specialists reviewed the logging design and caught issues (wrong Coralogix region, missing try/catch, static reason codes). This is a strong "wisdom of the crowd" story where the final design was measurably better than any single proposal.
+
+5. **The Roadmap Phase Itself** -- Meta-showcase: using multi-agent orchestration to plan the roadmap, with specialists arguing about priorities from their domains. This is the phase happening right now. If documented well, it demonstrates that despicable-agents works for planning, not just implementation.
+
+**Key insight for the despicable-agents narrative:** The most compelling showcase items are ones where specialists DISAGREED and the resolution was documented. Agreement is boring; conflict resolution is instructive.
+
+---
+
+### Question 4: Narrative Arc Assessment
+
+The current 15-phase evolution reads as a coherent build story: scaffold, core pipeline (capture, bundle, retrieve, verify), UX layer (verification page), hardening (OpenAPI, security), and operational maturity (open-source readiness, README, session reuse, observability). This is a credible "zero to working product" arc.
+
+**The risk going forward is exactly the "random feature accretion" problem the question raises.** If the roadmap sequence is: list endpoint, then TSA, then web UI, then MCP triggers, then scheduled captures -- that reads as a grab bag. Each item is individually useful but the sequence tells no story.
+
+**Recommended narrative arc for the roadmap (three acts):**
+
+**Act 1: "Ready for Others" (Phases 0016-0019ish)**
+Theme: Everything needed so a second person can use WRL confidently.
+Items: List/search endpoint, per-tenant API keys, key versioning, abuse policy, content moderation.
+Positioning shift: "I built a thing" becomes "you can use this thing."
+Launch moment: "WRL is open for users" blog post.
+
+**Act 2: "Evidence-Grade" (Phases 0020-0022ish)**
+Theme: Upgrading from integrity verification to legal-grade evidence.
+Items: RFC 3161 timestamps, HSTS preload, potentially eIDAS groundwork.
+Positioning shift: "Tamper-evident" becomes "evidence-grade." The word "evidence" carries legal weight that "tamper-evident" does not.
+Launch moment: "WRL captures are now independently timestamped" technical deep-dive.
+
+**Act 3: "Infrastructure" (Phases 0023+)**
+Theme: WRL as infrastructure other tools and agents build on.
+Items: MCP triggers, scheduled captures, webhooks, web UI.
+Positioning shift: "Archival service" becomes "web evidence infrastructure." Other products and workflows integrate with WRL rather than using it directly.
+Launch moment: "Your AI agent can now capture and verify web pages" demo.
+
+This three-act structure builds credibility in sequence: first prove you can be relied upon (Act 1), then prove your evidence is rigorous (Act 2), then prove you fit into larger workflows (Act 3). Each act makes the next one's claims credible. You cannot credibly pitch "evidence infrastructure for AI agents" if you do not have key rotation working.
+
+**The despicable-agents narrative maps to the same acts:** Act 1 showcases multi-agent planning and auth design. Act 2 showcases specialist conflict resolution on technical standards. Act 3 showcases how agent-built software evolves to serve other agents.
+
+---
+
+### Recommendations
+
+#### On Sequencing
+
+1. **Ship the "Ready for Others" bundle before any new feature work.** The list endpoint, per-tenant keys, and key versioning are not exciting features, but they are the foundation every future launch moment stands on. Shipping MCP triggers before fixing "losing a capture ID loses the capture" undermines the entire positioning.
+
+2. **Pair backlog items into launch moments, not individual ships.** List endpoint alone is not a launch moment. List endpoint + per-tenant keys + key versioning shipped as "WRL is ready for real users" IS a launch moment. The roadmap should identify bundles, not just items.
+
+3. **Do not ship the Web UI too early.** A web UI on top of a single-key, no-list-endpoint system invites evaluation by people who will hit the sharp edges immediately. Ship it after Act 1 is complete.
+
+4. **TSA timestamps should precede MCP triggers.** TSA strengthens the core value proposition (evidence). MCP expands the addressable audience. Strengthening the core before expanding the audience is the safer sequence.
+
+#### On Messaging
+
+5. **Retire the README caveat about capture ID loss as soon as the list endpoint ships.** That single paragraph is the most damaging sentence in the current positioning. It signals "not production-ready" to anyone evaluating WRL.
+
+6. **Start using "web evidence" instead of "web archival" in positioning.** Archival competes with archive.org (free, massive, established). Evidence competes with manual screenshots and notarization (expensive, slow, unverifiable). The evidence framing puts WRL in a category where it wins on every dimension.
+
+7. **Write the "Before/After" blog post for Phase 0014 (session reuse) now.** This is already shipped, has a strong technical narrative (10x throughput, security bug caught by test-minion, Playwright migration), and is excellent despicable-agents showcase material. It costs nothing to write and starts building the content library.
+
+#### On the Despicable-Agents Showcase
+
+8. **Every Act boundary should produce a "how we built it" blog post**, not just a changelog. The evolution log is the raw material; the blog post is the positioning artifact. The evolution log is for practitioners who want to reproduce the process. The blog post is for practitioners who want to understand why multi-agent orchestration matters.
+
+9. **Track and publish "catches" -- things a specialist agent found that a solo developer would likely have missed.** The categorizeError bug in Phase 0014, the Coralogix region correction in Phase 0015 -- these are concrete proof points for the despicable-agents value proposition. Maintain a running list.
+
+---
+
+### Proposed Tasks
+
+#### Task 1: Define the "Ready for Others" Launch Bundle
+**What:** Identify the exact backlog items that constitute the Act 1 bundle. Write the target positioning statement that becomes true when this bundle ships. Draft the README changes that would follow (removing caveats, updating the pitch).
+**Deliverables:** Launch bundle definition document, draft README diff, draft blog post outline.
+**Dependencies:** Backlog prioritization (this roadmap exercise). No code dependency.
+
+#### Task 2: Reframe Core Messaging from "Archival" to "Evidence"
+**What:** Audit all current copy (README, OpenAPI description, verification page text) for "archival" framing. Propose replacement language using "evidence" framing. Test: does each claim hold up if a skeptical developer reads it?
+**Deliverables:** Messaging audit with specific find-and-replace recommendations. Updated messaging hierarchy (core message, supporting messages, proof points).
+**Dependencies:** None. Can be done immediately. Should inform all subsequent copy.
+
+#### Task 3: Write Phase 0014 Technical Narrative (Blog-Ready)
+**What:** Using the evolution log from Phase 0014 (browser session reuse), write a technical narrative suitable for blog publication. Focus on the multi-agent orchestration angle: how specialists coordinated, where they disagreed, what the test-minion caught.
+**Deliverables:** Blog post draft (~1500 words), targeting developers interested in AI-assisted development.
+**Dependencies:** Phase 0014 evolution log (already complete).
+
+#### Task 4: Build "Specialist Catches" Tracking
+**What:** Review all 15 phases and extract instances where a specialist agent identified something that would likely have been missed by a solo developer. Maintain as a running document that grows with each phase.
+**Deliverables:** "Catches" document with phase reference, specialist, what was caught, and impact assessment.
+**Dependencies:** Evolution log phases 0001-0015 (already complete).
+
+#### Task 5: Competitive Positioning Page
+**What:** Draft an honest comparison of WRL vs. alternatives (Wayback Machine, manual screenshots, Webrecorder, build-it-yourself). Acknowledge where alternatives are stronger. Focus differentiation on: self-hosted, cryptographic verification, API-first, WACZ standard format.
+**Deliverables:** Comparison document suitable for README "Alternatives" section or standalone page.
+**Dependencies:** Task 2 (messaging reframe) should complete first to ensure consistent language.
+
+---
+
+### Risks and Concerns
+
+1. **"Evidence" framing without TSA is a credibility risk.** Self-asserted timestamps do not constitute evidence in any rigorous sense. If WRL adopts "evidence" language before shipping TSA timestamps, technically sophisticated users will call this out. Mitigation: use "evidence" in aspirational positioning but be explicit about what is and is not independently verifiable today. Do not claim "legal-grade" or "court-admissible" until TSA is shipped.
+
+2. **The despicable-agents showcase narrative could overshadow the product narrative.** If WRL is positioned primarily as "look what AI agents built," it undermines confidence in the product itself. No one wants to trust their evidence to a demo project. Mitigation: keep the two narratives in separate channels. README and product pages lead with the product. Blog posts and evolution log lead with the process. The despicable-agents badge in the README is fine as a signal, not a headline.
+
+3. **The backlog is heavily [consider]-weighted.** Of approximately 60 items, the majority are [consider]. This is appropriate for a young project but creates a risk of scope creep if the roadmap tries to address too many [consider] items before the [must] items are solid. Mitigation: the three-act structure above prioritizes [must] items in Act 1 and treats [consider] items as Act 3 candidates that may never ship.
+
+4. **No user research to validate positioning assumptions.** All target persona analysis is inferred from the product's capabilities, not from conversations with actual users. The "legal/compliance" and "journalism" use cases are hypotheses. Mitigation: flag these as hypotheses in all positioning documents. Seek validation through community engagement once Act 1 ships.
+
+5. **The "99% vibe coded" badge may work against production credibility.** For the despicable-agents audience, this badge is a feature. For the adopter audience, it could signal "untested experiment." These audiences see the same README. Mitigation: this is a judgment call for the project owner. If the primary near-term audience is despicable-agents showcase viewers, keep it. If independent adopters are the priority, consider whether the badge serves or undermines the pitch.
+
+---
+
+### Additional Agents Needed
+
+**content-strategy-minion or equivalent** -- The three-act roadmap produces at least three blog posts and ongoing "catches" documentation. Someone needs to own the content calendar, ensure posts are written at Act boundaries, and maintain consistency between the product narrative and the process narrative. This is execution work that falls between product-marketing (positioning) and user-docs (tutorials). If no content specialist exists in the agent framework, this work defaults to the human or to product-marketing-minion doing double duty.
+
+Otherwise, the current team (gru for technical viability, ux-strategy-minion for user journey, product-marketing-minion for positioning) is sufficient for the roadmap planning phase. Security-minion should review the Act 1 bundle definition since per-tenant auth and key versioning are security-critical.

--- a/docs/history/nefario-reports/2026-03-15-103905-prioritized-product-roadmap/phase2-security-minion-prompt.md
+++ b/docs/history/nefario-reports/2026-03-15-103905-prioritized-product-roadmap/phase2-security-minion-prompt.md
@@ -1,0 +1,48 @@
+You are contributing to the PLANNING phase of a multi-agent project.
+You are NOT executing yet — you are providing your domain expertise to help build a comprehensive plan.
+
+## Advisory Context
+This is an advisory-only orchestration. Your contribution will feed into a team recommendation, not an execution plan. Focus on analysis, trade-offs, and recommendations rather than implementation tasks.
+
+## Project Task
+Review backlog and produce a prioritized product roadmap for WRL (Web Resource Ledger), a tamper-evident web archival service on Cloudflare Workers.
+
+## Your Planning Question
+The backlog has 8 `[must]` items in Auth/Access Control, all flagged as "required before multi-user."
+
+1. What is the minimum viable security posture upgrade needed before a second user touches WRL -- is it all 8, or can some be staged?
+2. Among the `[should]` security items (content scanning, content moderation, hashed IP logging, HSTS preload), which have the highest risk-to-effort ratio and should move earlier?
+3. The signing/legal section has a chain: key versioning -> old key archive -> RFC 3161 TSA -> eIDAS. What is the right depth to commit to in the near-term vs. deferring?
+
+Note: api-design-minion will address how per-tenant keys affect the API contract, and iac-minion will assess infrastructure prerequisites (e.g., D1 vs. KV for key storage) -- focus your analysis on the security sequencing and threat model aspects.
+
+## Context
+Read these files for context:
+- `docs/backlog.md` -- Auth, Security, Signing sections
+- `src/index.js` -- current auth implementation (single static API key)
+- `src/signing.js` -- current signing implementation
+
+## Instructions
+1. Read relevant files to understand the current state
+2. Apply your domain expertise to the planning question
+3. Identify risks, dependencies, and requirements from your perspective
+4. If you believe additional specialists should be involved that aren't already part of the planning, say so and explain why
+5. Return your contribution in this format:
+
+## Domain Plan Contribution: security-minion
+
+### Recommendations
+<your expert recommendations for this aspect of the task>
+
+### Proposed Tasks
+<specific tasks that should be in the execution plan>
+For each task: what to do, deliverables, dependencies
+
+### Risks and Concerns
+<things that could go wrong from your domain perspective>
+
+### Additional Agents Needed
+<any specialists not yet involved who should be, and why>
+(or "None" if the current team is sufficient)
+
+6. Write your complete contribution to `/var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-oZkd87/prioritized-product-roadmap/phase2-security-minion.md`

--- a/docs/history/nefario-reports/2026-03-15-103905-prioritized-product-roadmap/phase2-security-minion.md
+++ b/docs/history/nefario-reports/2026-03-15-103905-prioritized-product-roadmap/phase2-security-minion.md
@@ -1,0 +1,342 @@
+## Domain Plan Contribution: security-minion
+
+### Recommendations
+
+#### Question 1: Minimum viable security posture for a second user
+
+The 8 `[must]` items in Auth/Access Control are NOT all equal. They form a
+dependency chain and can be staged into two tiers: a hard gate (must ship
+before the second user touches production) and a fast-follow (must ship
+before the service is broadly available, but not before a single trusted
+second user).
+
+**Hard gate -- ship before any second user:**
+
+1. **Per-tenant API keys** -- The current auth model (`auth.js`) compares
+   against a single `CAPTURE_API_KEY` env var. A second user sharing this key
+   means: no attribution of who captured what, no ability to revoke one user
+   without revoking both, and a shared rate-limit bucket (keyed on
+   `CF-Connecting-IP`, not tenant). This is the single biggest blocker.
+
+2. **Tenant isolation** -- Without tenant-scoped data, all captures from all
+   users live in one flat KV namespace under `capture:{captureId}`. Capture IDs
+   are the sole access secret (the comment in `index.js:143` says this
+   explicitly). Any user who guesses or enumerates a capture ID can access
+   another user's captures. The ID space is 128-bit hex, so brute-force is
+   infeasible, but there is no defense-in-depth: no ownership check, no tenant
+   prefix, nothing. Before a second user, captures must carry a tenant
+   identifier and retrieval must enforce `tenant == requesting_tenant`.
+
+3. **Audit logging of key usage** -- You need to know who did what from day
+   one of multi-tenancy. Retrofitting audit logs after an incident is useless.
+   The current security logging (`log.js`) records `security.auth_fail` but
+   NOT successful authentications or which key was used. The minimum viable
+   audit log entry is: `{event: 'api.request', tenant_id, method, path,
+   status, timestamp}`.
+
+4. **Key scoping (read vs write)** -- This is surprisingly important for
+   WRL's architecture. Today, the API key gates only `POST /v1/captures`.
+   Retrieval endpoints (GET capture, GET artifact, GET verify) are
+   unauthenticated -- capture ID is the access secret. If you add per-tenant
+   keys and a list endpoint (`GET /v1/captures`), a read-only key compromise
+   does not grant capture-creation privileges. Without scoping, every key
+   leak is a full write-access compromise. Given the explicit plan for a list
+   endpoint (first post-MVP addition), this must ship with per-tenant keys.
+
+**Fast-follow -- ship before broad availability but NOT a hard gate for one trusted second user:**
+
+5. **API key rotation without downtime** -- Important for operational hygiene,
+   but for a second trusted user, you can coordinate a brief rotation window.
+   The implementation is straightforward: accept an array of valid keys per
+   tenant instead of one.
+
+6. **RBAC** -- Full role-based access control is overkill for 2 users. Key
+   scoping (read/write) covers the immediate need. RBAC becomes necessary
+   when you have team accounts or admin operations.
+
+7. **OAuth for web UI** -- Explicitly `[consider]`, correctly deferred. No
+   web UI exists.
+
+8. **Social signup** -- Explicitly `[consider]`, correctly deferred.
+
+**Net answer:** 4 of the 8 are a hard gate (per-tenant keys, tenant
+isolation, audit logging, key scoping). The other 4 can be staged. Items 7
+and 8 are already `[consider]` and are correctly deferred indefinitely.
+
+**Implementation sequence for the hard-gate items:**
+
+```
+per-tenant keys  --->  tenant isolation  --->  key scoping  --->  audit logging
+     (1)                   (2)                    (3)                 (4)
+```
+
+Rationale: per-tenant keys are the foundation (you need a tenant identity
+before you can scope it). Tenant isolation depends on having a tenant ID to
+tag captures with. Key scoping refines the permission model. Audit logging
+wraps around all of the above (you log tenant ID, key ID, and scope on every
+request).
+
+In practice, items 1-3 should be implemented as a single unit (one PR that
+replaces the auth module, adds tenant tagging to KV records, and introduces
+read/write scopes). Item 4 (audit logging) can be a separate follow-on PR
+that adds `api.request` log entries with the tenant context.
+
+#### Question 2: Highest risk-to-effort ratio among `[should]` security items
+
+Ranked by risk-to-effort ratio (highest first):
+
+1. **HSTS preload submission** -- Effort: 15 minutes (add `preload` to the
+   existing HSTS header, submit to hstspreload.org). Risk mitigated:
+   SSL-stripping attacks on first visit. The HSTS header is already in place
+   (`index.js:53`), just missing the `preload` directive. This is the
+   single highest ROI security item on the entire backlog.
+
+2. **Hashed IP logging** -- Effort: ~1 hour (HMAC-SHA256 of
+   CF-Connecting-IP with a daily-rotating key). Risk mitigated: enables
+   brute-force correlation and abuse detection without storing PII (GDPR-
+   compatible). The design is already documented; implementation is
+   mechanical. This becomes critical the moment a second user exists,
+   because you need to distinguish between normal use and credential
+   stuffing.
+
+3. **Content moderation policy and abuse reporting** -- Effort: ~2 hours
+   (static policy page + abuse@ email endpoint). Risk mitigated: legal
+   liability. WRL stores arbitrary web content in R2 and serves it
+   (as text/plain with Content-Disposition, but still). Without a DMCA/
+   abuse reporting mechanism, the operator has no safe harbor defense.
+   This is not a code change -- it is a policy document and a contact
+   point. Very low effort, very high legal risk reduction.
+
+4. **Terms of service prohibiting illegal use** -- Same logic as above.
+   Ship alongside the content moderation policy. Combined effort with
+   item 3: ~3 hours total.
+
+5. **Content security scanning (Safe Browsing)** -- Effort: moderate
+   (integrate Google Safe Browsing API, ~4-8 hours). Risk mitigated:
+   WRL being used as a malware mirror or phishing content host. This is
+   important but the blast radius is limited by the fact that artifacts
+   are served as `text/plain` with `attachment` disposition, which
+   significantly reduces the XSS/phishing vector. Move this up if WRL
+   ever serves HTML with `text/html` content type. For now, it is
+   correctly a `[should]`.
+
+**Recommendation:** Move HSTS preload, hashed IP logging, content moderation
+policy, and ToS to the same tier as the multi-user auth work. They are low
+effort and close real gaps. Content scanning can stay `[should]` for now.
+
+#### Question 3: Signing/legal chain depth -- what to commit to now
+
+The signing chain is: key versioning -> old key archive -> RFC 3161 TSA -> eIDAS.
+
+**Commit to now (near-term, ship with multi-user):**
+
+1. **Key versioning / key ID in signature entries** -- This is not optional
+   if you ever plan to rotate keys, which you must do for any production
+   service. The current signing implementation (`signing.js`) has exactly
+   one key cached in module scope. `wacz.js` embeds the public key in
+   `datapackage-digest.json` (`signedData.publicKey`), but there is no
+   key ID. If you rotate the signing key, every WACZ signed with the old
+   key becomes unverifiable unless the verifier knows to try the old key.
+
+   The fix is straightforward: add a `keyId` field to `signedData` (e.g.,
+   SHA-256 fingerprint of the public key, truncated to 8 hex chars). The
+   verification endpoint uses the keyId to select the correct public key
+   for verification. This is a small schema change with large operational
+   payoff.
+
+   **Dependency note:** This must ship before the first key rotation,
+   which should be part of the multi-user launch. If you rotate keys
+   before adding key IDs, you create a backward-compatibility break that
+   requires a migration of all existing WACZ bundles.
+
+2. **Old public key archive endpoint** -- A simple extension of the
+   existing `/.well-known/signing-key` endpoint: add support for
+   `?keyId=xyz` or a `/.well-known/signing-keys` endpoint that returns
+   all current and historical public keys. Without this, third-party
+   verifiers cannot verify captures signed with rotated keys.
+
+   **Storage:** KV is sufficient for this. The number of keys will be
+   small (single digits over the lifetime of the service). A KV key like
+   `signing-key:{keyId}` with the base64 public key as the value is all
+   you need. No D1 required.
+
+**Defer (commit to a timeline, but don't build now):**
+
+3. **RFC 3161 TSA** -- The architecture already supports this (the
+   `signatures` array design in the WACZ manifest was explicitly designed
+   for TSA upgrade). However, implementing it requires ASN.1 parsing,
+   which is non-trivial in a Workers environment. The security value is
+   real (independent timestamp authority eliminates self-asserted timestamp
+   trust), but the current self-asserted timestamps are acceptable for
+   the current use case (internal compliance, not courtroom evidence).
+
+   **When to build:** When the first customer asks for timestamps that
+   would hold up in a legal proceeding, or when the list endpoint ships
+   and captures become discoverable (at which point the evidentiary value
+   of the archive increases).
+
+4. **eIDAS Qualified TSA** -- Strategically important for European
+   customers (eIDAS 2.0 rolling out through 2026), but this is a business
+   decision, not a security decision. The technical prerequisite is RFC
+   3161 support, so it is naturally sequenced after item 3. Defer until
+   there is a paying European customer or a clear product-market signal.
+
+**Net answer:** Ship key versioning and the key archive endpoint with the
+multi-user launch. Defer RFC 3161 and eIDAS with a clear note that the
+architecture supports the upgrade path and no schema migration will be
+needed.
+
+### Proposed Tasks
+
+#### Task 1: Per-tenant auth and tenant isolation (Hard Gate)
+
+**What:** Replace the single-static-key auth model with per-tenant API keys,
+add tenant tagging to KV capture records, enforce tenant-scoped retrieval,
+and add read/write key scoping.
+
+**Deliverables:**
+- New `auth.js` that looks up API keys from KV (key: `apikey:{hash}`,
+  value: `{tenantId, scope, createdAt, label}`). Keys are SHA-256 hashed
+  at rest.
+- `verifyApiKey()` returns `{ok: true, tenantId, scope}` on success
+- KV capture records include `tenantId` field
+- `GET /v1/captures/{id}` enforces `record.tenantId == authed.tenantId`
+  (or falls through to the unauthenticated capture-ID-as-secret model for
+  public verification)
+- `POST /v1/captures` requires `write` scope
+- `GET /v1/captures` (list endpoint) requires `read` scope and filters by
+  tenant
+- Rate limiting keyed on `tenantId` instead of `CF-Connecting-IP`
+- CLI tooling or admin script to provision/revoke keys
+
+**Dependencies:** None (foundational)
+
+**Security constraints:**
+- API keys must be hashed (SHA-256) at rest in KV -- never stored plaintext
+- Timing-safe comparison must remain (compare against hash, not raw key)
+- Migration path for existing captures (backfill tenantId or treat as
+  "system" tenant)
+
+#### Task 2: Audit logging for authenticated requests
+
+**What:** Add structured audit log entries for all authenticated API requests
+(not just auth failures).
+
+**Deliverables:**
+- Log entry on every authenticated request: `{event: 'api.request',
+  tenantId, keyId, scope, method, path, status, durationMs}`
+- Log entry on key provisioning/revocation: `{event: 'key.provision',
+  tenantId, keyId}` / `{event: 'key.revoke', tenantId, keyId}`
+- No PII in logs (no raw IP, no API key values)
+
+**Dependencies:** Task 1 (per-tenant auth)
+
+#### Task 3: Signing key versioning
+
+**What:** Add key ID to signature entries and implement key archive for
+backward-compatible verification after key rotation.
+
+**Deliverables:**
+- `keyId` field added to `signedData` in `datapackage-digest.json`
+  (SHA-256 fingerprint of public key, truncated to 8 hex chars)
+- `/.well-known/signing-key` response includes `keyId` field
+- New `/.well-known/signing-keys` endpoint returns all current + historical
+  keys with their keyIds
+- Historical keys stored in KV (`signing-key:{keyId}`)
+- Verification endpoint (`/v1/verify/{id}`) reads keyId from WACZ and
+  selects the correct public key
+- Key rotation procedure documented (add new key, old key moves to archive)
+
+**Dependencies:** None (can be done in parallel with Task 1)
+
+#### Task 4: HSTS preload + content moderation policy + ToS
+
+**What:** Quick-win security items that close real gaps with minimal effort.
+
+**Deliverables:**
+- Add `preload` to HSTS header and submit to hstspreload.org
+- Content moderation policy document (abuse reporting mechanism)
+- Terms of service prohibiting illegal use
+- Both served as static pages or linked from the API
+
+**Dependencies:** None
+
+#### Task 5: Hashed IP logging
+
+**What:** HMAC-SHA256 of CF-Connecting-IP with daily-rotating key for
+abuse detection without PII storage.
+
+**Deliverables:**
+- HMAC function using a daily key derived from a secret + date
+- Hashed IP included in security log entries
+- Enables correlation of requests from the same source within a day
+  without storing raw IPs
+
+**Dependencies:** None (can ship independently)
+
+### Risks and Concerns
+
+**Risk 1: Capture-ID-as-secret model breaks under multi-tenancy.**
+Today, capture IDs are the sole access control mechanism for retrieval.
+The code comment at `index.js:143` explicitly states this: "No
+authentication required -- capture ID acts as the access secret." This
+is fine for single-tenant, but in multi-tenant mode, a list endpoint
+would enumerate all capture IDs for a tenant, and any leaked ID grants
+access to anyone. The transition to per-tenant auth MUST include a
+decision on whether retrieval endpoints become authenticated or whether
+capture IDs remain bearer tokens. My recommendation: keep capture IDs
+as bearer tokens for the public verification use case (anyone with the
+link can verify), but add tenant-scoped authentication for the list
+endpoint and metadata retrieval. This is a nuanced access control
+design that needs explicit agreement.
+
+**Risk 2: KV is not a database -- tenant isolation queries will get awkward.**
+The current KV model stores captures under `capture:{captureId}`. There is
+no way to list captures by tenant without a secondary index. When the list
+endpoint ships, you will need either: (a) a per-tenant index key in KV
+(e.g., `tenant:{tenantId}:captures` with a JSON array of capture IDs), or
+(b) D1. The KV approach works for small scale but has consistency issues
+(KV is eventually consistent, and list operations are not atomic). This is
+an infrastructure decision that iac-minion should weigh in on, but the
+security implication is: if the tenant index is inconsistent, a capture
+could be "invisible" to its owner but accessible to anyone with the ID.
+
+**Risk 3: Key rotation without key versioning will break verification.**
+If the signing key is rotated before key versioning ships, every existing
+WACZ bundle becomes unverifiable through the API (the verification endpoint
+hardcodes the current public key). This is a data integrity risk. Task 3
+(key versioning) MUST ship before the first key rotation.
+
+**Risk 4: No admin authentication model.**
+The backlog items assume key provisioning and revocation, but there is no
+admin API or admin authentication model. Who provisions tenant keys? How?
+If it is `wrangler kv:key put` directly, that works for 2 users but does
+not scale. If it is an admin API endpoint, that endpoint needs its own
+authentication (and it cannot use the same tenant key system, or you have a
+bootstrap problem). This needs a design decision early.
+
+**Risk 5: CORS on capture POST.**
+The backlog notes that the capture POST endpoint should restrict CORS
+origins. Currently, the retrieval endpoints set `Access-Control-Allow-Origin: *`,
+which is correct for public verification. But the capture POST has no CORS
+headers at all (which is fine -- browsers will block cross-origin POSTs by
+default). If CORS is ever added to the capture endpoint, it MUST NOT be
+`*`. This is a "don't break it" risk rather than a "fix it now" risk.
+
+**Risk 6: Rate limiting shifts from IP to tenant.**
+When rate limiting moves from `CF-Connecting-IP` to `tenantId`, a
+compromised API key allows an attacker to exhaust the tenant's rate limit
+(denial of service against the legitimate user). The per-IP limit should
+be retained as a secondary control in addition to per-tenant limits.
+
+### Additional Agents Needed
+
+**privacy-minion (or legal-minion)** -- If such a specialist exists. The
+content moderation policy, terms of service, and GDPR implications of
+hashed IP logging are legal/policy decisions that benefit from specialized
+review. If no such agent exists, these items should be flagged for human
+review before shipping.
+
+Otherwise, the current team (api-design-minion for API contract, iac-minion
+for KV vs D1 storage decisions) is sufficient for the security aspects of
+this roadmap.

--- a/docs/history/nefario-reports/2026-03-15-103905-prioritized-product-roadmap/phase2-ux-strategy-minion-prompt.md
+++ b/docs/history/nefario-reports/2026-03-15-103905-prioritized-product-roadmap/phase2-ux-strategy-minion-prompt.md
@@ -1,0 +1,50 @@
+You are contributing to the PLANNING phase of a multi-agent project.
+You are NOT executing yet — you are providing your domain expertise to help build a comprehensive plan.
+
+## Advisory Context
+This is an advisory-only orchestration. Your contribution will feed into a team recommendation, not an execution plan. Focus on analysis, trade-offs, and recommendations rather than implementation tasks.
+
+## Project Task
+Review backlog and produce a prioritized product roadmap for WRL (Web Resource Ledger), a tamper-evident web archival service on Cloudflare Workers.
+
+**Outcome**: The existing backlog (`docs/backlog.md`) is transformed into a sequenced product roadmap that defines a meaningful evolution path for WRL. Each roadmap item is scoped and described well enough to become a GitHub issue without further research.
+
+## Your Planning Question
+Given WRL's current single-operator/API-only state and the backlog of ~60 items, what is the most coherent user journey evolution? Specifically:
+
+1. What capabilities does a real user need next to go from "I can capture a URL" to "I rely on WRL for evidence"?
+2. Which backlog items form natural clusters that deliver meaningful capability jumps vs. incremental polish?
+3. The backlog has items ranging from "list endpoint" to "eIDAS qualified TSA" -- where is the value cliff where we're building for hypothetical users rather than actual need?
+
+Focus on the user value sequencing; product-marketing-minion will separately address positioning and launch narratives, and lucy will evaluate YAGNI alignment -- so concentrate on the journey coherence and capability clustering that are uniquely your domain.
+
+## Context
+Read these files for context:
+- `docs/backlog.md` -- the full backlog to prioritize
+- `docs/MVP.md` -- What's Out section showing deliberate deferrals
+- `README.md` -- current usage flow (note the lost-ID problem)
+
+## Instructions
+1. Read relevant files to understand the current state
+2. Apply your domain expertise to the planning question
+3. Identify risks, dependencies, and requirements from your perspective
+4. If you believe additional specialists should be involved that aren't already part of the planning, say so and explain why
+5. Return your contribution in this format:
+
+## Domain Plan Contribution: ux-strategy-minion
+
+### Recommendations
+<your expert recommendations for this aspect of the task>
+
+### Proposed Tasks
+<specific tasks that should be in the execution plan>
+For each task: what to do, deliverables, dependencies
+
+### Risks and Concerns
+<things that could go wrong from your domain perspective>
+
+### Additional Agents Needed
+<any specialists not yet involved who should be, and why>
+(or "None" if the current team is sufficient)
+
+6. Write your complete contribution to `/var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-oZkd87/prioritized-product-roadmap/phase2-ux-strategy-minion.md`

--- a/docs/history/nefario-reports/2026-03-15-103905-prioritized-product-roadmap/phase2-ux-strategy-minion.md
+++ b/docs/history/nefario-reports/2026-03-15-103905-prioritized-product-roadmap/phase2-ux-strategy-minion.md
@@ -1,0 +1,185 @@
+## Domain Plan Contribution: ux-strategy-minion
+
+### Analysis: The Current User Journey and Its Gaps
+
+**Current state (JTBD mapping):**
+
+WRL today serves exactly one job: "When I need to prove what a web page looked like at a specific moment, I want to capture it with cryptographic integrity, so I can present tamper-evident evidence to a third party."
+
+The journey to accomplish this job is currently:
+
+1. **Capture** -- POST a URL with an API key. Get back a capture ID.
+2. **Wait** -- Poll the status endpoint until complete.
+3. **Retrieve** -- GET the capture metadata and artifact links.
+4. **Verify** -- Share the verification URL with a third party.
+
+This is a complete, functional journey. But it has a critical fragility and several friction points that prevent anyone from *relying* on WRL rather than merely *trying* it.
+
+---
+
+### Recommendations
+
+#### 1. The Trust Gap Is the Real Problem, Not the Feature Gap
+
+The question "what does a user need to go from 'I can capture' to 'I rely on WRL for evidence'" is fundamentally a trust question, not a feature question. Trust is built through three mechanisms:
+
+- **Recoverability** -- "If something goes wrong, I can recover." The lost-ID problem directly undermines this. A user who loses a capture ID has permanently lost their evidence. This is the single biggest barrier to reliance.
+- **Verifiability** -- "I can prove this is real to others." This exists today but is fragile: key rotation breaks all prior verification, and the timestamp is self-asserted (operator could lie about when).
+- **Reliability** -- "This will work when I need it." The 30s timeout, lack of observability dashboards, and absence of any retry mechanism create anxiety.
+
+The roadmap should sequence around closing these three trust gaps, in that order.
+
+#### 2. Capability Clusters (Natural Groupings That Deliver Meaningful Jumps)
+
+I see five natural clusters in the backlog, ordered by the capability jump they deliver:
+
+**Cluster A: "I can find my captures" (Recoverability)**
+- List/search endpoint (`GET /v1/captures`) -- [must]
+- Pagination, filtering, sorting -- [consider, but must if list is built]
+- Capture ID recovery -- [consider, becomes unnecessary with list]
+
+This is the single highest-value cluster. It transforms WRL from "a tool I use carefully" to "a tool I can rely on." The lost-ID problem is the #1 friction point in the current journey. The response body even warns about it, which is itself an anti-pattern -- if you have to warn users about a design limitation in every response, that limitation is a must-fix.
+
+The JTBD: "When I need to find a capture I made earlier, I want to search by URL or date, so I don't lose evidence because I lost an ID."
+
+**Cluster B: "Others can trust my evidence" (Verifiability)**
+- Key versioning / key ID in signature entries -- [should]
+- Old public key archive endpoint -- [should]
+- RFC 3161 timestamps via TSA -- [should]
+
+This cluster transforms verification from "works if the operator hasn't changed anything" to "works regardless of operational history." Key rotation currently *breaks all prior captures*. The README warns about this in bold. Again, the anti-pattern: if you have to prominently warn users about a catastrophic operational consequence, that consequence is a must-fix before reliance.
+
+RFC 3161 timestamps are the bridge from "the operator says this was captured at time X" to "an independent third party confirms time X." This is the difference between evidence and assertion.
+
+The JTBD: "When I present evidence to a skeptical third party, I want independent timestamp proof, so my evidence isn't dismissed as self-serving."
+
+**Cluster C: "I can scale my usage" (Multi-operator readiness)**
+- Per-tenant API keys -- [must]
+- Key scoping (read vs write) -- [must]
+- API key rotation without downtime -- [must]
+- Audit logging of key usage -- [must]
+- Per-tenant rate limiting -- [consider]
+
+This cluster is gated: you only need it when a second operator arrives. All items are marked [must], and correctly so -- you cannot share access without them. But building this before there's a second user is textbook premature optimization from a UX perspective. The *readiness* to build it should be validated (clean separation points in the code), but the actual build should wait.
+
+The JTBD: "When I want to give capture access to a colleague or client, I want scoped API keys, so they can capture without seeing my history."
+
+**Cluster D: "Captures are more reliable" (Reliability)**
+- Queue migration for capture processing -- [should]
+- Screenshot timing / wait-for-load -- [should]
+- Rate limit headers in responses -- [should]
+- Content security scanning -- [should]
+- Hashed IP logging -- [should]
+
+These are quality-of-life improvements that reduce the "will this work?" anxiety. None individually is transformative, but collectively they move WRL from "works for simple pages" to "works for real-world pages." The queue migration is the most impactful -- it removes the 30s hard limit that currently makes WRL unreliable for complex pages.
+
+**Cluster E: "WRL is a platform" (Future product features)**
+- Scheduled captures, watch lists, change detection, notifications
+- MCP / AI-agent triggers
+- Batch capture
+- Web UI for capture submission
+- Billing and quotas
+- Webhooks / SSE / WebSocket
+
+These are all [consider] items. None of them addresses a job that current users have articulated. They're features for hypothetical users of a hypothetical platform. This is the value cliff.
+
+#### 3. The Value Cliff: Where to Stop
+
+The cliff falls sharply after Cluster B. Here's why:
+
+- **Clusters A + B** serve the *same user* who uses WRL today, but remove the barriers to reliance. They answer: "I can find my captures" and "my evidence holds up under scrutiny." These are must-be features in Kano terms -- their absence destroys the value proposition.
+
+- **Cluster C** serves a *new user type* (multi-operator). Building it before that user exists is building for a hypothesis. The code should be *ready* for it (no architectural debt that blocks it), but the implementation should wait until the second user is real. This is a performance feature in Kano terms -- more tenants = more value, proportionally.
+
+- **Cluster D** improves the current experience incrementally. These are performance features -- they make existing users proportionally more satisfied. They should be picked up opportunistically or when specific pain is felt (a capture fails due to timeout, a page renders incompletely).
+
+- **Cluster E** is almost entirely excitement/indifferent territory for current users. Scheduled captures, change detection, batch capture -- these are solutions looking for problems. No evidence of actual demand. Building any of these before Clusters A and B is choosing novelty over reliability.
+
+The **eIDAS Qualified TSA, WACZ-Auth full implementation, domain-ownership certificates, HSM-backed key storage, S3 Object Lock** -- these are all regulatory/enterprise features that only matter if WRL is being used as evidence in formal proceedings with specific compliance requirements. They're real and important *for that use case*, but building them before any user has that use case is speculative. They belong in "documented upgrade path, not in roadmap."
+
+#### 4. Specific Sequencing Recommendation
+
+**Phase 1: Recoverability (Cluster A)**
+- List endpoint with URL and date filtering
+- Basic pagination
+- This eliminates the lost-ID problem, the single most user-hostile aspect of the current design
+
+**Phase 2: Verification Durability (Cluster B, keys)**
+- Key versioning with key ID in signatures
+- Old public key archive endpoint
+- This makes key rotation safe -- captures signed with old keys remain verifiable
+
+**Phase 3: Independent Timestamps (Cluster B, timestamps)**
+- RFC 3161 TSA integration
+- This elevates evidence from "operator assertion" to "independently verifiable"
+
+**Phase 4: Reliability Hardening (Cluster D, selective)**
+- Queue migration (removes 30s limit)
+- Screenshot wait-for-load improvements
+- Rate limit response headers
+- These address the "will it work?" anxiety for real-world pages
+
+**Phase 5+: Only on demand**
+- Multi-tenancy (Cluster C) -- when a second operator actually appears
+- Platform features (Cluster E) -- when specific user demand is demonstrated
+- Compliance features -- when a user has a specific compliance need
+
+#### 5. Journey Friction Worth Fixing Along the Way
+
+Several small items in the backlog are not clusters but friction points that should be addressed as part of adjacent work:
+
+- **CORS configuration for capture POST** -- if anyone integrates WRL from a web app, this blocks them. Low effort, high annoyance.
+- **HTML error pages for 404/429/503** -- browsers showing raw JSON is hostile when someone mistypes a verification URL. Fix when touching the verification page next.
+- **HSTS preload submission** -- pure ops hygiene, do it once the domain is final.
+- **Content moderation policy and Terms of Service** -- these are must-haves before any public usage, but they're content/legal tasks, not engineering. Should be done before promoting WRL externally.
+
+### Proposed Tasks
+
+#### Task 1: List Endpoint with Search
+**What**: Build `GET /v1/captures` with filtering by URL (exact and prefix match) and date range, cursor-based pagination, sorted by creation date descending.
+**Deliverables**: Working endpoint, OpenAPI spec update, tests, removal of "lost ID" warnings from response bodies and README.
+**Dependencies**: None -- can start immediately.
+**UX rationale**: Eliminates the single largest friction point. Changes the mental model from "you get one chance to save the ID" to "your captures are always findable."
+
+#### Task 2: Key Versioning and Archive
+**What**: Add key ID to signature entries, store historical public keys, add `GET /.well-known/signing-keys` (pluralized) that returns all historical keys with their validity periods.
+**Deliverables**: Updated signing flow, key archive endpoint, updated verification to check against the correct historical key, removal of the bold key-rotation warning from README.
+**Dependencies**: None -- can start immediately, but should ship after Task 1 to maintain focus.
+**UX rationale**: Eliminates the catastrophic "key rotation breaks all prior captures" failure mode. Non-negotiable for any user relying on WRL for evidence.
+
+#### Task 3: RFC 3161 Timestamp Integration
+**What**: Add TSA timestamp request to the WACZ signing pipeline, store the TSA response in the signatures array, update verification to validate the TSA timestamp.
+**Deliverables**: TSA integration, updated WACZ format, updated verification endpoint and page, documentation of what the timestamp proves vs. what the self-signature proves.
+**Dependencies**: Task 2 (key versioning) should be done first so the signing pipeline is already being touched.
+**UX rationale**: Transforms the evidence quality from "operator asserts" to "independently proven." This is the capability that makes WRL useful for actual disputes, not just record-keeping.
+
+#### Task 4: Capture Queue Migration
+**What**: Move capture processing from `ctx.waitUntil()` to Cloudflare Queues. This removes the 30s hard limit and gives 15 minutes of processing budget.
+**Deliverables**: Queue-based processing, updated status polling behavior, updated error handling for queue failures.
+**Dependencies**: None architecturally, but should follow the trust-building Tasks 1-3 in the roadmap.
+**UX rationale**: The 30s limit means complex pages can fail silently. Users who try WRL on a real-world page and get a failure will not come back. Queue migration makes the promise ("capture any page") actually reliable.
+
+#### Task 5: Terms of Service and Content Policy
+**What**: Draft ToS prohibiting illegal use, content moderation policy, and abuse reporting mechanism. Publish at a well-known URL.
+**Deliverables**: ToS page, content policy, abuse reporting endpoint or email.
+**Dependencies**: None -- can be done in parallel with any technical work.
+**UX rationale**: Required before any public promotion. Users relying on WRL need to know the rules. Operators hosting WRL need legal cover.
+
+### Risks and Concerns
+
+**Risk 1: Building multi-tenancy too early.** All five auth/access items are marked [must] in the backlog, but they're [must] *before second user*, not [must] *now*. If the roadmap prioritizes multi-tenancy over recoverability and verification durability, WRL will have enterprise features for hypothetical users while the single real user can't find their captures. This is the classic "building for scale before finding product-market fit" anti-pattern.
+
+**Risk 2: The "evidence" framing creates expectations WRL can't yet meet.** The README says "tamper-evident archival" and "evidence." But with self-asserted timestamps and key rotation that breaks verification, the evidence claim is aspirational. If a user relies on WRL for a real dispute and the evidence is challenged ("you could have set the timestamp to anything"), the product fails its core promise. RFC 3161 timestamps are not a nice-to-have -- they're the minimum for the "evidence" job to actually be done.
+
+**Risk 3: Cluster E items distract from foundational trust.** Items like scheduled captures, MCP triggers, and change detection are exciting to build but add zero value until the foundation is trustworthy. Every hour spent on a [consider] platform feature is an hour not spent closing the trust gap. The roadmap should make it uncomfortable to work on Cluster E until Clusters A and B are complete.
+
+**Risk 4: The D1 / database consideration is a hidden dependency.** The list endpoint (Task 1) will stress KV's query limitations. KV is a key-value store -- it doesn't support filtering, sorting, or range queries natively. The list endpoint implementation will likely require either (a) a secondary index pattern in KV, (b) migration to D1 (edge SQLite), or (c) a creative workaround. This architectural decision should be made upfront, not discovered during implementation.
+
+**Risk 5: No feedback loop with actual users.** The backlog is entirely agent-generated. There's no signal from real users about what they actually need. The sequencing I've recommended is based on first-principles user journey analysis, but it should be validated. Even a handful of real captures by real users with real problems would provide more signal than the current backlog.
+
+### Additional Agents Needed
+
+**None for the roadmap itself**, but I want to flag:
+
+- When Task 1 (list endpoint) reaches implementation, an **api-design-minion** should be involved to ensure the pagination, filtering, and sorting patterns are consistent with the existing API and don't create migration pain when the query backend eventually changes (KV secondary indexes vs. D1).
+- The **security-minion** should review the list endpoint's auth model -- currently all read endpoints are auth-free (capture ID is the secret). A list endpoint changes this fundamentally: if it's authenticated, it's consistent but requires auth for browsing. If it's unauthenticated, anyone can enumerate all captures. This is a significant security design decision, not just an implementation detail.

--- a/docs/history/nefario-reports/2026-03-15-103905-prioritized-product-roadmap/phase3-synthesis-prompt.md
+++ b/docs/history/nefario-reports/2026-03-15-103905-prioritized-product-roadmap/phase3-synthesis-prompt.md
@@ -1,0 +1,64 @@
+MODE: SYNTHESIS
+ADVISORY: true
+
+You are synthesizing specialist planning contributions into a team recommendation. This is an advisory-only orchestration -- no code will be written, no branches created, no PRs opened.
+
+Do NOT produce task prompts, agent assignments, execution order, approval gates, or delegation plan structure. Produce an advisory report with the structure described below.
+
+## Original Task
+Review backlog and produce a prioritized product roadmap for WRL (Web Resource Ledger).
+
+**Outcome**: The existing backlog (`docs/backlog.md`) is transformed into a sequenced product roadmap that defines a meaningful evolution path for WRL. Each roadmap item is scoped and described well enough to become a GitHub issue without further research, so that issue creation is a mechanical follow-up step rather than a planning session.
+
+**Success criteria**:
+- Every backlog item is explicitly addressed (prioritized, deferred, or dropped with rationale)
+- Roadmap items are sequenced with dependency reasoning (what enables what)
+- Each item has a one-line summary, outcome statement, and rough scope — sufficient to seed a GitHub issue title + body
+- The roadmap distinguishes between near-term (next 1-3 phases), mid-term, and longer-horizon work
+- Product coherence: the sequence tells a story of incremental value, not a grab-bag of tasks
+
+## Specialist Contributions
+
+Read the following scratch files for full specialist contributions:
+- /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-oZkd87/prioritized-product-roadmap/phase2-ux-strategy-minion.md
+- /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-oZkd87/prioritized-product-roadmap/phase2-security-minion.md
+- /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-oZkd87/prioritized-product-roadmap/phase2-api-design-minion.md
+- /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-oZkd87/prioritized-product-roadmap/phase2-iac-minion.md
+- /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-oZkd87/prioritized-product-roadmap/phase2-gru.md
+- /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-oZkd87/prioritized-product-roadmap/phase2-product-marketing-minion.md
+- /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-oZkd87/prioritized-product-roadmap/phase2-lucy.md
+
+## Key consensus across specialists:
+- ux-strategy: Three-gap trust model. Five clusters: A=list endpoint, B=key versioning+TSA, C=multi-tenancy, D=reliability, E=platform. Sequence A→B→D-selective, C/E on demand.
+- security: 4 of 8 [must] are hard gates for multi-user. HSTS preload, hashed IP, moderation policy are quick wins. Key versioning before first rotation. Defer TSA/eIDAS.
+- api-design: List endpoint with cursor-based KV pagination, status filter. Rate limit: X-RateLimit-Limit only. CORS for capture POST is highest-impact. Per-tenant keys via 3-phase transparent evolution.
+- iac: KV sufficient for per-tenant auth. D1 only for query filtering. Session pre-warming is only worthwhile scaling item. CD alongside per-tenant auth.
+- gru: RFC 3161 TSA is the one near-term signing investment. MCP triggers should move up to [should]. Browser Rendering limitations real but not blocking. Don't chase forensic fidelity.
+- product-marketing: Five launch moments. Three-act narrative: "Ready for Others" → "Evidence-Grade" → "Infrastructure". Reframe to "web evidence". Minimum second-user package: list, tenant keys, key versioning, abuse policy.
+- lucy: 85% of [consider] items are YAGNI. All [must] should be downgraded (multi-user decision unmade). 17 items exist only because agents raised them. Actionable backlog is ~10 items.
+
+## External Skills Context
+No external skills detected.
+
+## Instructions
+1. Review all specialist contributions (read the full files, not just summaries)
+2. Resolve any conflicts between recommendations
+3. Identify consensus and dissent -- preserve minority positions
+4. Produce an advisory report with:
+   - **Executive Summary**: 1-paragraph synthesis of the team's recommendation
+   - **Team Consensus**: What all specialists agree on
+   - **Dissenting Views**: Where specialists disagreed and how the conflict was resolved
+   - **The Roadmap**: A concrete, sequenced roadmap document that addresses every backlog item. For each roadmap item include:
+     - One-line summary (suitable as a GitHub issue title)
+     - Outcome statement (what changes when this ships)
+     - Rough scope (S/M/L)
+     - Dependencies (what must ship first)
+     - Horizon: near-term (next 1-3 phases), mid-term, or longer-horizon
+   - **Dropped/Parked Items**: Backlog items explicitly not in the roadmap, with rationale
+   - **Risks**: Key risks the roadmap must navigate
+   - **Conflict Resolutions**: How competing positions were resolved
+   - **Next Steps**: What should happen after this advisory
+   - **Conditions to Revisit**: Under what circumstances this roadmap should be reconsidered
+
+5. Also read `docs/backlog.md` to ensure every single item is addressed (prioritized, deferred, or dropped)
+6. Write your complete advisory synthesis to /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-oZkd87/prioritized-product-roadmap/phase3-synthesis.md

--- a/docs/history/nefario-reports/2026-03-15-103905-prioritized-product-roadmap/phase3-synthesis.md
+++ b/docs/history/nefario-reports/2026-03-15-103905-prioritized-product-roadmap/phase3-synthesis.md
@@ -1,0 +1,469 @@
+# Advisory Report
+
+**Question**: What is the right sequenced product roadmap for WRL, transforming the existing backlog into a prioritized evolution path?
+**Confidence**: HIGH
+**Recommendation**: Adopt a three-act roadmap ("Ready for Others" / "Evidence-Grade" / "Infrastructure") with 10 concrete near-term items, 4 mid-term items, and everything else parked. The multi-user decision is the single most important strategic choice -- the roadmap sequences work so it can be made deliberately rather than forced by premature investment.
+
+## Executive Summary
+
+Seven specialists analyzed WRL's 70+ item backlog against the project's engineering philosophy (YAGNI, KISS, Helix Manifesto) and the product's actual state (single operator, no external users, 15 completed build phases). The team reached strong consensus on three points: (1) the backlog has inflated well beyond actionable scope through agent thoroughness, (2) the trust gap (recoverability, verifiability, reliability) is the real problem to solve, not the feature gap, and (3) sequencing should build credibility before expanding capability.
+
+The roadmap below distills the backlog into a sequenced plan of approximately 14 actionable items across three horizons. Every current backlog entry is explicitly addressed -- prioritized, parked, or dropped. Items are scoped tightly enough to become GitHub issues without further research. The overall narrative: make WRL reliable for one user, then trustworthy for evidence, then ready for others -- in that order. The multi-user decision (per-tenant keys, isolation, RBAC) is deliberately staged as a gate: prepare the architecture now, build the implementation only when a second user is real.
+
+## Team Consensus
+
+1. **The list endpoint is the single highest-priority item.** All seven specialists agree. It eliminates the "lost ID = lost capture" problem, which is the most user-hostile aspect of the current design. The README and API response both warn about it -- a sign that it should be fixed, not documented around.
+
+2. **Key versioning must ship before the first key rotation.** Security-minion, gru, ux-strategy-minion, and product-marketing-minion all flag this independently. Rotating the signing key without versioning breaks verification of all prior captures -- a catastrophic failure for an evidence tool.
+
+3. **RFC 3161 timestamps are the one signing upgrade worth near-term investment.** Gru, ux-strategy-minion, and product-marketing-minion agree this transforms WRL from "integrity tool" to "evidence tool." Security-minion agrees on the value but recommends deferring until there is demand for legal defensibility.
+
+4. **~85% of [consider] items are YAGNI.** Lucy's audit found that 23 of 27 [consider] items have no evidence of human need. Many were self-acknowledged as premature by the agents that raised them. The backlog needs aggressive pruning.
+
+5. **Multi-tenancy should wait for a real second user.** Ux-strategy-minion, lucy, and product-marketing-minion all argue against building per-tenant auth before demand exists. Security-minion agrees the items are correctly scoped but their trigger condition is "second user exists," not "now."
+
+6. **HSTS preload, hashed IP logging, and content moderation policy are quick wins.** Security-minion identifies these as high risk-to-effort ratio items. All specialists who touched this area agree.
+
+7. **The "evidence" framing is stronger than "archival."** Product-marketing-minion and ux-strategy-minion both recommend reframing WRL's positioning from web archival (competes with archive.org) to web evidence (competes with manual screenshots and notarization, where WRL wins on every dimension).
+
+8. **KV is sufficient for per-tenant auth; D1 is only needed for query-by-attribute.** Iac-minion and api-design-minion agree: key lookups are hash-based (O(1) in KV), while the list endpoint's filtering needs will eventually drive D1 adoption -- but not yet.
+
+## Dissenting Views
+
+- **RFC 3161 timing**: Ux-strategy-minion places TSA in Phase 3 (after key versioning), arguing it elevates evidence quality and should come soon. Security-minion recommends deferring until "a customer asks for timestamps that hold up in a legal proceeding." Gru says Trial ring, build in H2 2026. Resolution: TSA is placed in mid-term (Act 2), after the trust foundation is solid but before platform expansion. This balances security-minion's pragmatism with ux-strategy's recognition that "evidence" claims require temporal proof. The trigger is not "someone asked" but "key versioning ships," since the signing pipeline will already be in motion.
+
+- **MCP trigger priority**: Gru argues strongly for elevating MCP from [consider] to [should], citing ecosystem maturity (Linux Foundation donation, major vendor adoption, Cloudflare-native support) and market positioning ("the MCP server for web evidence" has zero competitors). Lucy flags it as "interesting to agents, unvalidated by users" and notes it was explicitly listed under "What's Out" in MVP.md. Resolution: MCP moves to mid-to-long-term (Act 3), after the evidence foundation ships. Gru's market analysis is sound -- the opportunity is real and the implementation cost is low (thin adapter over existing API). But product-marketing-minion's sequencing is correct: "strengthening the core before expanding the audience is the safer sequence." MCP should ship after TSA, not before.
+
+- **[must] tier validity**: Lucy argues all five [must] items should be downgraded to [should] or [consider] because they are gated on a multi-user decision that has not been made. Security-minion maintains they are correctly [must] -- "before second user" is the qualifier, and it is accurate. Resolution: The roadmap treats these as "must before multi-user, not must now." They are sequenced in Act 1 but gated on the multi-user decision. The backlog tiers should be updated to reflect this nuance -- the items are important but conditional, not unconditional.
+
+- **Backlog cleanup aggressiveness**: Lucy recommends removing items that contradict explicit kickoff rejections (SSE/WebSocket, webhooks, database) and moving most [consider] items to a parking lot. Product-marketing-minion wants to retain some [consider] items (web UI, scheduled captures) for Act 3 narrative planning. Resolution: Items that were explicitly rejected during kickoff with rationale should be removed from the active backlog. Items that are genuinely speculative but could become relevant under stated conditions stay in a clearly labeled "Parking Lot" section. The backlog should shrink from 70+ items to approximately 15-20 active items.
+
+- **CORS for capture POST**: Api-design-minion elevates this to "should, not consider -- upgrade priority," calling it the highest DX impact for lowest implementation cost. Security-minion warns that CORS on the POST endpoint must not be wildcard and notes it is currently a "don't break it" risk rather than a "fix it now" risk. Resolution: Include CORS as a near-term item in the roadmap. The implementation is small (preflight handler + configurable allowlist), and it unblocks browser-based integrations. Security-minion's constraint (no wildcard, configurable origins) is incorporated as a requirement.
+
+## The Roadmap
+
+### Act 1: "Solid Foundation" (Near-term, next 1-3 phases)
+
+These items make WRL reliable and trustworthy for its current single-operator use case. They close the trust gaps (recoverability, verifiability) and handle quick-win security hardening.
+
+---
+
+#### R1. List captures endpoint (GET /v1/captures)
+
+**Summary**: Add a list/search endpoint so captures are recoverable without memorizing IDs
+
+**Outcome**: Users can browse and recover their captures by date. The "lost ID = lost capture" anti-pattern is eliminated. The README and 202 response warnings about ID loss are removed.
+
+**Scope**: M (medium) -- new endpoint, KV list integration, pagination, auth requirement, OpenAPI spec update, tests
+
+**Dependencies**: None (can start immediately)
+
+**Horizon**: Near-term (Phase 0016)
+
+**Design decisions to make upfront**:
+- Cursor-based pagination using KV's native list cursor (api-design-minion consensus)
+- `{ data, pagination }` envelope pattern established for all future collection endpoints
+- `status` filter included (cheap client-side filter on KV list results); URL filter and sorting deferred (require D1)
+- Requires Bearer auth (the list endpoint cannot use capture-ID-as-secret pattern)
+- Secondary KV index (`tenant:{tenantId}:ts:{ISO8601}:{captureId}`) for time-ordered listing -- a bridge pattern until D1
+
+**Note on storage**: KV `list()` returns keys only; populating responses requires N additional `get()` calls. This is acceptable at current scale (low hundreds of captures). When this becomes a bottleneck, D1 migration is the answer -- but the API contract (cursor + envelope) should not need to change.
+
+---
+
+#### R2. Key versioning and public key archive
+
+**Summary**: Add key ID to signatures and maintain a historical key archive so key rotation does not break verification
+
+**Outcome**: The signing key can be rotated without breaking verification of prior captures. The bold README warning about key rotation is removed.
+
+**Scope**: M -- updated signing flow, keyId field in signedData, new `/.well-known/signing-keys` endpoint, KV storage for historical keys, updated verification logic, tests
+
+**Dependencies**: None (can start immediately; should ship before or alongside R1 to maintain focus)
+
+**Horizon**: Near-term (Phase 0016 or 0017)
+
+**Design decisions to make upfront**:
+- keyId = SHA-256 fingerprint of public key, truncated to 8 hex chars
+- Historical keys stored in KV (`signing-key:{keyId}`) -- key count will be single digits over the service lifetime
+- Verification endpoint reads keyId from WACZ and selects the correct historical public key
+- Key rotation procedure: generate new key, deploy, old key automatically moves to archive
+
+---
+
+#### R3. CORS for capture POST endpoint
+
+**Summary**: Enable browser-based clients to submit captures via proper CORS preflight handling
+
+**Outcome**: Browser extensions and web applications can call the capture API without CORS errors.
+
+**Scope**: S (small) -- OPTIONS preflight handler, configurable origin allowlist (env var), Access-Control-Allow-Headers/Methods, tests
+
+**Dependencies**: None
+
+**Horizon**: Near-term (any phase, can be done alongside R1/R2)
+
+**Constraints**: Origin allowlist must NOT be wildcard (`*`). The POST endpoint requires auth; wildcard CORS exposes the auth flow to any origin. Default to empty (no cross-origin access) with operator-configurable origins.
+
+---
+
+#### R4. HSTS preload submission
+
+**Summary**: Add the `preload` directive to the existing HSTS header and submit to hstspreload.org
+
+**Outcome**: SSL-stripping attacks on first visit are mitigated for all browsers that ship the preload list.
+
+**Scope**: XS -- one header change, one form submission
+
+**Dependencies**: Domain must be finalized (it is: wrl.fyi)
+
+**Horizon**: Near-term (do immediately, no phase needed)
+
+---
+
+#### R5. X-RateLimit-Limit header
+
+**Summary**: Return the static rate limit value in response headers on all rate-limited endpoints
+
+**Outcome**: API clients know their rate limit budget without reading documentation.
+
+**Scope**: XS -- add one header to three handlers, static value from config
+
+**Dependencies**: None
+
+**Horizon**: Near-term (any phase)
+
+**Scope guard**: Do NOT fabricate X-RateLimit-Remaining or X-RateLimit-Reset. The Cloudflare rate limiter binding does not expose remaining tokens. An inaccurate header is worse than no header. Add remaining/reset only when the rate limiter binding supports it or WRL migrates to a custom token-bucket.
+
+---
+
+#### R6. Hashed IP logging
+
+**Summary**: Log HMAC-SHA256 of connecting IP with daily-rotating key for abuse correlation without PII
+
+**Outcome**: Brute-force correlation and abuse detection are possible without storing raw IP addresses (GDPR-compatible).
+
+**Scope**: S -- HMAC function, daily key derivation, integration into existing log entries
+
+**Dependencies**: None
+
+**Horizon**: Near-term (any phase)
+
+---
+
+#### R7. Content moderation policy and Terms of Service
+
+**Summary**: Publish ToS prohibiting illegal use and a content moderation policy with abuse reporting mechanism
+
+**Outcome**: The operator has legal cover for stored content. Required before any public promotion of WRL.
+
+**Scope**: S -- policy documents (not code), abuse contact endpoint or email, static pages or linked from API
+
+**Dependencies**: None (content/legal task, not engineering)
+
+**Horizon**: Near-term (before any external promotion)
+
+---
+
+#### R8. Auth identity enrichment (internal refactor)
+
+**Summary**: Refactor verifyApiKey() to return tenant identity, preparing the codebase for per-tenant keys without changing external behavior
+
+**Outcome**: The auth module returns `{ ok: true, tenantId }` instead of just `{ ok: true }`. The single static key maps to a "default" tenant. All downstream code threads tenantId into logging and KV operations. No external API change.
+
+**Scope**: S -- internal refactor of auth module, updated handler call sites, updated log entries, tests
+
+**Dependencies**: Should happen before or alongside R1 (list endpoint) to ensure KV keys include tenant scope from the start
+
+**Horizon**: Near-term (Phase 0016, prerequisite for R1)
+
+**Rationale**: This is preparation, not premature building. It ensures the list endpoint is tenant-scoped from day one, avoiding a painful KV key migration later. The refactor is invisible to API consumers.
+
+---
+
+#### R9. Staging environment
+
+**Summary**: Add a staging environment to wrangler.toml with isolated KV and R2 bindings, plus automated deploy-to-staging on push to main
+
+**Outcome**: Every push to main is automatically deployed to a staging environment for validation before manual production deploy.
+
+**Scope**: S -- wrangler.toml env section, GitHub Actions workflow, basic smoke test script
+
+**Dependencies**: None
+
+**Horizon**: Near-term (any phase, low risk)
+
+---
+
+#### R10. Backlog cleanup
+
+**Summary**: Restructure docs/backlog.md to remove items that contradict kickoff rejections, park agent-only-provenance items, and align tiers with current project state
+
+**Outcome**: The backlog shrinks from 70+ items to ~15-20 active items. [must] tier reflects conditional triggers ("must before X") rather than unconditional urgency. Removed items are preserved in the evolution log.
+
+**Scope**: S -- documentation task
+
+**Dependencies**: This advisory (human approval of tier changes and removal rationale)
+
+**Horizon**: Near-term (next phase, before roadmap execution begins)
+
+---
+
+### Act 2: "Evidence-Grade" (Mid-term, phases 0019-0022)
+
+These items upgrade WRL's integrity claims from "self-asserted" to "independently verifiable." They make the word "evidence" defensible.
+
+---
+
+#### R11. RFC 3161 timestamp integration
+
+**Summary**: Add independent timestamp authority proof to every capture, transforming evidence from operator-asserted to third-party-verified
+
+**Outcome**: Every WACZ bundle includes an RFC 3161 timestamp response from an independent TSA. Verification confirms both signature integrity AND temporal proof from a third party. WRL can credibly use the word "evidence."
+
+**Scope**: L (large) -- TSA integration module, ASN.1 parsing, updated WACZ bundling, updated verification pipeline, TSA selection (DigiCert or GlobalSign recommended over FreeTSA for reliability), tests
+
+**Dependencies**: R2 (key versioning) should ship first -- the signing pipeline will already be in motion
+
+**Horizon**: Mid-term
+
+**Design note**: The `signatures` array in `datapackage-digest.json` was explicitly designed for this extension. The WACZ format does not need to change -- a new entry of `type: "rfc3161"` is added alongside the existing `type: "self"` entry.
+
+---
+
+#### R12. Per-tenant API keys and tenant isolation
+
+**Summary**: Replace single static API key with per-tenant keys, add tenant tagging to captures, enforce tenant-scoped retrieval
+
+**Outcome**: A second operator can use WRL with their own API key. Captures are isolated by tenant. Key compromise affects only one tenant.
+
+**Scope**: L -- new auth module (KV-based key lookup), tenant tagging in KV records, tenant-scoped list endpoint, read/write key scoping, key provisioning tooling, migration path for existing captures
+
+**Dependencies**: R1 (list endpoint) and R8 (auth identity enrichment) should ship first. This item is also gated on the multi-user decision -- do not build until a second user is real or imminent.
+
+**Horizon**: Mid-term (triggered by demand, not calendar)
+
+**Activation trigger**: A concrete second user wants access. Until then, the architecture is prepared (via R8) but the implementation is not built.
+
+**Implementation note**: Security-minion recommends items 1-3 (per-tenant keys, tenant isolation, key scoping) as a single PR, with audit logging as a follow-on. Api-design-minion confirms the v1 API contract does not break -- the single key becomes the first tenant's key.
+
+---
+
+#### R13. Audit logging for authenticated requests
+
+**Summary**: Log all authenticated API requests with tenant context, not just auth failures
+
+**Outcome**: Full audit trail: who captured what, when, with which key.
+
+**Scope**: S -- structured log entries on every authenticated request, key provisioning/revocation events
+
+**Dependencies**: R12 (per-tenant keys)
+
+**Horizon**: Mid-term (ships with or immediately after R12)
+
+---
+
+#### R14. Production CD pipeline
+
+**Summary**: Automated deployment to production with GitHub environment protection, triggered by tags or manual dispatch
+
+**Outcome**: Deployments are reproducible, gated by approval, and have rollback capability.
+
+**Scope**: M -- GitHub Actions workflow, environment protection rules, post-deploy health check, rollback documentation
+
+**Dependencies**: R9 (staging environment) should exist first for pre-production smoke tests. Becomes operationally important when external users depend on uptime.
+
+**Horizon**: Mid-term (ship before first external user onboarding)
+
+---
+
+### Act 3: "Infrastructure" (Longer-horizon, phases 0023+)
+
+These items make WRL a platform that other tools and agents build on. They expand the addressable audience.
+
+---
+
+#### R15. MCP server for WRL
+
+**Summary**: Build an MCP server exposing capture, retrieval, and verification as tools for AI agents
+
+**Outcome**: Any MCP-compatible AI agent can capture and verify web pages as part of its workflow. WRL becomes "the MCP server for web evidence" -- a niche with zero current occupants.
+
+**Scope**: M -- thin adapter over existing REST API, 3 tools (capture_url, get_capture, verify_capture), Streamable HTTP transport, documentation
+
+**Dependencies**: R1 (list endpoint) -- agents need to retrieve their captures. R11 (TSA) recommended first -- "evidence infrastructure for AI" is a stronger pitch with independent timestamps.
+
+**Horizon**: Longer-term
+
+---
+
+#### R16. Queue migration for capture processing
+
+**Summary**: Replace ctx.waitUntil() with Cloudflare Queue consumer to remove the 30s processing hard limit
+
+**Outcome**: Complex pages that exceed 30s can complete successfully. Capture reliability improves for real-world pages.
+
+**Scope**: M -- Queue binding, producer/consumer split, retry policy, dead-letter handling
+
+**Dependencies**: None architecturally, but this is data-driven, not calendar-driven.
+
+**Horizon**: Longer-term
+
+**Activation trigger**: Coralogix data shows timeout-related capture failures >5% of attempts, OR sustained traffic regularly approaches 200/min. Until then, the 30s budget (25s navigation + 5s headroom) is sufficient.
+
+---
+
+#### R17. Web UI for capture submission
+
+**Summary**: Browser-based interface for submitting and browsing captures without curl
+
+**Outcome**: WRL is demonstrable without a terminal. Evaluators can try it by clicking a link.
+
+**Scope**: M -- vanilla HTML/JS/CSS, no framework (per project philosophy), auth flow for web
+
+**Dependencies**: R1 (list endpoint), R3 (CORS). Should ship after Act 1 is complete -- a web UI on top of sharp edges invites negative first impressions.
+
+**Horizon**: Longer-term
+
+---
+
+#### R18. Batch capture endpoint
+
+**Summary**: Accept multiple URLs in one request for bulk archival workflows
+
+**Outcome**: Legal teams, monitoring services, and CI pipelines can archive multiple pages in one call.
+
+**Scope**: M -- POST /v1/captures/batch, per-URL validation, 207 Multi-Status responses, rate limit interaction design
+
+**Dependencies**: R1 (list endpoint), R5 (rate limit headers). Design should be finalized before implementation.
+
+**Horizon**: Longer-term
+
+---
+
+## Dropped / Parked Items
+
+Every backlog item not in the roadmap above is addressed here. Items are either **PARKED** (preserved in a parking lot section of the backlog, revisited under stated conditions) or **DROPPED** (removed from the backlog, rationale preserved in evolution log).
+
+### PARKED (revisit under stated conditions)
+
+| Item | Condition to Revisit | Current Tier |
+|------|---------------------|--------------|
+| API key rotation without downtime | When per-tenant keys ship (R12). Implementation is straightforward: accept array of valid keys per tenant. | [should] |
+| Per-tenant rate limiting | When per-tenant keys ship (R12). Switch rate limit key from IP to tenantId. | [consider] |
+| Content security scanning (Safe Browsing) | When WRL serves content with text/html content type, or when multi-user opens public submission. Currently artifacts are text/plain with attachment disposition. | [should] |
+| Screenshot timing / wait-for-load | When a user reports incomplete renders. Known gap, no complaints yet. | [should] |
+| Queue-based backpressure (Queues) | When Coralogix shows timeout failures >5% or traffic >200/min sustained. See R16. | [consider] |
+| Session pre-warming via cron | When Coralogix shows cold-start latency is a measurable problem. Low risk, could implement speculatively. | [consider] |
+| D1 (edge SQLite) | When KV list performance becomes a bottleneck for the list endpoint (R1). Signal: list endpoint latency >300ms at observed capture counts. | [consider] |
+| Pagination, filtering, sorting | Partially addressed by R1 (cursor pagination, status filter). URL filter and sorting require D1. Revisit when D1 ships. | [consider] |
+| eIDAS Qualified TSA | When WRL has paying European customers asking for it, OR when 3+ QTSPs offer timestamp services with published pricing and APIs. Not before 2027. | [consider] |
+| WACZ-Auth full spec compliance | When a production toolchain exists that consumes WACZ-Auth signatures for verification. The spec has seen minimal evolution since 2023. | [consider] |
+| Multiple TSAs for redundancy | 6+ months after first TSA integration (R11). Evaluate based on observed TSA reliability. | [consider] |
+| HSM-backed key storage | When a compliance requirement (FIPS 140-2 Level 3) explicitly mandates it, or when WRL handles keys for multiple tenants at scale. Cloudflare has no native HSM integration. | [consider] |
+| Cloudflare Containers | When Browser Rendering session limits are consistently exhausted AND Queues cannot absorb overflow. Monitor for GA announcement. | [consider] |
+| Durable Object session coordinator | When session contention causes >1% capture failures. Current random selection + fallback handles contention fine. | [consider] |
+| Scheduled captures (cron-style) | When a user requests recurring capture capability. Explicitly listed under "What's Out" in MVP.md. | [consider] |
+| Watch lists / bulk monitoring | Requires scheduling (also parked). Two-deep dependency on unvalidated need. | [consider] |
+| Change detection / diffing | Requires multiple captures over time. No evidence of demand. | [consider] |
+| Notifications | When event-driven workflows are needed. Current polling pattern works for capture lifecycle. | [consider] |
+| Billing and quotas | When monetization is actively planned. | [consider] |
+| Webhooks / outbound callbacks | When per-tenant keys exist and async notification demand is demonstrated. | [consider] |
+| Web UI OAuth | When/if web UI (R17) is built and requires user authentication. | [consider] |
+| Capture ID recovery | Solved by R1 (list endpoint). Remove from backlog after R1 ships. | [consider] |
+| Screenshot height cap configurability | When a user reports capped screenshots as a problem. | [consider] |
+| Coralogix alerting rules | When operational load justifies alerting. Useful but premature before traffic exists. | [consider] |
+| Fastly CDN layer | When verification traffic justifies CDN. No traffic data exists. | [consider] |
+| Preview deployments on PRs | When team size > 1. Not useful for single-developer project. | [consider] |
+| R2 artifact streaming | When large WACZ bundles (>10MB) become common. | [consider] |
+
+### DROPPED (removed from active backlog)
+
+| Item | Rationale |
+|------|-----------|
+| SSE / WebSocket | Explicitly rejected during kickoff as "overkill." The polling pattern works for 5-30s capture lifecycle. Should not be in an active backlog. |
+| Database for metadata (generic) | Explicitly rejected during kickoff as "overkill for key-value." D1 is the specific option if query-by-attribute is needed; the generic "database" item is redundant. |
+| Domain-ownership certificate | Architecturally problematic (couples TLS identity to application signing). Evidentiary value is marginal -- WRL's .well-known/signing-key already ties the public key to the domain. |
+| Social signup (GitHub first) | Premature. No identity system, no signup flow, no external users. Self-acknowledged as YAGNI by the agent that raised it. |
+| Network namespace isolation | Defense-in-depth for a browser sandbox already managed by Cloudflare. Over-engineering. |
+| DNS rebinding integration tests | Requires controlled DNS with TTL manipulation. Untestable in current environment. Same-domain DNS rebinding accepted as residual risk in Phase 0014. |
+| Cloud metadata DNS alias tests | Only resolvable inside cloud VPCs. Untestable in Cloudflare Workers. |
+| Additional security event types | Self-acknowledged as "low signal-to-noise for MVP" by the agent that raised them. |
+| Auth reason codes | Refactoring for finer-grained logging with no demonstrated operational need. |
+| R2 write try/catch granularity | Self-acknowledged as "catch-all sufficient for MVP" by the agent that raised it. |
+| 404 rate limiting | Theoretical log volume amplification with no evidence of scanning attacks. |
+| Coralogix Send Key IP allowlisting | Blast radius reduction for a key that has not been leaked. |
+| Nonce-based CSP | "If template ever needs server-side dynamic data" -- it currently does not. |
+| HTML error pages for 404/429/503 | "Acceptable for MVP" per the agent that raised them. Fix opportunistically when touching adjacent code. |
+| S3 Object Lock (WORM-certified) | For "regulated customers" who do not exist and are not targeted. |
+| Full HTTP exchange capture | Forensic-grade capture requiring proxy-based approach. Far beyond current scope. |
+| Sub-resource archiving | Significant complexity escalation for offline replay fidelity. Not core to evidence value prop. |
+| Certificate info capture | Not available via Playwright API. Would require CDP dual-protocol management. Forensic-grade, not needed for web state evidence. |
+| Network timing capture | Same as certificate info -- forensic nicety, not core value. |
+| Resource manifest (CSS/JS/images) | Significant complexity escalation. HTML + screenshot prove content state. |
+
+## Risks
+
+1. **No user feedback loop.** The entire backlog and this roadmap are based on first-principles analysis, not user research. The sequencing is sound in theory but unvalidated by real usage. Mitigation: prioritize getting WRL in front of real users (even informally) after Act 1 ships. A handful of real captures by real users provides more signal than any amount of agent analysis.
+
+2. **"Evidence" framing without TSA is a credibility risk.** If WRL adopts "evidence" language before shipping RFC 3161 timestamps, technically sophisticated users will point out that self-asserted timestamps are not evidence. Mitigation: use "evidence" in aspirational positioning but be explicit about what is independently verifiable today. Do not claim "legal-grade" until TSA ships.
+
+3. **KV list performance ceiling.** The list endpoint (R1) will require 1 + N KV operations per request (1 list + N gets). At hundreds of captures this is fine. At thousands it will hit latency and cost ceilings. Mitigation: design the API contract (cursor + envelope) to be storage-backend-agnostic. D1 is the escape hatch. Monitor list endpoint latency in Coralogix.
+
+4. **Key rotation before key versioning ships.** If the signing key is rotated before R2 ships, every existing WACZ becomes unverifiable through the API. This is a data integrity risk. Mitigation: R2 must ship before any key rotation. Document this as an operational constraint.
+
+5. **Multi-user timing mismatch.** The roadmap prepares for multi-user (R8, architectural readiness) without building it. Risk: a second user appears before R12 is built, and the onboarding is blocked. Mitigation: R8 (auth identity enrichment) reduces the gap. The remaining work (R12) is a focused sprint, not a quarter-long project, because the architecture is prepared.
+
+6. **Backlog re-inflation.** Phase 0015 added 7 new [consider] items in a single phase. Without a gating criterion, agents will continue expanding the backlog. Mitigation: establish a policy -- only add items to the backlog that the human explicitly deferred or that address a demonstrated (not theoretical) need. Agent-originated items go to a "suggestions" section that is reviewed periodically, not to the active backlog.
+
+7. **Despicable-agents showcase vs. product credibility tension.** The "99% vibe coded" badge and process documentation serve the showcase audience. But they could undermine confidence for the adopter audience ("is this a real tool or a demo?"). Mitigation: keep the two narratives in separate channels -- README and product pages lead with the product; blog posts and evolution log lead with the process.
+
+## Conflict Resolutions
+
+1. **TSA timing (security-minion vs. ux-strategy-minion vs. gru)**: Security-minion wanted to defer TSA until customer demand. Ux-strategy-minion wanted it in Phase 3 (soon). Gru said Trial ring, H2 2026. **Resolution**: Mid-term (Act 2), after key versioning ships. This balances pragmatism with the recognition that "evidence" claims require temporal proof. The trigger is architectural readiness (key versioning done), not customer demand, because the positioning upgrade is worth the investment even without explicit asks.
+
+2. **MCP priority (gru vs. lucy)**: Gru argued strongly for elevation to [should] based on ecosystem maturity and market positioning. Lucy flagged it as explicitly "What's Out" in MVP.md with no validated user need. **Resolution**: Act 3 (longer-horizon). The market opportunity is real but the foundation must be solid first. MCP is a thin adapter (~days of work) so the opportunity cost of waiting is low. The benefit of waiting is that WRL will have a list endpoint and TSA by the time agents discover it, making the first impression much stronger.
+
+3. **[must] tier validity (lucy vs. security-minion)**: Lucy argued all [must] items should be downgraded because multi-user is not decided. Security-minion maintained they are correctly [must] before second user. **Resolution**: Reframe as conditional -- "must before multi-user, not must now." The items retain their importance but the urgency is tied to a decision gate, not a calendar date. The backlog should use a notation like `[must:multi-user]` to make the condition explicit.
+
+4. **Backlog cleanup scope (lucy vs. product-marketing-minion)**: Lucy recommended aggressive removal of agent-only-provenance items. Product-marketing-minion wanted to retain some for narrative planning. **Resolution**: Items that contradict explicit kickoff rejections are dropped. Agent-only items with no stated condition go to a "Parking Lot" section. Items with clear activation conditions stay in the backlog with those conditions documented. Nothing is silently deleted -- all removals are documented in the evolution log.
+
+5. **CORS priority (api-design-minion vs. security-minion)**: Api-design-minion called it the highest-impact DX improvement. Security-minion warned about the risk of wildcard CORS. **Resolution**: Include in near-term with security-minion's constraint (configurable allowlist, no wildcard) baked in as a requirement.
+
+## Next Steps
+
+1. **Get human approval of this roadmap.** The tier changes, item drops, and sequencing decisions are prioritization calls that belong to the project owner.
+
+2. **Execute R10 (backlog cleanup) first.** Restructure `docs/backlog.md` to reflect the roadmap. Remove dropped items (with evolution log documentation). Add parking lot section. Update tiers. This creates a clean working document for all subsequent phases.
+
+3. **Create GitHub issues for Act 1 items (R1-R9).** Each roadmap item above has enough detail for an issue title + body. Issues can be created mechanically from this document.
+
+4. **Begin Phase 0016 with R8 (auth identity enrichment) and R1 (list endpoint).** R8 is a prerequisite for R1 and is a small internal refactor. R1 is the highest-value item. These can be a single phase or two sequential phases.
+
+5. **R2 (key versioning) in Phase 0017.** Ship before any key rotation occurs.
+
+6. **R3-R7 (CORS, HSTS, rate limit header, hashed IP, ToS) are independent quick wins.** They can be bundled into any phase or shipped as individual small PRs. HSTS preload (R4) can be done today with no phase needed.
+
+7. **After Act 1 ships, seek user feedback.** Even informal usage by 2-3 real users will validate or redirect the Act 2/3 roadmap. The roadmap is a hypothesis until users touch it.
+
+8. **Write the Phase 0014 technical narrative.** Product-marketing-minion correctly notes this is already shipped, has a strong multi-agent story, and costs nothing to write. It starts building the content library for the despicable-agents showcase.
+
+## Conditions to Revisit
+
+This roadmap should be reconsidered when:
+
+1. **A second user wants access.** This triggers the multi-user decision and potentially accelerates R12 (per-tenant keys) from mid-term to near-term.
+
+2. **Coralogix data shows capture timeout failures >5%.** This triggers R16 (Queue migration) regardless of roadmap position.
+
+3. **KV list endpoint latency exceeds 300ms at observed capture volume.** This triggers D1 evaluation.
+
+4. **A user requests evidence for a legal proceeding.** This may accelerate R11 (TSA) and trigger eIDAS evaluation.
+
+5. **Cloudflare Containers reach GA with stable pricing.** This opens the capture fidelity upgrade path (CDP-based certificate and network capture).
+
+6. **The backlog exceeds 25 active items again.** This triggers another cleanup pass. The backlog should not be allowed to re-inflate past the threshold established by R10.
+
+7. **3 or more QTSPs offer timestamp services with published pricing.** This makes eIDAS evaluation actionable.
+
+8. **Phase count exceeds 25 without Act 1 complete.** This is a signal of scope creep or distraction. Act 1 items should dominate the next 5-8 phases.

--- a/docs/history/nefario-reports/2026-03-15-103905-prioritized-product-roadmap/prompt.md
+++ b/docs/history/nefario-reports/2026-03-15-103905-prioritized-product-roadmap/prompt.md
@@ -1,0 +1,14 @@
+Review backlog and produce a prioritized product roadmap
+
+**Outcome**: The existing backlog (`docs/backlog.md`) is transformed into a sequenced product roadmap that defines a meaningful evolution path for WRL. Each roadmap item is scoped and described well enough to become a GitHub issue without further research, so that issue creation is a mechanical follow-up step rather than a planning session.
+
+**Success criteria**:
+- Every backlog item is explicitly addressed (prioritized, deferred, or dropped with rationale)
+- Roadmap items are sequenced with dependency reasoning (what enables what)
+- Each item has a one-line summary, outcome statement, and rough scope — sufficient to seed a GitHub issue title + body
+- The roadmap distinguishes between near-term (next 1-3 phases), mid-term, and longer-horizon work
+- Product coherence: the sequence tells a story of incremental value, not a grab-bag of tasks
+
+**Scope**:
+- In: Reviewing `docs/backlog.md`, evolution log context, current codebase state; producing a prioritized roadmap document
+- Out: Creating GitHub issues (tracked separately), writing code, changing architecture, modifying existing backlog format


### PR DESCRIPTION
## Summary

- Advisory roadmap produced by 7-specialist nefario orchestration — transforms the 70+ item backlog into a sequenced three-act product roadmap
- Backlog restructured: 18 active items (with GH issues #31-#48), 28 parked with activation triggers, 20 dropped with rationale
- Issues labeled `act-1` (Solid Foundation), `act-2` (Evidence-Grade), `act-3` (Infrastructure)

## What changed

| File | Change |
|------|--------|
| `docs/backlog.md` | Restructured: acts with issue refs, parking lot with triggers, dropped items table, inflation policy |
| `docs/history/nefario-reports/2026-03-15-103905-*` | Advisory report + 21 working files (specialist contributions, prompts, synthesis) |

## Roadmap at a glance

**Act 1** (near-term): R1 list endpoint, R2 key versioning, R3-R7 quick wins, R8 auth enrichment, R9 staging, R10 backlog cleanup
**Act 2** (mid-term): R11 RFC 3161 timestamps, R12 per-tenant keys (demand-gated), R13 audit logging, R14 production CD
**Act 3** (longer-horizon): R15 MCP server, R16 queue migration, R17 web UI, R18 batch capture

## Test plan

- [x] All 18 GitHub issues created with correct labels
- [x] Every original backlog item addressed (prioritized, parked, or dropped)
- [ ] Verify backlog.md renders correctly on GitHub
- [ ] Verify issue cross-references resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)
