### PR TITLE
docs: evidence framing, HAR advisory, backlog governance

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 [![CI](https://github.com/benpeter/web-resource-ledger/actions/workflows/ci.yml/badge.svg)](https://github.com/benpeter/web-resource-ledger/actions/workflows/ci.yml) [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE) [![despicable](https://img.shields.io/badge/%E2%9A%97%EF%B8%8F-despicable-FFC107?style=flat&labelColor=FFF8E1)](https://github.com/benpeter/despicable-agents) [![99% Vibe Coded](https://img.shields.io/badge/99%25-Vibe_Coded-ff69b4?style=flat&logo=claude&logoColor=white)](https://github.com/ai-ecoverse/vibe-coded-badge-action)
 
-Tamper-evident archival of web resources -- captures rendered screenshots, HTML snapshots, HTTP headers, and resource manifests as cryptographically signed, immutable bundles.
+Cryptographic evidence of web content -- capture what a page looked like, when, with proof anyone can verify.
 
-Submit a URL, get back a screenshot, rendered HTML, HTTP headers, and an Ed25519-signed archive that anyone can verify without an account. Deploy it on your own infrastructure; your captures, your keys, your evidence.
+Submit a URL, get back a screenshot, rendered HTML, HTTP headers, and an Ed25519-signed WACZ bundle. The verification URL works for anyone -- no account needed. Deploy on your own infrastructure; your captures, your keys, your evidence.
+
+> **Status:** Early development, single-operator deployment. The API is functional and deployed but pre-1.0. See the [roadmap](#roadmap) for what's coming.
 
 ## What you get
 
@@ -71,14 +73,14 @@ Returns a JSON verification result with three checks: `artifactHashes`, `bundleH
 
 The `verifyUrl` is safe to share publicly. The raw capture ID grants full access to all artifacts -- treat it as a secret.
 
-For error codes and full request/response shapes, see [`openapi.yaml`](openapi.yaml).
+Captures are rate-limited to 10 per minute per IP. Verification is limited to 60 per minute per IP. Error responses use RFC 9457 `application/problem+json` format. For full details, see [`openapi.yaml`](openapi.yaml).
 
 ## Setup
 
 ### Prerequisites
 
 - [Wrangler CLI](https://developers.cloudflare.com/workers/wrangler/) installed and authenticated
-- Node.js 20+
+- Node.js 22+ (see `.nvmrc`)
 - Cloudflare account with R2 and Browser Rendering enabled
 
 ### 1. Install dependencies
@@ -165,9 +167,19 @@ wrangler deploy
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for local dev setup, test conventions, and contribution guidelines.
 
+## Roadmap
+
+WRL follows a three-act development plan:
+
+1. **Solid Foundation** (in progress) -- List endpoint, key versioning, CORS, security hardening. Closes the trust gaps for single-operator use.
+2. **Evidence-Grade** -- RFC 3161 timestamps, per-tenant keys, audit logging. Makes "evidence" independently verifiable.
+3. **Infrastructure** -- MCP server, web UI, batch capture. Expands WRL into a platform other tools build on.
+
+See [`docs/backlog.md`](docs/backlog.md) for the full roadmap and [GitHub issues](https://github.com/benpeter/web-resource-ledger/issues) for detailed tracking.
+
 ## Built with despicable-agents
 
-WRL was built using [despicable-agents](https://github.com/benpeter/despicable-agents), a multi-agent orchestration framework. Every phase of development is documented in [`docs/evolution/`](docs/evolution/) -- 12 phases from initial scaffolding to open-source readiness. The prompts, decisions, and outcomes are all there.
+WRL was built using [despicable-agents](https://github.com/benpeter/despicable-agents), a multi-agent orchestration framework. Every phase of development is documented in [`docs/evolution/`](docs/evolution/) -- the prompts, decisions, and outcomes are all there.
 
 ## Reference
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -12,13 +12,6 @@ for full rationale, conflict resolutions, and specialist contributions.
 - **[should]** -- strong consensus it's needed, no hard commitment yet
 - **[consider]** -- may or may not be needed; parked with activation trigger
 
-## Backlog Inflation Policy
-
-Only add items to the active backlog that the human explicitly deferred or that
-address a demonstrated (not theoretical) need. Agent-originated items go to the
-Parking Lot with a revisit condition. Backlog should not exceed ~25 active items;
-exceeding this triggers a cleanup pass.
-
 ---
 
 ## Act 1: Solid Foundation (near-term, next 1-3 phases)
@@ -35,7 +28,7 @@ security hardening for the current single-operator use case.
 - #36 **R6: Hashed IP logging** [S] -- HMAC-SHA256 abuse correlation without PII
 - #37 **R7: Content moderation policy and ToS** [S] -- required before external promotion
 - #39 **R9: Staging environment** [S] -- automated deploy-to-staging on push to main
-- #40 **R10: Backlog cleanup and restructure** [S] -- this restructure; evolution log entry
+- ~~#40 **R10: Backlog cleanup and restructure** [S]~~ -- DONE: this document
 
 ## Act 2: Evidence-Grade (mid-term)
 
@@ -133,8 +126,7 @@ Deferred items with explicit activation triggers. Revisit when condition is met.
 
 ## Dropped Items
 
-Removed from active backlog. Rationale preserved here and in
-[evolution log](evolution/0016-roadmap-backlog-cleanup/).
+Removed from active backlog. Rationale preserved here.
 
 | Item | Rationale |
 |------|-----------|
@@ -153,11 +145,11 @@ Removed from active backlog. Rationale preserved here and in
 | Nonce-based CSP | Template doesn't use server-side dynamic data in scripts |
 | HTML error pages for 404/429/503 | "Acceptable for MVP"; fix opportunistically |
 | S3 Object Lock (WORM-certified) | For regulated customers who don't exist |
-| Full HTTP exchange capture | Forensic-grade; far beyond current scope |
-| Sub-resource archiving | Significant complexity for offline replay; not core to evidence |
+| Full HTTP exchange capture | Forensic-grade; far beyond current scope. HAR recording evaluated (Phase 0016-advisory) — Playwright `recordHar()` non-functional on Workers (3 independent blockers). Application-level serializer via existing route interceptor is viable future path if demand emerges. |
+| Sub-resource archiving | Significant complexity for offline replay; not core to evidence. Partial coverage possible via application-level HAR serializer (see Full HTTP exchange capture). |
 | Certificate info capture | Not available via Playwright API; forensic nicety |
-| Network timing capture | Not available via Playwright API; forensic nicety |
-| Resource manifest (CSS/JS/images) | Significant complexity; HTML + screenshot prove content state |
+| Network timing capture | Not available via Playwright API; forensic nicety. Partial coverage possible via application-level HAR serializer timing data. |
+| Resource manifest (CSS/JS/images) | Significant complexity; HTML + screenshot prove content state. Partial coverage possible via application-level HAR serializer (see Full HTTP exchange capture). |
 
 ---
 
@@ -172,3 +164,20 @@ Completed items removed from active tracking:
 - ~~Captured HTML XSS prevention~~ -- DONE (retrieval-endpoint)
 - ~~Security event logging~~ -- PARTIAL (mvo-coralogix): auth failures, SSRF blocks, rate limit hits logged
 - ~~HSTS header~~ -- DONE (static-verification-page)
+
+---
+
+## Backlog Governance
+
+**Adding items**: Only items the project owner explicitly deferred or that
+address a user-reported need belong in the active backlog (Acts 1-3).
+Agent-originated suggestions go to the Parking Lot with a concrete revisit
+condition — not to the active backlog.
+
+**Removing items**: Items are dropped when their premise is invalidated,
+their scope is absorbed by another item, or they were added speculatively
+without human validation. Dropped items stay in the Dropped Items table
+with rationale.
+
+**Size cap**: The active backlog (Acts 1-3) should not exceed 25 items.
+Exceeding this threshold triggers a cleanup pass before new items are added.

--- a/docs/history/nefario-reports/2026-03-16-091706-har-vs-wacz-format-evaluation.md
+++ b/docs/history/nefario-reports/2026-03-16-091706-har-vs-wacz-format-evaluation.md
@@ -1,0 +1,87 @@
+---
+task: Evaluate HAR vs WACZ archive format and Playwright HAR recording
+date: 2026-03-16
+slug: har-vs-wacz-format-evaluation
+mode: advisory
+task-count: 0
+gate-count: 0
+compaction-events: 0
+---
+
+## Summary
+
+Two specialists evaluated whether WRL should switch from WACZ to HAR format and whether Playwright's `recordHar()` is usable. Answer: do not switch (WACZ has ISO standardization, institutional adoption, signing — HAR has none), and `recordHar()` is non-functional on Cloudflare Workers (three independent source-code blockers). If richer network metadata is ever needed, the viable path is an application-level serializer built on existing route interceptor events, not Playwright's HAR API.
+
+## Original Prompt
+
+Should we switch the archive format to HAR? Are we already taking advantage of the Playwright capability for that?
+
+## Key Design Decisions
+
+1. **Stay on WACZ/WARC** — ISO 28500, Library of Congress/NARA/Internet Archive adoption, Ed25519 signing, chain-of-custody tooling. HAR has zero legal evidence pedigree (W3C abandoned in 2012). Switching would regress WRL's evidence positioning.
+2. **Do not use Playwright recordHar()** — Three independent blockers in `@cloudflare/playwright@1.1.2`: `fs.writeFileSync()` in HarRecorder, filesystem-dependent Artifact model, null `localUtils` in thin-client connection. Not a platform gap — an architectural incompatibility.
+3. **Future enrichment path identified** — The existing `context.route('**/*')` and `page.on('response')` hooks already observe all sub-resource traffic but discard the metadata. An application-level HAR serializer could capture this data and embed it as a WARC metadata record inside WACZ. M-sized work item, no Playwright HAR APIs needed.
+
+## Phases
+
+### Phase 1: Meta-Plan
+Identified 2 specialists: gru (format comparison, technology landscape), iac-minion (Cloudflare Workers feasibility gate). Lean staffing — focused technical advisory on a format comparison question.
+
+### Phase 2: Specialist Planning
+- **gru**: HAR is not a replacement for WACZ (different purposes: performance analysis vs preservation). HAR data is valuable as a capture mechanism. Hybrid approach (HAR → WARC metadata) is architecturally sound. Recommended spike test.
+- **iac-minion**: Definitive source-code analysis proving `recordHar()` is non-functional on Workers. Three independent blockers. Recommended application-level serializer if HAR data is ever needed.
+
+### Phase 3: Synthesis
+Resolved feasibility conflict in iac-minion's favor — source-code blockers are deterministic, making a spike test redundant. Produced unified recommendation: stay on WACZ, skip spike test, document decision, set revisit trigger.
+
+### Phases 3.5-8
+Skipped (advisory-only orchestration).
+
+## Agent Contributions
+
+| Agent | Phase | Key Contribution |
+|-------|-------|-----------------|
+| gru | planning | Format comparison (ISO 28500 vs abandoned W3C draft), hybrid architecture analysis, data enrichment opportunity identification |
+| iac-minion | planning | Source-code analysis of @cloudflare/playwright proving recordHar() non-functional, memory/timing budget assessment, alternative path recommendation |
+
+## Team Recommendation
+
+### Executive Summary
+
+Do not switch to HAR. Do not attempt Playwright's `recordHar()`. Stay on WACZ/WARC. The format has ISO standardization, institutional adoption, and signing support that HAR lacks entirely. The Playwright HAR API is architecturally incompatible with Cloudflare Workers. If richer network metadata is ever needed, build an application-level serializer from the request/response events already flowing through the existing route interceptor.
+
+### Consensus
+- HAR is not a replacement for WACZ (both agree)
+- WRL is not using and cannot use `recordHar()` (both agree)
+- The data HAR captures is genuinely valuable even if the format is not (both agree)
+- Future enrichment path is application-level, not Playwright API (both agree)
+
+### Dissenting View (resolved)
+gru recommended a spike test for `recordHar()` on Workers `/tmp`. iac-minion's source-code analysis showed three independent blockers at the code level (before filesystem is ever reached). Resolution: spike test unnecessary — the blockers are deterministic.
+
+### Conditions to Revisit
+1. Cloudflare announces native HAR support in `@cloudflare/playwright`
+2. A user or integration partner requests richer network metadata in captures
+3. The application-level serializer path becomes a roadmap item
+
+## Session Resources
+
+<details>
+<summary>Skills Invoked</summary>
+
+- `/nefario` (this orchestration)
+
+</details>
+
+<details>
+<summary>Compaction</summary>
+
+0 compaction events during this session.
+
+</details>
+
+## Working Files
+
+[`docs/history/nefario-reports/2026-03-16-091706-har-vs-wacz-format-evaluation/`](./2026-03-16-091706-har-vs-wacz-format-evaluation/)
+
+Files: prompt.md, phase1-metaplan.md, phase2-gru.md, phase2-iac-minion.md, phase3-synthesis.md (+ corresponding -prompt.md files)

--- a/docs/history/nefario-reports/2026-03-16-091706-har-vs-wacz-format-evaluation/phase1-metaplan-prompt.md
+++ b/docs/history/nefario-reports/2026-03-16-091706-har-vs-wacz-format-evaluation/phase1-metaplan-prompt.md
@@ -1,0 +1,26 @@
+MODE: META-PLAN
+
+You are creating a meta-plan — a plan for who should help plan.
+
+## Task
+Should we switch the archive format to HAR? Are we already taking advantage of the Playwright capability for HAR recording?
+
+Context from codebase review:
+- WRL uses @cloudflare/playwright for browser rendering (src/capture.js)
+- Current capture pipeline: screenshot (PNG) + rendered HTML + HTTP headers (via separate Workers fetch)
+- Artifacts bundled into WACZ format (ZIP containing WARC records + SHA-256 manifest + Ed25519 signature)
+- NO Playwright HAR capabilities are currently used (no recordHar, routeFromHAR)
+- Playwright offers browserContext.recordHar() which captures all network traffic as HAR files
+- The WACZ format was a deliberate MVP decision (see docs/evolution/0001-kickoff/decisions.md)
+
+## Working Directory
+/Users/ben/github/benpeter/web-resource-ledger
+
+## External Skill Discovery
+No project-local skills exist.
+
+## Instructions
+1. Read relevant files to understand the codebase context (especially src/capture.js, src/wacz.js, src/warc.js, docs/MVP.md)
+2. This is a focused technical advisory — identify 2-3 specialists max. Don't over-staff for what is essentially a format comparison question.
+3. For each specialist, write a specific planning question.
+4. Write your complete meta-plan to /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-D6WP0B/har-vs-wacz-format-evaluation/phase1-metaplan.md

--- a/docs/history/nefario-reports/2026-03-16-091706-har-vs-wacz-format-evaluation/phase1-metaplan.md
+++ b/docs/history/nefario-reports/2026-03-16-091706-har-vs-wacz-format-evaluation/phase1-metaplan.md
@@ -1,0 +1,88 @@
+# Meta-Plan: HAR vs WACZ Format Evaluation
+
+## Context
+
+This is a **technical advisory** question, not an implementation task. The user
+wants to know:
+
+1. Whether WRL should switch its archive format from WACZ to HAR
+2. Whether WRL is already leveraging Playwright's HAR recording capabilities
+
+### Current State
+
+- WRL captures: screenshot (PNG) + rendered HTML + HTTP headers (separate Workers fetch)
+- Artifacts bundled into WACZ format (ZIP containing WARC records + SHA-256 manifest + Ed25519 signature)
+- `@cloudflare/playwright` is used for browser rendering but **zero HAR capabilities are used** (no `recordHar`, no `routeFromHAR`)
+- WACZ was a deliberate MVP decision (0001-kickoff/decisions.md) chosen for: legal pedigree (Harvard LIL, Library of Congress, Starling Lab), built-in integrity verification, additive upgrade path
+- The backlog explicitly dropped "Full HTTP exchange capture" and "Sub-resource archiving" as out of scope
+- The capture pipeline already has `context.route('**/*')` intercepting all requests for safety limits (subresource counting, cross-domain blocking) -- this infrastructure could theoretically be extended
+
+### What This Question Really Asks
+
+This is a format comparison with architectural implications. It touches:
+
+1. **Archive format tradeoffs** (WACZ/WARC vs HAR) -- standards, tooling, legal weight, ecosystem
+2. **Playwright capabilities** -- what `recordHar()` actually captures vs what WRL currently collects
+3. **Whether HAR recording could *complement* WACZ** rather than replace it (HAR as a capture mechanism feeding into WARC records)
+
+---
+
+## Planning Consultations
+
+### Consultation 1: Technology Landscape and Format Comparison
+
+- **Agent**: gru
+- **Planning question**: Compare HAR and WACZ/WARC as web archive formats for an evidence-grade capture system. Evaluate: (a) HAR spec maturity and legal standing vs WACZ's legal pedigree, (b) whether HAR is a replacement for or complement to WARC/WACZ, (c) the @cloudflare/playwright `recordHar()` API -- what it captures (full request/response bodies, timing, headers) vs what WRL currently captures, (d) ecosystem tooling for each format, (e) whether a hybrid approach (use Playwright HAR recording to capture richer network data, then embed that data into WARC records within the existing WACZ container) would be architecturally sound. Consider that WRL's "Full HTTP exchange capture" and "Resource manifest" are both in the Dropped Items section of the backlog -- would HAR recording be a lightweight way to get partial credit on those capabilities without the complexity that caused them to be dropped?
+- **Context to provide**: `src/capture.js` (current pipeline, especially `defaultRenderer` and `context.route`), `src/wacz.js` and `src/warc.js` (current bundling), `docs/evolution/0001-kickoff/decisions.md` (WACZ rationale), `docs/backlog.md` (dropped items: "Full HTTP exchange capture", "Sub-resource archiving", "Resource manifest")
+- **Why this agent**: gru evaluates technology landscape, format comparisons, and adopt/hold/wait decisions. This is fundamentally a technology radar question -- should WRL adopt HAR, hold with WACZ, or use HAR as a complementary capture mechanism?
+
+### Consultation 2: Capture Pipeline Architecture
+
+- **Agent**: iac-minion
+- **Planning question**: Evaluate the operational implications of adding Playwright `recordHar()` to WRL's capture pipeline on Cloudflare Workers. Specifically: (a) does `@cloudflare/playwright` support `browserContext.recordHar()` given the `connect()`/`acquire()` session model? (b) HAR files contain full response bodies -- what are the storage and memory implications within the Worker's memory limits and the 30s `ctx.waitUntil` budget? (c) if HAR recording is feasible, where does the HAR file land (local filesystem? in-memory?) and how does that interact with Workers' lack of a real filesystem? (d) would HAR recording conflict with the existing `context.route('**/*')` interception used for safety limits?
+- **Context to provide**: `src/capture.js` (session model, route interception, timeout budgets), `wrangler.toml` (Worker configuration), Cloudflare Browser Rendering documentation constraints
+- **Why this agent**: iac-minion understands Cloudflare Workers runtime constraints, Browser Rendering binding limitations, and can assess whether HAR recording is even technically feasible in this deployment model before we debate format merits.
+
+---
+
+## Cross-Cutting Checklist
+
+- **Testing**: NOT included for planning. This is an advisory -- no code will be produced.
+- **Security**: NOT included for planning. If the advisory recommends adoption, security review would be part of the implementation plan. For the advisory itself, gru covers format-level security properties (integrity, legal weight).
+- **Usability -- Strategy**: NOT included for planning. This is an internal format/architecture question with no user-facing UX impact. The verification page and API contract are unaffected by the internal archive format.
+- **Usability -- Design**: NOT included. No UI involved.
+- **Documentation**: NOT included for planning. Advisory output is self-documenting. If adoption proceeds, documentation would be part of implementation.
+- **Observability**: NOT included. No runtime changes in scope.
+
+**Rationale for lean staffing**: This is a focused technical advisory on a format comparison question. Two specialists cover the necessary ground: gru for the technology/format evaluation (the core question), iac-minion for the Cloudflare-specific feasibility constraints (the "can we even do this" gate). Adding more specialists would over-staff a question that has a clear answer structure.
+
+---
+
+## Anticipated Approval Gates
+
+None. This is an advisory -- no code changes, no irreversible decisions. The advisory itself will present recommendations that the user can choose to act on.
+
+---
+
+## Rationale
+
+The question has two layers:
+
+1. **Should we switch formats?** -- This is gru's domain. WACZ was a deliberate, well-reasoned choice. The question is whether HAR offers something WACZ doesn't, or whether HAR recording is a complementary capture technique rather than a format replacement.
+
+2. **Can we even use Playwright's HAR features?** -- This is iac-minion's domain. `@cloudflare/playwright` is a constrained subset of Playwright running on Workers. `recordHar()` writes to a filesystem path, and Workers don't have a traditional filesystem. This may be a hard blocker that makes the format question moot.
+
+The likely outcome is that HAR and WACZ serve different purposes: HAR is a capture/debug format (network traffic log), while WACZ is an archival/evidentiary format (integrity-verified bundle). The advisory should clarify this distinction and recommend whether Playwright HAR recording could enrich the data flowing into the existing WACZ pipeline.
+
+---
+
+## Scope
+
+- **In scope**: Format comparison (HAR vs WACZ), Playwright HAR recording capabilities, feasibility on Cloudflare Workers, recommendation (adopt/hold/complement)
+- **Out of scope**: Implementation plan, code changes, sub-resource archiving strategy, full HTTP exchange capture design
+
+---
+
+## External Skill Integration
+
+No external skills detected in project.

--- a/docs/history/nefario-reports/2026-03-16-091706-har-vs-wacz-format-evaluation/phase2-gru-prompt.md
+++ b/docs/history/nefario-reports/2026-03-16-091706-har-vs-wacz-format-evaluation/phase2-gru-prompt.md
@@ -1,0 +1,31 @@
+You are contributing to the PLANNING phase of a multi-agent project.
+You are NOT executing yet — you are providing your domain expertise to help build a comprehensive plan.
+
+## Advisory Context
+This is an advisory-only orchestration. Your contribution will feed into a team recommendation, not an execution plan. Focus on analysis, trade-offs, and recommendations rather than implementation tasks.
+
+## Project Task
+Should WRL switch its archive format from WACZ to HAR? Is it already taking advantage of Playwright's HAR recording capabilities?
+
+## Your Planning Question
+Compare HAR and WACZ/WARC as web archive formats for an evidence-grade capture system. Evaluate:
+
+(a) HAR spec maturity and legal standing vs WACZ's legal pedigree (Harvard LIL, Library of Congress, Starling Lab)
+(b) Whether HAR is a replacement for or complement to WARC/WACZ
+(c) The @cloudflare/playwright `recordHar()` API — what it captures (full request/response bodies, timing, headers) vs what WRL currently captures (screenshot, rendered HTML, separate fetch headers)
+(d) Ecosystem tooling for each format
+(e) Whether a hybrid approach (use Playwright HAR recording to capture richer network data, then embed that data into WARC records within the existing WACZ container) would be architecturally sound
+
+Consider that WRL's "Full HTTP exchange capture" and "Resource manifest" are both in the Dropped Items section of the backlog — would HAR recording be a lightweight way to get partial credit on those capabilities without the complexity that caused them to be dropped?
+
+## Context
+Read these files:
+- `src/capture.js` -- current pipeline (especially defaultRenderer and context.route)
+- `src/wacz.js` and `src/warc.js` -- current bundling
+- `docs/backlog.md` -- dropped items section (Full HTTP exchange capture, Sub-resource archiving, Resource manifest)
+
+## Instructions
+1. Read relevant files to understand the current state
+2. Apply your domain expertise to the planning question
+3. Return your contribution with Recommendations, Proposed Tasks, Risks and Concerns, Additional Agents Needed
+4. Write your complete contribution to `/var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-D6WP0B/har-vs-wacz-format-evaluation/phase2-gru.md`

--- a/docs/history/nefario-reports/2026-03-16-091706-har-vs-wacz-format-evaluation/phase2-gru.md
+++ b/docs/history/nefario-reports/2026-03-16-091706-har-vs-wacz-format-evaluation/phase2-gru.md
@@ -1,0 +1,393 @@
+# Gru: HAR vs WACZ Format Evaluation for WRL
+
+## TL;DR
+
+HAR is **not a replacement** for WACZ/WARC -- it is a different tool for a
+different job. WARC has ISO 28500 standardization and institutional adoption
+across preservation organizations; HAR was abandoned by W3C and has zero legal
+evidence pedigree. However, Playwright's `recordHar()` API is a low-cost way
+to capture rich network data (full request/response bodies, timing, cookies,
+headers for every sub-resource) that WRL currently lacks. The architecturally
+sound move is a **hybrid approach**: use `recordHar()` to capture network data,
+then embed the HAR JSON as an additional WARC metadata record inside the
+existing WACZ container. This gets partial credit on three dropped backlog items
+with minimal complexity. But there is a **blocking platform question**: whether
+`recordHar()` works on Cloudflare Workers' `/tmp` filesystem needs a spike test
+before any planning proceeds.
+
+---
+
+## (a) Spec Maturity and Legal Standing
+
+### WARC/WACZ: Strong Legal Pedigree
+
+| Attribute | Status |
+|-----------|--------|
+| Standard | WARC: ISO 28500:2009, revised 2017 |
+| Maintainers | IIPC (International Internet Preservation Consortium), IETF |
+| Institutional adoption | Library of Congress, British Library, BnF, National Library of Australia, Internet Archive |
+| NARA mandate | WARC is the *only* acceptable format for long-term preservation of website records (Bulletin 2014-04) |
+| WACZ signing | Harvard Library Innovation Lab (Scoop capture engine), Starling Lab (authenticated archives) |
+| Legal use | Perma.cc (used by courts and law reviews for link rot prevention), Starling Lab evidence submissions |
+
+**Ring: Adopt.** WARC is the ISO standard for web archiving. WACZ adds the
+packaging, indexing, and signing layer that makes WARC bundles portable and
+verifiable. WRL is already using both correctly.
+
+### HAR: Industry Convention, Not a Standard
+
+| Attribute | Status |
+|-----------|--------|
+| Standard | HAR 1.2 spec published 2011 as a "frozen" community spec |
+| W3C status | **Abandoned.** Draft submitted to W3C Web Performance WG in 2012; never published as a Recommendation |
+| Maintainers | No active standards body. Community-maintained spec at softwareishard.com |
+| Institutional adoption | Zero preservation institutions. Used by browser DevTools, performance tools, HTTP Archive project |
+| Legal standing | **None.** No court has recognized HAR as an evidence format. No chain-of-custody tooling exists |
+| Evidence use | Not designed for evidence; designed for performance analysis and debugging |
+
+**Ring: Hold (as an archive format).** HAR has no path to becoming an evidence
+standard. It was designed for a fundamentally different purpose (performance
+measurement, not preservation). Using HAR *as the archive format* would
+undermine WRL's "evidence-grade" positioning.
+
+**Ring: Adopt (as a data capture mechanism).** Every major browser and Playwright
+support HAR recording natively. The *data* it captures is valuable even if the
+*format* is not suitable as a primary archive container.
+
+### Key Distinction
+
+Legal admissibility of digital evidence depends on chain of custody, integrity
+verification, and established forensic standards -- not the file format per se.
+But format recognition matters for institutional acceptance. WARC/WACZ has this;
+HAR does not. The question is not "which format?" but "can we capture HAR's
+richer data and preserve it within WARC's established container?"
+
+---
+
+## (b) HAR as Replacement vs Complement
+
+**Verdict: Complement, never replacement.**
+
+| Dimension | HAR | WARC/WACZ |
+|-----------|-----|-----------|
+| Primary purpose | Performance analysis, debugging | Long-term preservation |
+| Data model | HTTP transactions (request + response + timing) | Arbitrary web resources + metadata |
+| Content scope | Network-level: every HTTP exchange the browser makes | Archive-level: resources + rendering output |
+| Signing | None | Ed25519 / X.509 via WACZ-Auth |
+| Integrity | None (plain JSON, trivially editable) | SHA-256 per record, signed bundle hash |
+| ISO standard | No | Yes (ISO 28500) |
+| Replay | Via browser DevTools or mock server | Via ReplayWeb.page, Wayback Machine, pywb |
+| Compression | Not specified | WARC supports gzip per-record |
+| Extensibility | `_custom` fields (convention only) | WARC record types (standardized extension) |
+
+HAR captures *different data* than WARC, not *better data*. WARC can contain
+everything HAR contains (as metadata records), but HAR cannot contain what WARC
+provides (integrity, signing, institutional compatibility).
+
+---
+
+## (c) Playwright `recordHar()` vs Current WRL Capture
+
+### What WRL Currently Captures
+
+From `src/capture.js` (defaultRenderer + captureHeaders):
+
+| Artifact | Source | What it contains |
+|----------|--------|------------------|
+| `screenshot.png` | `page.screenshot()` | Full-page visual capture |
+| `rendered.html` | `page.content()` | DOM after JS execution |
+| `headers.json` | Separate `fetch()` call | Status, statusText, response headers for main URL only |
+
+**Critical gaps in current approach:**
+1. `captureHeaders()` makes a *separate* HTTP request (not the browser's
+   actual request) -- it may see different headers due to different UA,
+   cookies, TLS negotiation, CDN routing, etc.
+2. Only captures headers for the *main document* -- no sub-resource headers
+3. No request headers captured (only response)
+4. No timing data
+5. No response bodies for sub-resources
+6. No cookie exchange data
+7. No redirect chain data (uses `redirect:'manual'`)
+
+### What `recordHar()` Would Capture
+
+Playwright's `recordHar()` records the *actual browser network traffic*:
+
+| Data | Available | Notes |
+|------|-----------|-------|
+| Full request headers (per resource) | Yes | Including cookies, UA, referrer |
+| Full response headers (per resource) | Yes | The actual headers the browser received |
+| Response bodies | Yes (configurable) | `content: 'embed'` or `content: 'attach'` |
+| Request bodies (POST data) | Yes | Form data, JSON payloads |
+| HTTP timing (DNS, connect, TLS, wait, receive) | Yes | Per-resource breakdown |
+| Redirect chains | Yes | Each hop is a separate entry |
+| Cookie details | Yes | Domain, path, expiry, httpOnly, secure flags |
+| Cache state | Yes | Before/after cache info per resource |
+| Content MIME types and sizes | Yes | Actual vs. transferred size |
+
+### Configuration Options in @cloudflare/playwright
+
+```javascript
+const context = await browser.newContext({
+  recordHar: {
+    path: '/tmp/capture.har',  // Must be /tmp on Workers
+    mode: 'full',              // 'full' or 'minimal'
+    content: 'embed',          // 'embed', 'attach', or 'omit'
+    urlFilter: undefined,      // Optional: filter by URL pattern
+  },
+});
+```
+
+Key options:
+- `mode: 'full'` -- captures everything (timing, cookies, security, etc.)
+- `content: 'embed'` -- embeds response bodies inline as base64 in the HAR JSON
+- `content: 'omit'` -- captures metadata without bodies (much smaller output)
+- `content: 'attach'` -- stores bodies as separate files in a ZIP (requires `.zip` path extension)
+
+### Platform Constraint: Cloudflare Workers Filesystem
+
+**This is the blocking unknown.** Playwright's `recordHar()` writes to the
+filesystem. On Cloudflare Workers, `fs` only supports writing into `/tmp`.
+The documentation confirms `/tmp` works for tracing (`/tmp/trace.zip`), which
+is architecturally similar to HAR recording. However:
+
+1. `/tmp` size limits are undocumented for Browser Rendering
+2. HAR files with embedded content can be large (all sub-resource bodies)
+3. No confirmed production usage of `recordHar()` on @cloudflare/playwright
+4. The "not yet fully supported" features list does not mention HAR (neither
+   as supported nor unsupported), and Cloudflare notes the list is "not exhaustive"
+
+**This needs a spike test before any architectural commitment.**
+
+---
+
+## (d) Ecosystem Tooling
+
+### WARC/WACZ Ecosystem
+
+| Tool | Purpose | Maturity |
+|------|---------|----------|
+| ReplayWeb.page | Client-side WACZ replay | Production (Webrecorder) |
+| pywb | Server-side WARC replay | Production (Internet Archive) |
+| Heritrix / Browsertrix | WARC crawlers | Production |
+| wacz-auth | Signing and verification | Emerging (Harvard LIL) |
+| py-wacz | WACZ creation/validation in Python | Production |
+| cdxj-indexer | CDXJ index generation | Production |
+| Wayback Machine | WARC replay at scale | Production (billions of records) |
+
+### HAR Ecosystem
+
+| Tool | Purpose | Maturity |
+|------|---------|----------|
+| Chrome DevTools | HAR recording/viewing | Production |
+| Firefox DevTools | HAR recording/viewing | Production |
+| Playwright | HAR recording/replay | Production |
+| Charles Proxy | HAR export | Production |
+| har-validator | HAR schema validation | npm package, maintained |
+| har-to-warc | HAR to WARC conversion | Available but niche |
+| Google HAR Analyzer | Performance analysis from HAR | Production |
+
+### Key Observation
+
+HAR tooling is *developer-oriented* (debugging, testing, performance). WARC
+tooling is *preservation-oriented* (archiving, replay, legal). There is
+essentially no overlap. This reinforces the "complement, not replacement"
+conclusion.
+
+---
+
+## (e) Hybrid Approach Assessment
+
+### Proposed Architecture
+
+```
+  Playwright BrowserContext
+  +------------------------------------------+
+  |  recordHar: { path: '/tmp/capture.har',  |
+  |               mode: 'full',              |
+  |               content: 'omit' }          |
+  |                                          |
+  |  page.goto(url)                          |
+  |  page.screenshot()                       |
+  |  page.content()                          |
+  +------------------------------------------+
+            |
+            v
+  Read /tmp/capture.har (JSON)
+            |
+            v
+  Strip sensitive data (Set-Cookie values, etc.)
+            |
+            v
+  Pass to buildWarc() as additional artifact:
+    artifacts.har = harJsonString
+            |
+            v
+  warc.js: new WARC metadata record
+    WARC-Type: metadata
+    Content-Type: application/json
+    WARC-Target-URI: <url>
+    (body: sanitized HAR JSON)
+            |
+            v
+  Existing WACZ pipeline unchanged
+  (datapackage.json gets one more resource entry)
+```
+
+### Why `content: 'omit'`
+
+Embedding all sub-resource response bodies would massively inflate the WACZ
+bundle. For evidence purposes, what matters is:
+- Which resources were loaded (URLs, MIME types, sizes)
+- What headers were exchanged (request AND response)
+- Timing data (proves contemporaneous capture)
+- Redirect chains (proves what the browser actually followed)
+- Cookie exchanges (proves session state)
+
+The rendered HTML + screenshot already capture the *content outcome*. The HAR
+without bodies captures the *network provenance* -- what the browser talked to
+and how. This is the data the dropped backlog items were asking for.
+
+### What This Addresses from Dropped Items
+
+| Dropped Item | Coverage via HAR | Notes |
+|--------------|-----------------|-------|
+| Full HTTP exchange capture | ~80% | Full request+response headers for every resource. Missing: raw TCP/TLS data |
+| Resource manifest (CSS/JS/images) | ~90% | HAR entries list every loaded resource with URL, MIME type, size, timing |
+| Network timing capture | 100% | HAR timing object has DNS/connect/TLS/wait/receive per resource |
+| Certificate info capture | 0% | HAR does not capture TLS certificate details |
+| Sub-resource archiving | 0-100% | `content: 'omit'` = 0%; `content: 'embed'` = 100% but at significant size cost |
+
+### Architectural Risks
+
+1. **Platform risk (HIGH)**: `recordHar()` may not work on Cloudflare Workers.
+   If `/tmp` write fails or if HAR recording is in the "not yet supported"
+   category, the entire approach is blocked. Spike test required.
+
+2. **Size risk (MEDIUM)**: Even with `content: 'omit'`, a HAR file for a
+   complex page with 200 sub-resources could be 200-500KB of JSON. With
+   `content: 'embed'`, it could be multiple MB. This affects the 30-second
+   `ctx.waitUntil` budget (ZIP assembly, SHA-256 hashing, R2 upload).
+
+3. **Privacy risk (LOW-MEDIUM)**: HAR captures cookies, auth headers, and
+   potentially sensitive request data. The existing `captureHeaders()` already
+   redacts Set-Cookie. HAR sanitization would need to be equally thorough --
+   and applied across potentially hundreds of entries, not just one.
+
+4. **Timing budget risk (MEDIUM)**: Reading back the HAR file from `/tmp`,
+   parsing it, sanitizing it, and encoding it into a WARC record all add
+   time to the capture pipeline. Current pipeline already operates within
+   tight margins (25s navigation timeout in a 30s budget).
+
+5. **Complexity risk (LOW)**: The change is well-contained -- add `recordHar`
+   to `newContext()`, read the file back, pass as artifact to `buildWarc()`,
+   add one WARC record. No new dependencies. No architectural changes to the
+   WACZ pipeline.
+
+### What This Does NOT Replace
+
+The separate `captureHeaders()` fetch should be kept even if HAR recording is
+added. Reasons:
+- It captures the server's response to a *non-browser* client (different
+  perspective, complementary evidence)
+- It works independently of `recordHar()` (graceful degradation)
+- Removing it is a breaking change to the WACZ structure
+
+---
+
+## Recommendations
+
+### 1. Do NOT switch from WACZ to HAR
+
+**Ring: Hold** for HAR as a primary archive format.
+
+HAR lacks standardization, integrity mechanisms, signing support, and
+institutional recognition. Switching would be a significant regression in
+WRL's evidence-grade positioning. The WACZ investment is sound and should be
+maintained.
+
+### 2. DO investigate Playwright HAR recording as a data enrichment
+
+**Ring: Assess** (pending spike test; upgrade to Trial if spike succeeds).
+
+The `recordHar()` API is a near-zero-cost way to capture network-level data
+that WRL currently lacks. The data maps directly to three dropped backlog items.
+The hybrid approach (HAR data embedded as WARC metadata) is architecturally
+clean.
+
+### 3. Spike test first, plan second
+
+**Proposed spike scope:**
+- Add `recordHar: { path: '/tmp/capture.har', mode: 'full', content: 'omit' }`
+  to the `newContext()` call in `defaultRenderer()`
+- After `context.close()`, attempt to read `/tmp/capture.har` via `node:fs`
+- Deploy to Cloudflare Workers and test against 3-5 real URLs
+- Measure: Does it work? What is the file size? What is the timing impact?
+- This spike should take < 1 day
+
+**If spike succeeds:**
+- Upgrade to Trial ring
+- Plan the WARC metadata record integration (estimated: S-M sized work item)
+- Add HAR sanitization (redact Set-Cookie values, Authorization headers,
+  sensitive query parameters)
+- Re-evaluate the three dropped backlog items with "partially addressed via
+  HAR recording" annotation
+
+**If spike fails:**
+- Stay on current architecture
+- The dropped items remain dropped for the right reasons (complexity)
+- Revisit when Cloudflare expands Browser Rendering filesystem capabilities
+
+### 4. Re-evaluation timeline
+
+- Spike: immediate (can be done in next development cycle)
+- If spike succeeds: Trial for 2-3 phases, then decide on Adopt
+- Re-evaluate HAR spec status: 12 months (no movement expected)
+- Re-evaluate WACZ: no action needed (stable, well-invested)
+
+---
+
+## Proposed Tasks
+
+1. **Spike: Playwright `recordHar()` on Cloudflare Workers** -- S-sized.
+   Test whether `recordHar()` writes to `/tmp` and can be read back in the
+   Workers runtime. Measure file sizes and timing impact. This gates all
+   subsequent work.
+
+2. **If spike passes: HAR sanitization module** -- S-sized. Strip
+   Set-Cookie values, Authorization headers, and configurable sensitive
+   fields from HAR JSON before embedding in WARC.
+
+3. **If spike passes: WARC metadata record for HAR data** -- S-sized. Add
+   a new WARC metadata record type to `warc.js` that embeds the sanitized
+   HAR JSON. Update `wacz.js` resource manifest accordingly.
+
+4. **Backlog annotation** -- XS-sized. Update `docs/backlog.md` dropped
+   items with notes on partial coverage via HAR recording (if spike passes).
+
+---
+
+## Risks and Concerns
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| `recordHar()` does not work on Cloudflare Workers `/tmp` | HIGH | Spike test before any commitment. If it fails, the entire HAR approach is blocked with no wasted investment. |
+| HAR file size exceeds `/tmp` capacity on complex pages | MEDIUM | Use `content: 'omit'` (no response bodies). Enforce MAX_SUBRESOURCES limit (already in place at 200). Measure in spike. |
+| HAR sanitization misses sensitive data | MEDIUM | Define explicit allowlist of headers to preserve (not blocklist). Security-minion review of sanitization logic. |
+| Timing budget exceeded (30s ctx.waitUntil) | MEDIUM | Measure in spike. HAR reading/parsing adds ~10-50ms for typical files. If tight, make HAR recording optional/degradable like current WACZ bundling. |
+| HAR format changes break parsing | LOW | HAR 1.2 has been frozen since 2011. Playwright's output is stable. No format evolution expected. |
+
+---
+
+## Additional Agents Needed
+
+- **edge-minion**: To execute the spike test on Cloudflare Workers and measure
+  `/tmp` filesystem behavior, HAR file sizes, and timing impact within the
+  Browser Rendering runtime.
+- **security-minion**: To review HAR sanitization requirements -- HAR captures
+  significantly more sensitive data (cookies, auth headers, POST bodies) than
+  the current `captureHeaders()` flow. Need a threat model for what to strip
+  vs. preserve.
+- **margo (code review)**: To review the WARC metadata record integration for
+  spec compliance -- ensure the new record type and CDXJ index entries conform
+  to WARC/1.1 and WACZ 1.1.1.

--- a/docs/history/nefario-reports/2026-03-16-091706-har-vs-wacz-format-evaluation/phase2-iac-minion-prompt.md
+++ b/docs/history/nefario-reports/2026-03-16-091706-har-vs-wacz-format-evaluation/phase2-iac-minion-prompt.md
@@ -1,0 +1,28 @@
+You are contributing to the PLANNING phase of a multi-agent project.
+You are NOT executing yet — you are providing your domain expertise to help build a comprehensive plan.
+
+## Advisory Context
+This is an advisory-only orchestration. Your contribution will feed into a team recommendation, not an execution plan. Focus on analysis, trade-offs, and recommendations rather than implementation tasks.
+
+## Project Task
+Should WRL switch its archive format from WACZ to HAR? Is it already taking advantage of Playwright's HAR recording capabilities?
+
+## Your Planning Question
+Evaluate the operational implications of adding Playwright `recordHar()` to WRL's capture pipeline on Cloudflare Workers. Specifically:
+
+(a) Does `@cloudflare/playwright` support `browserContext.recordHar()` given the `connect()`/`acquire()` session model? The standard Playwright API requires a filesystem path for HAR output — how does this work on Workers?
+(b) HAR files contain full response bodies — what are the storage and memory implications within the Worker's memory limits and the 30s `ctx.waitUntil` budget?
+(c) If HAR recording is feasible, where does the HAR file land (local filesystem? in-memory?) and how does that interact with Workers' lack of a real filesystem?
+(d) Would HAR recording conflict with the existing `context.route('**/*')` interception used for safety limits (subresource counting, cross-domain blocking)?
+
+## Context
+Read these files:
+- `src/capture.js` -- session model (getOrCreateSession, connect/acquire), route interception, timeout budgets
+- `wrangler.toml` -- Worker configuration
+- Check if @cloudflare/playwright docs or source hints exist in node_modules
+
+## Instructions
+1. Read relevant files to understand the current state
+2. Apply your domain expertise to the planning question
+3. Return your contribution with Recommendations, Proposed Tasks, Risks and Concerns, Additional Agents Needed
+4. Write your complete contribution to `/var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-D6WP0B/har-vs-wacz-format-evaluation/phase2-iac-minion.md`

--- a/docs/history/nefario-reports/2026-03-16-091706-har-vs-wacz-format-evaluation/phase2-iac-minion.md
+++ b/docs/history/nefario-reports/2026-03-16-091706-har-vs-wacz-format-evaluation/phase2-iac-minion.md
@@ -1,0 +1,123 @@
+# IAC Minion -- HAR Recording Feasibility on Cloudflare Workers
+
+## Summary
+
+Playwright's `recordHar()` is architecturally incompatible with `@cloudflare/playwright` on Cloudflare Workers. The HAR recording pipeline depends on `node:fs` filesystem writes at multiple critical points, and the Workers runtime does not provide a real filesystem. Even if the recording could be made to work, the resulting HAR files (with embedded response bodies) would likely exceed the Worker's memory limits for non-trivial pages. WRL is not currently using Playwright's HAR recording -- it builds its own WARC records from captured artifacts.
+
+---
+
+## Detailed Analysis
+
+### (a) Does `@cloudflare/playwright` support `browserContext.recordHar()`?
+
+**No, not in any usable way.** The analysis of the `@cloudflare/playwright@1.1.2` source code reveals three blocking incompatibilities:
+
+1. **`HarRecorder` requires a real filesystem.** The server-side `HarRecorder` (in `lib/playwright-core/src/server/har/harRecorder.js`) constructs an `Artifact` whose `localPath` is computed as `path.join(context._browser.options.artifactsDir, ...)`. When flushing, it calls `fs.writeFileSync()` (for zip mode) or `fs.promises.writeFile()` (for uncompressed mode) to write the HAR data to disk. Workers do not have a writable filesystem -- `node:fs` operations are shimmed through `unenv` and will fail at write time.
+
+2. **`harExport()` returns an `Artifact` that references a file path.** The client-side export flow (`browserContext.js` lines 415-428) calls `this._channel.harExport()`, gets back an `Artifact`, then calls `artifact.saveAs(path)`. The `saveAs` implementation on the server side (`artifact.js` line 58) uses `saveCallback(this._localPath)` which copies from one filesystem location to another. On the client side, the remote path uses `fs.createWriteStream()`. Both paths require filesystem access.
+
+3. **Uncompressed HAR explicitly blocked for thin clients.** The client-side code at line 423 throws: `"Uncompressed har is not supported in thin clients"`. The `@cloudflare/playwright` connection model is in-process (not technically a "thin client"), but the underlying Playwright code treats connections without `localUtils` as thin. The `createInProcessPlaywright()` call in `lib/index.js` passes no `localUtils` argument to the `Connection` constructor, meaning `this._connection.localUtils()` returns `undefined/null`, which blocks the uncompressed HAR codepath.
+
+4. **`routeFromHAR()` is also blocked.** Both `BrowserContext` and `Page` throw `"Route from har is not supported in thin clients"` when `localUtils` is absent.
+
+**Bottom line:** Even though `@cloudflare/playwright` includes all the Playwright HAR code in its bundle, the code paths are inoperable on Workers. The `recordHar` option on `browser.newContext({ recordHar: { path: '...' } })` would attempt filesystem operations that will crash.
+
+### (b) Storage and memory implications of HAR files
+
+Even if the filesystem issue were solved (e.g., by streaming to an in-memory buffer), HAR files with full response bodies are significantly larger than WRL's current artifact set:
+
+- **HAR captures all subresource bodies.** A HAR file in `"full"` mode embeds every HTTP response body (images, scripts, stylesheets, fonts) as base64-encoded strings. For a typical web page that loads 50-100 subresources, this easily reaches 5-30 MB of base64 content.
+- **Base64 encoding inflates by ~33%.** A page with 10 MB of binary assets would produce ~13 MB of HAR JSON just for the bodies.
+- **Worker memory limit is 128 MB.** The current capture pipeline already holds: a full-page PNG screenshot (can be several MB), the rendered HTML (typically <1 MB), HTTP headers (negligible), and the WACZ assembly buffers. Adding a full HAR file risks memory pressure, especially for media-heavy pages.
+- **WRL already limits pages to 50 MB total and 200 subresources.** These limits help, but a page at those limits would produce a HAR file in the 30-60 MB range (with base64 inflation), which is a significant fraction of the 128 MB Worker memory budget.
+- **The 30s `ctx.waitUntil` budget.** HAR recording adds serialization overhead at context close time. The `HarRecorder.flush()` method must finalize all entries, serialize to JSON, and optionally zip. For large HAR files, this serialization time is non-trivial and eats into the already-tight 5s headroom between the 25s NAV_TIMEOUT and the 30s `ctx.waitUntil` deadline.
+
+### (c) Where does the HAR file land?
+
+In standard Playwright: the HAR file lands on the local filesystem, at the path specified in `recordHar.path`.
+
+In `@cloudflare/playwright` on Workers:
+
+- **There is no real filesystem.** The `node:fs` module is polyfilled via `unenv` (part of `@cloudflare/unenv-preset`), but these polyfills are stubs that throw or no-op on write operations.
+- **The `artifactsDir` is set to `/tmp/tests`** (seen in `lib/internal.js` for the test runner), but this path does not exist in the Worker runtime outside of the test framework.
+- **The HarRecorder constructs an `Artifact` at `path.join(artifactsDir, guid + '.har')`**, then attempts `fs.writeFileSync()` or `fs.promises.writeFile()` to that path during `flush()`. Both will fail.
+- **The in-process architecture** (`createInProcessPlaywright`) means the server-side code runs in the same isolate as the client-side code -- both are in the Worker. There is no separate browser server process with its own filesystem. The HAR recording, flushing, and artifact saving all happen within the Worker's V8 isolate.
+
+**Theoretical workaround:** One could monkey-patch `HarTracer` to accumulate entries in memory and export them as a buffer rather than writing to disk. But this would require forking `@cloudflare/playwright` or adding significant wrapper code -- well beyond a configuration change.
+
+### (d) Would HAR recording conflict with `context.route('**/*')`?
+
+**Yes, it would create complex interactions.** Analysis of both code paths:
+
+- **WRL's route interceptor** (`capture.js` lines 295-318) uses `context.route('**/*')` to block cross-domain navigation and enforce subresource/size limits via `route.continue()` and `route.abort()`.
+- **`HarTracer`** (`harTracer.js`) registers event listeners on `BrowserContext` for request/response events, including `BrowserContext.Events.Request`, `BrowserContext.Events.Response`, and frame navigation events.
+- **Both systems observe the same request pipeline.** HarTracer hooks into the lower-level network events (CDP-level), while `context.route()` operates at the request interception layer. In standard Playwright, they coexist because `route.continue()` passes the request through and HAR traces the underlying network events.
+- **Aborted requests would create partial HAR entries.** When WRL aborts requests (cross-domain navigation, subresource limit, size limit), the HarRecorder would see those as failed/incomplete entries. The resulting HAR file would contain entries without response bodies or with error states -- not a clean archive.
+- **The interplay is untested on Workers.** Since `@cloudflare/playwright` has never supported HAR recording, the interaction between route interception and HAR tracing has not been validated in the Workers CDP-over-WebSocket model.
+
+---
+
+## Recommendations
+
+### R1: Do not attempt native Playwright `recordHar()` on Workers
+
+The approach is blocked by filesystem dependencies at multiple levels of the Playwright internals. This is not a configuration issue -- it is an architectural mismatch between Playwright's HAR recording design (filesystem-centric) and Workers' execution model (no filesystem).
+
+### R2: If HAR output is desired, build it from existing captured data
+
+WRL already intercepts all requests via `context.route('**/*')` and monitors responses via `page.on('response', ...)`. These event streams contain the same data that `HarTracer` captures. A custom HAR builder could:
+
+1. Collect request/response metadata from the existing route interceptor and response listener
+2. Optionally capture response bodies (careful: memory implications per analysis above)
+3. Serialize to HAR 1.2 JSON format in-memory
+4. Store to R2 alongside existing artifacts
+
+This would be a pure application-level solution that stays within Workers constraints. However, it duplicates functionality that already exists in the WACZ pipeline (WARC records contain the same information, structured differently).
+
+### R3: Evaluate whether the format question (WACZ vs HAR) should be answered at the storage/export layer, not the capture layer
+
+The capture pipeline already collects: screenshot (PNG), rendered HTML, HTTP headers. The WACZ format wraps these in WARC records with a signed manifest. If HAR is desired as an output format, it could be generated from the same source data at retrieval/export time rather than at capture time. This avoids the real-time memory and timing constraints of the capture pipeline.
+
+### R4: Consider response body capture separately from format choice
+
+The key functional difference between WRL's current WACZ (which contains rendered HTML + screenshot + headers) and a full HAR (which would contain all subresource bodies) is **response body capture**. If the goal is to archive subresource content:
+- This requires intercepting response bodies during page load (via `route.fulfill()` patterns or CDP interception)
+- The memory implications are significant (see section b)
+- The current 200-subresource and 50 MB limits would need to account for in-memory body buffering
+- This is independent of whether the output format is WACZ or HAR
+
+---
+
+## Proposed Tasks
+
+| # | Task | Effort | Dependency |
+|---|------|--------|------------|
+| 1 | Document that Playwright HAR recording is not feasible on Workers (decision record) | S | None |
+| 2 | If HAR format is needed: build a lightweight in-memory HAR serializer from existing request/response events | M | Requires scope decision on response body capture |
+| 3 | If response body capture is needed: extend route interceptor to buffer response bodies with memory-aware limits | L | Architecture decision on memory budget |
+| 4 | If HAR is needed as export format: build HAR generation from stored WACZ/artifact data at retrieval time | M | None |
+
+---
+
+## Risks and Concerns
+
+### Hard Blockers
+
+1. **`@cloudflare/playwright` HAR recording is non-functional on Workers.** The `node:fs` dependency chain in `HarRecorder -> Artifact -> fs.writeFileSync/fs.promises.writeFile` cannot be satisfied. This is not a bug -- it is a fundamental design assumption in Playwright (HAR goes to disk).
+
+2. **No Cloudflare roadmap visibility.** There is no public indication that Cloudflare intends to add HAR recording support to their Playwright Workers binding. The `unsupportedOperations.js` file only blocks `launch`, `launchPersistentContext`, `launchServer`, and `connect` -- HAR-related operations are not explicitly blocked because they fail naturally via filesystem errors.
+
+### Operational Risks (if HAR recording were somehow made to work)
+
+3. **Memory pressure.** Full HAR files with embedded response bodies could consume 30-60% of the Worker's 128 MB memory limit for complex pages, leaving insufficient headroom for the screenshot, HTML, and WACZ assembly.
+
+4. **Timing budget.** HAR serialization during `context.close()` adds latency that competes with the 30s `ctx.waitUntil` budget. The current pipeline uses 25s for navigation + ~5s for screenshot/HTML/WACZ. HAR serialization for a large page could consume 1-3s of that headroom.
+
+5. **Partial captures from aborted requests.** The safety limits (`context.route('**/*')` blocking cross-domain and enforcing subresource limits) would produce HAR files with incomplete entries, reducing their archival value.
+
+---
+
+## Additional Agents Needed
+
+- **data-minion**: Should evaluate whether HAR 1.2 or WACZ 1.1 is the better archival format for WRL's use case, considering: legal admissibility, tooling ecosystem, replay capabilities, and long-term preservation standards. The format choice is a data architecture decision, not an infrastructure one.
+- **gru**: Should weigh in on whether response body capture (the key functional delta between current WACZ and full HAR) is in scope for MVP or should remain on the backlog. This is a product scope decision with significant engineering cost.

--- a/docs/history/nefario-reports/2026-03-16-091706-har-vs-wacz-format-evaluation/phase3-synthesis-prompt.md
+++ b/docs/history/nefario-reports/2026-03-16-091706-har-vs-wacz-format-evaluation/phase3-synthesis-prompt.md
@@ -1,0 +1,25 @@
+MODE: SYNTHESIS
+ADVISORY: true
+
+You are synthesizing specialist planning contributions into a team recommendation. This is an advisory-only orchestration -- no code will be written, no branches created, no PRs opened.
+
+## Original Task
+Should we switch the archive format to HAR? Are we already taking advantage of the Playwright capability for HAR recording?
+
+## Specialist Contributions
+
+Read the following scratch files for full specialist contributions:
+- /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-D6WP0B/har-vs-wacz-format-evaluation/phase2-gru.md
+- /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-D6WP0B/har-vs-wacz-format-evaluation/phase2-iac-minion.md
+
+## Key consensus across specialists:
+- gru: HAR is NOT a replacement for WACZ (no ISO standard, no signing, W3C abandoned). HAR IS valuable as a data capture mechanism -- recordHar() captures full request/response headers, timing, cookies, redirect chains that WRL currently lacks. Hybrid approach (HAR data → WARC metadata record inside WACZ) is architecturally sound. Recommends spike test for recordHar() on Workers.
+- iac-minion: Playwright HAR recording is NON-FUNCTIONAL on Cloudflare Workers. Three independent blockers: (1) HarRecorder.flush() calls fs.writeFileSync(), (2) Artifact model assumes filesystem paths, (3) localUtils is null in @cloudflare/playwright. If HAR data is needed, must build application-level serializer, not use Playwright recordHar().
+
+CRITICAL CONFLICT: gru recommends a spike test; iac-minion says the source code definitively blocks it. Synthesis must resolve this.
+
+## Instructions
+1. Review both specialist contributions (read the full files)
+2. Resolve the feasibility conflict
+3. Produce an advisory report with executive summary, consensus, dissent, recommendations, risks, next steps
+4. Write to /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-D6WP0B/har-vs-wacz-format-evaluation/phase3-synthesis.md

--- a/docs/history/nefario-reports/2026-03-16-091706-har-vs-wacz-format-evaluation/phase3-synthesis.md
+++ b/docs/history/nefario-reports/2026-03-16-091706-har-vs-wacz-format-evaluation/phase3-synthesis.md
@@ -1,0 +1,77 @@
+# Advisory Report: HAR Format Evaluation for WRL
+
+**Question**: Should WRL switch its archive format to HAR? Is WRL already taking advantage of Playwright's HAR recording capability?
+**Confidence**: HIGH
+**Recommendation**: Do not switch to HAR. Do not attempt Playwright's native `recordHar()` on Cloudflare Workers -- it is non-functional. If richer network metadata is desired in the future, build an application-level HAR serializer from existing request/response events already flowing through the route interceptor.
+
+## Executive Summary
+
+WRL should stay on WACZ/WARC. The format question is settled: WARC has ISO 28500 standardization, institutional adoption (Library of Congress, Internet Archive, British Library), Ed25519 signing support, and chain-of-custody tooling. HAR has none of these -- it was abandoned by W3C in 2012 and has zero legal evidence pedigree. Switching would be a significant regression in WRL's evidence-grade positioning.
+
+WRL is **not** using Playwright's `recordHar()`, and it **cannot** -- iac-minion's source-code analysis of `@cloudflare/playwright@1.1.2` identifies three independent blockers: `HarRecorder.flush()` calls `fs.writeFileSync()` (unavailable on Workers), the Artifact model assumes filesystem paths for save/export, and `localUtils` is null in the in-process Playwright connection (blocking the uncompressed HAR codepath entirely). This is not a configuration gap or an untested edge case -- it is an architectural incompatibility between Playwright's filesystem-centric HAR design and Workers' execution model.
+
+The valuable insight from this evaluation is not about format switching but about data enrichment. WRL's current capture pipeline has real gaps: `captureHeaders()` makes a separate fetch (different from the browser's actual request), captures only the main document's response headers, and records no timing, cookies, redirect chains, or sub-resource metadata. These gaps map to five items in the Dropped Items section of the backlog. If WRL ever needs richer network provenance, the path forward is an application-level serializer built on the request/response events already flowing through `context.route('**/*')` and `page.on('response')` -- not Playwright's native HAR API.
+
+## Team Consensus
+
+1. **HAR is not a replacement for WACZ/WARC.** Both specialists agree the formats serve fundamentally different purposes (performance analysis vs. preservation). HAR lacks standardization, integrity mechanisms, signing, and institutional recognition.
+2. **WRL is not using Playwright HAR recording.** The current pipeline (`src/capture.js`) captures screenshots, rendered HTML, and HTTP headers via a separate fetch. No HAR recording is configured.
+3. **The data HAR captures is valuable even if the format is not.** Full request/response headers per sub-resource, timing data, redirect chains, and cookie exchanges are genuine gaps in WRL's current capture. Both specialists acknowledge these gaps.
+4. **Memory and timing budgets are tight.** The current pipeline operates within a 30s `ctx.waitUntil` budget with 25s allocated to navigation. Any data enrichment must fit within the remaining ~5s headroom. Worker memory is capped at 128 MB, and the current artifact set (screenshot + HTML + WACZ assembly) already consumes a meaningful share.
+5. **The separate `captureHeaders()` fetch should be kept.** It provides a complementary perspective (server response to a non-browser client) and serves as graceful degradation if any future enrichment mechanism fails.
+
+## Dissenting Views
+
+- **Spike test feasibility**: gru recommended a spike test to determine whether `recordHar()` works on Cloudflare Workers' `/tmp` filesystem, noting that tracing (`/tmp/trace.zip`) works and is architecturally similar. iac-minion countered with definitive source-code evidence: `HarRecorder.flush()` calls `fs.writeFileSync()`, the Artifact model uses `saveCallback(this._localPath)` which copies between filesystem locations, and `createInProcessPlaywright()` passes no `localUtils` (causing the uncompressed HAR path to throw `"Uncompressed har is not supported in thin clients"`). **Resolution: iac-minion's analysis is dispositive.** The blockers are at the source-code level, not the platform-capability level -- the code will fail before it ever reaches `/tmp`. A spike test would confirm what the source already proves. gru's observation about tracing working on `/tmp` is valid but irrelevant: tracing uses a different code path (`Tracing` class) that was explicitly adapted for Workers, while HAR recording was not. No spike test is needed; the answer is already known.
+
+## Supporting Evidence
+
+### Standards and Legal Standing (gru)
+
+WARC is ISO 28500:2009 (revised 2017), maintained by IIPC and IETF, mandated by NARA (Bulletin 2014-04) as the only acceptable format for long-term website preservation. It is used by Perma.cc for court citations and by Starling Lab for authenticated evidence submissions. HAR 1.2 was frozen in 2011 as a community spec. Its W3C draft was never published as a Recommendation. No preservation institution uses it. No court has recognized it as an evidence format. WRL's WACZ investment (Ed25519 signing, CDXJ indexing, WARC record assembly) is aligned with the institutional standard.
+
+### Platform Incompatibility (iac-minion)
+
+Three independent blockers in `@cloudflare/playwright@1.1.2`:
+
+1. **Filesystem dependency**: `HarRecorder` -> `Artifact` -> `fs.writeFileSync()` / `fs.promises.writeFile()`. Workers' `node:fs` is polyfilled via `unenv` with stubs that throw on write operations.
+2. **Artifact model**: `harExport()` returns an `Artifact` with a `localPath`. Both server-side `saveAs()` (copies files) and client-side `saveAs()` (uses `fs.createWriteStream()`) require filesystem access.
+3. **Thin client guard**: `createInProcessPlaywright()` passes no `localUtils`, so `this._connection.localUtils()` returns null, and the code throws `"Uncompressed har is not supported in thin clients"` before reaching any filesystem operation.
+
+Additionally, `routeFromHAR()` (HAR-based request mocking) is also blocked by the same `localUtils` absence.
+
+### Current Capture Gaps
+
+WRL's `captureHeaders()` (lines 189-222 of `src/capture.js`) makes a separate `fetch()` with a different User-Agent (`WRL/0.1`), different TLS negotiation, and `redirect:'manual'`. It captures only the main document's response headers. The route interceptor (`context.route('**/*')`, lines 295-318) and response listener (`page.on('response')`, lines 323-329) already observe every sub-resource request and response but only extract `content-length` for the size budget -- they discard all other metadata.
+
+### Alternative Path: Application-Level Serializer
+
+If richer network metadata is ever needed, WRL already has the event streams to build it. The route interceptor sees every request (URL, headers, resource type). The response listener sees every response (status, headers). Building a lightweight in-memory HAR 1.2 serializer from these existing hooks would:
+
+- Stay within Workers constraints (no filesystem, no Playwright internals)
+- Capture the browser's actual request/response headers (not a separate fetch)
+- Add timing data via `performance.now()` deltas
+- Record redirect chains from navigation request sequences
+- Fit naturally as a WARC metadata record inside the existing WACZ container
+
+This is an M-sized work item that does not require any Playwright HAR APIs.
+
+## Risks and Caveats
+
+1. **The application-level serializer path is untested.** While the data is available in the route interceptor and response listener, serializing it into HAR 1.2 format during capture adds memory allocation and serialization time. The ~5s headroom between navigation timeout and `ctx.waitUntil` deadline is not generous.
+2. **Cloudflare could add HAR support in a future `@cloudflare/playwright` release.** If they do, the native API would be simpler than a custom serializer. However, there is no public roadmap indication this is planned, and the architectural changes required (in-memory HAR accumulation, buffer export instead of file export) would be non-trivial on Playwright's side.
+3. **HAR sanitization is harder than header sanitization.** Current `captureHeaders()` redacts only `Set-Cookie` on one response. A HAR file covering 200 sub-resources would need sanitization across hundreds of entries, covering cookies, `Authorization` headers, sensitive query parameters, and POST body data. The sanitization surface area is an order of magnitude larger.
+4. **The five dropped backlog items were dropped for good reasons.** "Full HTTP exchange capture", "sub-resource archiving", "certificate info capture", "network timing capture", and "resource manifest" were all assessed and dropped as beyond current scope. Partially addressing them via HAR data does not change the scope decision -- it creates a maintenance commitment for partial coverage.
+
+## Next Steps
+
+If the recommendation is adopted (stay on WACZ, do not pursue HAR recording):
+
+1. **Document the decision.** Add an evolution log entry recording the format evaluation, the `recordHar()` incompatibility finding, and the decision to stay on WACZ. This prevents the question from being re-litigated without new evidence.
+2. **Annotate dropped backlog items.** Add a note to the five capture-fidelity dropped items: "Evaluated HAR recording path (Phase NNNN); blocked by `@cloudflare/playwright` filesystem dependency. Application-level serializer is a viable future path if demand emerges."
+3. **No code changes.** The current capture pipeline is unchanged. No spike test, no feature branch, no new dependencies.
+4. **Revisit trigger.** Re-evaluate if (a) Cloudflare announces native HAR support in `@cloudflare/playwright`, or (b) a concrete user or integration partner requests richer network metadata in capture artifacts.
+
+## Conflict Resolutions
+
+**Spike test vs. source-code analysis**: gru recommended a spike test for `recordHar()` on Workers. iac-minion provided definitive source-code evidence that the code paths are inoperable (three independent blockers at the code level, not the platform level). Resolution: iac-minion's analysis supersedes the need for a spike test. The blockers are deterministic -- `fs.writeFileSync()` will throw, `localUtils` is null, `Artifact.saveAs()` requires filesystem paths. A spike test would confirm the failure but not reveal anything the source code analysis hasn't already shown. The recommendation is to skip the spike and treat the incompatibility as a known fact.

--- a/docs/history/nefario-reports/2026-03-16-091706-har-vs-wacz-format-evaluation/prompt.md
+++ b/docs/history/nefario-reports/2026-03-16-091706-har-vs-wacz-format-evaluation/prompt.md
@@ -1,0 +1,1 @@
+Should we switch the archive format to HAR? Are we already taking advantage of the Playwright capability for that?


### PR DESCRIPTION
## Summary

- HAR vs WACZ advisory report: stay on WACZ, `recordHar()` non-functional on Workers
- README repositioned from "archival" to "evidence" framing per specialist review
- Backlog governance improved: policy moved to end, precise language, HAR annotations on dropped items, R10 closed

## Changes

### README.md
- Opening line reframed: "Tamper-evident archival" → "Cryptographic evidence of web content"
- Removed stale "resource manifests" claim (capability was dropped from backlog)
- Added project status indicator (early development, pre-1.0)
- Added three-act roadmap section linking to backlog and issues
- Added rate limit info (10/min capture, 60/min verification)
- Added RFC 9457 error format note
- Fixed Node.js version (20+ → 22+ to match .nvmrc)
- Fixed stale phase count

### docs/backlog.md
- Moved inflation policy to end as "Backlog Governance" with actionable language
- Marked R10 as done (closed #40)
- Annotated 4 dropped capture fidelity items with HAR advisory finding
- Removed broken evolution log link to non-existent directory

### Advisory report
- HAR vs WACZ evaluation: 2 specialists (gru + iac-minion)
- Conclusion: HAR is not a replacement for WACZ (no ISO standard, no signing). Playwright `recordHar()` has 3 independent blockers on Workers.
- Future path: application-level serializer via existing route interceptor if demand emerges

## Test plan

- [x] All changes are documentation-only
- [ ] Verify README renders correctly on GitHub
- [ ] Verify backlog issue references auto-link on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)
