### PR TITLE
docs: capture parameterization advisory (Phase 0021)

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -78,7 +78,7 @@ Deferred items with explicit activation triggers. Revisit when condition is met.
 | Item | Condition | Source |
 |------|-----------|--------|
 | [should] Screenshot timing / wait-for-load | When a user reports incomplete renders | kickoff |
-| [should] Server-controlled cookie consent dismissal | When a user reports cookie consent banners as blocking for capture quality, OR when Web UI (R17) ships | 0017-advisory: ux-strategy, gru, frontend, security |
+| [should] Dual-screenshot cookie consent dismissal (#58) | After Act 1 and Wave 2 merge (depends on #53 and #41) | 0017-advisory: ux-strategy, gru, frontend, security |
 | [consider] Screenshot height cap configurability | When a user reports capped screenshots as a problem | edge-minion, capture-endpoint |
 | [consider] Viewport parameterization | When a user reports viewport size as a problem | 0017-advisory: api-design, security |
 | [consider] Capture options metadata schema (`captureSettings`) | When any capture parameterization feature ships | 0017-advisory: data-minion |

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -78,7 +78,10 @@ Deferred items with explicit activation triggers. Revisit when condition is met.
 | Item | Condition | Source |
 |------|-----------|--------|
 | [should] Screenshot timing / wait-for-load | When a user reports incomplete renders | kickoff |
+| [should] Server-controlled cookie consent dismissal | When a user reports cookie consent banners as blocking for capture quality, OR when Web UI (R17) ships | 0017-advisory: ux-strategy, gru, frontend, security |
 | [consider] Screenshot height cap configurability | When a user reports capped screenshots as a problem | edge-minion, capture-endpoint |
+| [consider] Viewport parameterization | When a user reports viewport size as a problem | 0017-advisory: api-design, security |
+| [consider] Capture options metadata schema (`captureSettings`) | When any capture parameterization feature ships | 0017-advisory: data-minion |
 
 ### API Enhancements
 

--- a/docs/evolution/0021-capture-parameterization-advisory/decisions.md
+++ b/docs/evolution/0021-capture-parameterization-advisory/decisions.md
@@ -1,0 +1,61 @@
+# 0017 Decisions: Capture Parameterization Advisory
+
+## Decision 1: General parameterization -- Hold
+
+**Chosen**: Do not build general capture parameterization (viewport, cookies, wait conditions, session injection) in Act 1 or Act 2.
+
+**Alternatives considered**:
+- Build full parameterization now (api-design-minion, frontend-minion leaned this way with designs ready)
+- Build only cookie handling now (ux-strategy-minion argued it's a "broken must-be")
+
+**Rationale**: The competitive landscape splits cleanly. Screenshot APIs (URLBox, ScreenshotOne) compete on parameterization breadth; evidence services (Page Vault, Pagefreezer, FAW) limit caller control. WRL is positioned in the evidence category. Every caller-controlled parameter weakens the objectivity claim. Act 1 has 7 remaining items. No external user has reported any parameterization gap.
+
+## Decision 2: Cookie consent -- server-controlled, not caller-controlled
+
+**Chosen**: When built, consent dismissal will be a server-controlled operator policy, not a caller parameter.
+
+**Alternatives considered**:
+- Caller-controlled layered approach: Layer 0 (none), Layer 1 (CSS hide), Layer 2 (caller cookies) -- frontend-minion
+- Caller parameter with provenance tracking -- api-design-minion
+
+**Rationale**: Server-controlled preserves the attestation model. WRL says "we captured this URL and dismissed consent banners using method X." Caller-controlled opens the door to evidence that reflects the caller's choices rather than a neutral observation. gru's argument: evidence services that make legal admissibility claims deliberately limit caller control.
+
+## Decision 3: Consent action (dismiss vs. reject-all) -- Deferred
+
+**Chosen**: Defer to implementation time. Both approaches have merit.
+
+**ux-strategy position**: "Dismiss without choosing" is maximally neutral -- removes the overlay without making a consent choice. Does not change what tracking/personalization the page performs.
+
+**gru position**: "Reject all" minimizes tracking state. Keeps browser context closest to a neutral observer. Cleaner from a state perspective.
+
+**Why deferred**: The choice depends on which action the selected consent library supports more reliably. Both must be recorded in metadata regardless.
+
+## Decision 4: Cookie injection limit -- 20, not 50
+
+**Chosen**: Max 20 cookies per request (security-minion recommendation).
+
+**Alternative**: api-design-minion proposed maxItems: 50.
+
+**Rationale**: The evidence use case for cookie injection is narrow (consent state, locale preferences). 20 is generous. Limiting reduces abuse surface. Can be raised if a legitimate use case emerges.
+
+## Decision 5: Viewport cap -- 1920, not 3840
+
+**Chosen**: Cap viewport width at 1920 initially (security-minion recommendation).
+
+**Alternative**: api-design-minion proposed up to 3840 (4K support).
+
+**Rationale**: The pixel budget constraint (50M pixels max) provides defense-in-depth. A 4K viewport with fullPage:true could exceed the pixel budget. Starting conservative is safer. Can be raised if demand materializes.
+
+## Decision 6: Parameter metadata architecture
+
+**Chosen**: `captureSettings` block in both `datapackage.json` (dense, all resolved settings) and KV (sparse, caller overrides). Automatically covered by existing Ed25519 signature chain.
+
+**No alternatives seriously considered** -- all specialists agreed parameters must be in WACZ for portable evidence. data-minion's design was consensus.
+
+## Decision 7: Parking lot tier -- [should], not [consider]
+
+**Chosen**: Cookie consent dismissal enters parking lot at [should] tier.
+
+**Alternative**: gru initially positioned it as [consider] (Assess ring).
+
+**Rationale**: Compromise between YAGNI (don't build yet) and ux-strategy's "broken must-be" argument. The problem is real and well-understood, just not yet user-reported. [should] signals the team believes it's needed, even if timing isn't immediate.

--- a/docs/evolution/0021-capture-parameterization-advisory/outcome.md
+++ b/docs/evolution/0021-capture-parameterization-advisory/outcome.md
@@ -1,0 +1,48 @@
+# 0017 Outcome: Capture Parameterization Advisory
+
+## What was produced
+
+Advisory report with team recommendation on capture request parameterization.
+No code changes. Three new backlog items added to the Parking Lot.
+
+## Key outputs
+
+1. **Advisory report**: `docs/history/nefario-reports/2026-03-16-120123-capture-parameterization.md`
+   with full specialist contributions in companion directory.
+
+2. **Team recommendation**: Do not build general parameterization now. Address
+   cookie consent through server-controlled dismissal when triggered by user
+   demand or Web UI launch. Every future parameter must be WACZ-embedded and
+   signature-covered.
+
+3. **Security constraints**: 12 minimum security constraints defined for safe
+   parameterization. No caller-supplied JS execution is a non-negotiable red
+   line across all 6 specialists.
+
+4. **Competitive landscape**: Clean market segmentation documented. Screenshot
+   APIs compete on parameterization; evidence services limit caller control.
+   WRL should stay in the evidence lane.
+
+5. **Technical feasibility**: Four consent handling approaches evaluated with
+   reliability estimates (CSS hiding 60-70%, click automation 70-80%, CMP APIs
+   80-85%, cookie pre-injection 85-90%). Autoconsent library identified as the
+   most viable path for broad coverage.
+
+6. **Data architecture**: `captureSettings` schema designed. Ed25519 signature
+   automatically covers parameters through existing canonicalize-hash-sign
+   chain -- no signing code changes needed.
+
+## Backlog changes
+
+### Added to Parking Lot > Capture Fidelity
+- [should] Server-controlled cookie consent dismissal (trigger: user report OR R17)
+- [consider] Viewport parameterization (trigger: user reports viewport as problem)
+- [consider] Capture options metadata schema (trigger: any parameterization ships)
+
+### No items removed or changed tier
+
+## Open questions for project owner
+
+1. Consent action: "dismiss without choosing" vs. "reject all"
+2. Default-on vs. opt-in for consent dismissal
+3. Autoconsent bundle size evaluation needed before committing to that library

--- a/docs/evolution/0021-capture-parameterization-advisory/prompt.md
+++ b/docs/evolution/0021-capture-parameterization-advisory/prompt.md
@@ -1,0 +1,44 @@
+# 0017: Capture Parameterization Advisory
+
+## Task Briefing
+
+Run an advisory with the specialist team to evaluate whether WRL should
+establish a mechanism for parameterizing capture requests — allowing callers
+to control browser behavior during capture.
+
+## Motivation
+
+WRL captures currently start with a blank browser session. This means:
+
+1. **Cookie consent banners** dominate every screenshot — the browser has no
+   prior consent state, so cookie pop-ups appear on virtually every capture.
+   This is the single biggest fidelity issue for screenshots.
+
+2. **No cookie control** — callers cannot instruct the capture to
+   auto-accept, auto-reject, or skip cookie consent banners.
+
+3. **No personalization control** — captures always show the anonymous/
+   first-visit experience. There's no way to inject cookies, localStorage,
+   or other session state to capture a personalized view.
+
+4. **No viewport or rendering parameters** — viewport size, device
+   emulation, wait conditions, and other rendering controls are hardcoded.
+
+## Key Questions for the Advisory
+
+- Should WRL support capture parameters at all, or is "clean slate capture"
+  the right default for an evidence product?
+- If yes, what parameter categories make sense? (cookie handling, viewport,
+  wait conditions, session injection, etc.)
+- How does parameterization interact with evidence integrity? If someone
+  injects cookies, is the capture still "evidence"?
+- What's the API surface? Query params, request body fields, presets?
+- What are the security implications of accepting browser-controlling
+  parameters from API callers?
+- How do cookie consent tools (OneTrust, Cookiebot, etc.) work technically,
+  and can we reliably dismiss them?
+
+## Scope
+
+Advisory only (--advisory). No implementation. Produce recommendations and
+backlog items for future phases.

--- a/docs/evolution/README.md
+++ b/docs/evolution/README.md
@@ -29,3 +29,4 @@ software development.
 | [0018-staging-and-tos](0018-staging-and-tos/) | Staging environment with automated deploy and legal documents (Issues #39, #37) |
 | [0019-cors-hsts-ratelimit](0019-cors-hsts-ratelimit/) | CORS for capture POST, HSTS preload directive, and X-RateLimit-Limit header (Issues #33, #34, #35) |
 | [0020-hashed-ip-logging](0020-hashed-ip-logging/) | HMAC-SHA256 hashed IP logging and categorizeError fix (Issues #36, #52) |
+| [0021-capture-parameterization-advisory](0021-capture-parameterization-advisory/) | Advisory: capture request parameterization (cookies, viewport, evidence integrity) |

--- a/docs/history/nefario-reports/2026-03-16-120123-capture-parameterization.md
+++ b/docs/history/nefario-reports/2026-03-16-120123-capture-parameterization.md
@@ -1,0 +1,123 @@
+---
+task: Evaluate capture request parameterization for WRL
+date: 2026-03-16
+slug: capture-parameterization
+mode: advisory
+task-count: 0
+gate-count: 0
+compaction-events: 0
+---
+
+## Summary
+
+Six specialists evaluated whether WRL should support parameterized capture requests -- controlling browser behavior (viewport, cookies, wait conditions, consent handling) during capture. Answer: do not build general parameterization now. Cookie consent banners are a real fidelity problem; address them through a server-controlled dismissal mechanism as a [should] parking lot item. When parameterization ships, every setting must be recorded immutably in the WACZ bundle (existing Ed25519 chain covers it automatically) and visible to verifiers. No caller-supplied JavaScript execution, ever.
+
+## Original Prompt
+
+Evaluate whether WRL should establish a mechanism to parameterize capture requests. Primary motivation: cookie consent banners dominate every screenshot because captures start with an empty session. Secondary concerns: personalization, viewport control, wait conditions, session state injection. Run as advisory only.
+
+## Key Design Decisions
+
+1. **General parameterization: Hold.** The competitive landscape splits cleanly -- screenshot APIs (URLBox, ScreenshotOne) compete on parameterization breadth; evidence services (Page Vault, Pagefreezer) limit caller control. WRL is in the evidence category. Adding caller-controlled cookies or JS injection would push WRL toward a screenshot API where it cannot compete and would undermine its core positioning.
+
+2. **Cookie consent: server-controlled dismissal, not caller-controlled.** When built, WRL should decide the consent policy (dismiss or reject-all), apply it uniformly, and record the action in capture metadata. The caller has no control over consent handling. This preserves the attestation model -- the capture reflects WRL's documented policy, not the caller's preference.
+
+3. **Timing: parking lot, not now.** Act 1 (Solid Foundation) has 7 remaining items. No external user has reported cookie banners as blocking. YAGNI applies. But the item is [should] tier (not [consider]) acknowledging the problem is real.
+
+4. **Evidence integrity through transparency.** Every parameter must be recorded in `captureSettings` block in `datapackage.json`, automatically covered by the Ed25519 signature chain (no signing changes needed). Verifiers must see capture conditions alongside URL and timestamp.
+
+5. **Two-tier evidence model.** Level 1 (Verified): clean-slate capture, no parameters, full evidence claim. Level 2 (Documented): parameterized capture, evidence claim limited to "this is what the page showed given these inputs." Both signed and timestamped.
+
+6. **12 minimum security constraints for safe parameterization.** Most critical: no caller-supplied JS execution (#1), cookie domain scoping (#3), pixel budget enforcement (#6), parameterization flags in metadata (#9). Architecture: validation/normalization layer that accepts WRL parameters, not a passthrough to Playwright's `newContext()`.
+
+7. **API extension approach when ready.** Extend `POST /v1/captures` with optional fields alongside `url`. No presets, no separate endpoint. `appliedParams` in responses shows actual values used. Backward compatible.
+
+## Phases
+
+### Phase 1: Meta-Plan
+Identified 6 specialists: ux-strategy-minion (evidence vs. fidelity tension, user jobs), security-minion (attack surface analysis), api-design-minion (parameter model design), frontend-minion (cookie consent technical feasibility), gru (strategic YAGNI assessment), data-minion (evidence provenance architecture).
+
+### Phase 2: Specialist Planning
+- **ux-strategy-minion**: The clean-slate vs. parameterized tension is a false dichotomy. Evidence integrity comes from declaring conditions, not restricting them. Cookie consent handling should be a default behavior (dismiss without accepting). Distinguished "neutral" parameters (viewport) from "opinion" parameters (cookie consent) -- this distinction should be visible to verifiers.
+- **security-minion**: Parameterization is safe IF every category is independently threat-modeled. Cookie injection is CRITICAL in multi-tenant (transforms WRL into a credentialed proxy). Defined 12 minimum security constraints. Recommended two-tier evidence model.
+- **api-design-minion**: Extend `POST /v1/captures` with optional fields. Six initial parameters (viewport, waitUntil, maxWaitMs, cookies, screenshotMaxHeight). `appliedParams` in responses. Cookie values never echoed (count only). Fully backward compatible.
+- **frontend-minion**: Evaluated four consent approaches. CSS hiding: 60-70% known CMPs. Click automation: 70-80%. CMP API calls: 80-85%. Cookie pre-injection: 85-90%. All have 0% custom banner coverage. Recommended layered architecture, not a general-purpose consent handler. Autoconsent library is the only viable broad-coverage path.
+- **gru**: General parameterization: Hold. Server-controlled consent dismissal: Assess. Market analysis confirms evidence services limit caller control. Timing: not now (Act 1 in progress). Use autoconsent with reject-all. Bundle size and 30s budget are open constraints.
+- **data-minion**: Parameters in both `datapackage.json` (dense) and KV (sparse). Ed25519 signature automatically covers parameters through existing canonicalize-hash-sign chain. Schema: closed, minimal, 4 fields Tier 1 with `settingsVersion`. KV impact negligible (~400-500 bytes).
+
+### Phase 3: Synthesis
+Resolved four conflicts:
+1. **Server-controlled vs. caller-controlled consent**: server-controlled first (gru wins on evidence positioning); caller cookies as future escape hatch.
+2. **Dismiss vs. reject-all consent action**: deferred to implementation (depends on library feasibility).
+3. **Build now vs. parking lot**: parking lot at [should] tier (YAGNI respected, problem acknowledged).
+4. **Cookie limit 20 vs. 50**: adopt 20 (security recommendation; evidence use case is narrow).
+
+### Phases 3.5-8
+Skipped (advisory-only orchestration).
+
+## Agent Contributions
+
+| Agent | Phase | Recommendation | Risks |
+|-------|-------|----------------|-------|
+| ux-strategy-minion | planning | Evidence integrity = declaring conditions, not restricting them. Neutral vs opinion parameter taxonomy. Cookie dismiss as default. | Scope creep, evidence confusion, contested boundary |
+| security-minion | planning | 12 security constraints. Two-tier evidence model. No caller JS execution ever. | Cookie injection as credentialed proxy (CRITICAL multi-tenant) |
+| api-design-minion | planning | Extend POST body with optional fields. appliedParams in responses. Cookie count only. | Cookie domain validation is a security boundary |
+| frontend-minion | planning | Layered architecture: CSS hiding + caller cookies. No general consent handler. | Selector drift, 0% custom banner coverage |
+| gru | planning | General params: Hold. Server consent: Assess. Not now. | Autoconsent fragility, bundle size, 30s budget |
+| data-minion | planning | captureSettings in datapackage.json + KV. Signature covers it automatically. | Schema immutability under signing, false precision |
+
+## Team Recommendation
+
+### Do not build parameterization now. Prepare the ground for when it's needed.
+
+**Immediate action**: Update `docs/backlog.md` with three parking lot items:
+
+1. **[should] Server-controlled cookie consent dismissal**
+   - Trigger: User reports banners as blocking, OR Web UI (R17) ships
+   - Approach: Integrate autoconsent (or curated subset) via `addInitScript()`. Operator policy (reject-all or dismiss), not caller parameter.
+   - Record action in WACZ `captureSettings.consentHandling`. Display on verification page.
+   - Scope: S-M. Dependencies: none, but should wait for Act 1 completion.
+
+2. **[consider] Viewport parameterization**
+   - Trigger: User reports viewport size as a problem
+   - Approach: Optional `viewport` field in request body. Caps: width [320, 1920], height [480, 1080]. Pixel budget: 50M max.
+   - Record in `captureSettings`. Scope: S.
+
+3. **[consider] Capture options metadata schema (`captureSettings`)**
+   - Trigger: When any capture parameterization feature ships
+   - Approach: Closed schema with `settingsVersion`, embedded in `datapackage.json`. Four Tier 1 fields (viewport width/height, waitUntil, maxScreenshotHeight). Signature coverage comes for free.
+   - Scope: S. This is prerequisite infrastructure for any parameterization.
+
+**When multi-tenant (R12) ships**: revisit cookie injection threat model. Require elevated permissions, per-tenant audit logging, Terms of Service updates before enabling caller-provided cookies.
+
+**What NOT to build, ever**: Caller-supplied JavaScript execution in the page context (`waitForFunction`, `evaluate`, `addScriptTag`, `addInitScript` with user content). This is a non-negotiable security red line across all specialists.
+
+### Open questions for the project owner
+
+1. **Consent action**: "dismiss without choosing" (maximally neutral, technically harder) vs. "reject all" (cleaner state, active choice that may hide consent-gated content)?
+2. **Should consent dismissal be default-on or opt-in?** ux-strategy argues default-on (the banner-free view is better evidence of page content); gru argues opt-in (explicit is safer).
+3. **Autoconsent bundle size**: needs evaluation against Cloudflare Workers' 10MB script limit before committing to that library.
+
+## Session Resources
+
+### Skills Invoked
+- `/nefario` (this advisory)
+
+### Compaction
+0 compaction events.
+
+## Working Files
+
+All specialist contributions and synthesis available in the companion directory:
+[2026-03-16-120123-capture-parameterization/](./2026-03-16-120123-capture-parameterization/)
+
+Files:
+- `prompt.md` -- original task description
+- `phase1-metaplan-prompt.md` / `phase1-metaplan.md` -- meta-plan
+- `phase2-ux-strategy-minion-prompt.md` / `phase2-ux-strategy-minion.md`
+- `phase2-security-minion-prompt.md` / `phase2-security-minion.md`
+- `phase2-api-design-minion-prompt.md` / `phase2-api-design-minion.md`
+- `phase2-frontend-minion-prompt.md` / `phase2-frontend-minion.md`
+- `phase2-gru-prompt.md` / `phase2-gru.md`
+- `phase2-data-minion-prompt.md` / `phase2-data-minion.md`
+- `phase3-synthesis-prompt.md` / `phase3-synthesis.md` -- advisory synthesis

--- a/docs/history/nefario-reports/2026-03-16-120123-capture-parameterization/phase1-metaplan-prompt.md
+++ b/docs/history/nefario-reports/2026-03-16-120123-capture-parameterization/phase1-metaplan-prompt.md
@@ -1,0 +1,59 @@
+MODE: META-PLAN
+
+You are creating a meta-plan — a plan for who should help plan.
+
+## Task
+
+Evaluate whether WRL (Web Resource Ledger) should support parameterized capture requests — allowing API callers to control browser behavior during web page capture.
+
+### Context
+
+WRL is a web evidence/archival service running on Cloudflare Workers with Playwright-based browser rendering. It captures web pages (HTML + screenshot + metadata) and stores them in R2 with Ed25519 signatures for integrity. Currently, every capture starts with a completely blank browser session — no cookies, no localStorage, no prior state.
+
+**The core problem**: Cookie consent banners (GDPR/ePrivacy) appear on virtually every capture because the browser has no prior consent state. This dominates screenshots and reduces capture fidelity. The question extends beyond cookies to broader capture parameterization.
+
+### Key areas to evaluate
+
+1. **Cookie consent handling**: Auto-accept, auto-reject, skip/dismiss cookie banners. Technical approaches (CSS hiding, click automation, consent management platform APIs). Reliability across different CMP implementations (OneTrust, Cookiebot, Didomi, custom).
+2. **Session state injection**: Should callers be able to inject cookies, localStorage values, or other session state?
+3. **Viewport and rendering parameters**: Device emulation, viewport size, wait-for conditions, JavaScript execution toggle, dark mode, etc.
+4. **Evidence integrity implications**: How does parameterization interact with WRL's evidence/archival mission?
+5. **API design**: How should parameters be passed? Request body fields vs query params vs presets.
+6. **Security implications**: What attack surface does parameterization open?
+7. **Complexity vs value tradeoff**: Is this worth building at all? YAGNI considerations.
+
+### Technical constraints
+
+- Runs on Cloudflare Workers with Browser Rendering (Playwright)
+- Captures must complete within Workers CPU/wall-time limits
+- Browser sessions are ephemeral (no session reuse between captures)
+- Ed25519 signatures cover all capture artifacts
+- Current API: POST /v1/captures with { url } body
+- Single-tenant today, multi-tenant planned (R12)
+
+### Current capture implementation
+
+The capture pipeline (src/capture.js) creates a fresh BrowserContext per capture with:
+- Fixed viewport: 1280x720
+- Service workers blocked
+- Cross-domain navigation blocked via route interception
+- Subresource count limit (200) and page size limit (50MB)
+- Navigation timeout: 25s
+- Screenshot: full-page PNG, height capped at 8000px
+- No cookie handling, no consent management, no session state injection
+
+The API (src/index.js handleCreateCapture) accepts only `{ url }` in the request body.
+
+## Working Directory
+/Users/ben/github/benpeter/web-resource-ledger/.claude/worktrees/capture-parameterization-advisory
+
+## External Skill Discovery
+No external skills found in .claude/skills/ or .skills/.
+
+## Instructions
+1. Read relevant files to understand the codebase context
+2. Analyze the task against your delegation table
+3. Identify which specialists should be CONSULTED FOR PLANNING (not execution — planning). These are agents whose domain expertise is needed to create a good plan.
+4. For each specialist, write a specific planning question that draws on their unique expertise.
+5. Return the meta-plan in the structured format.
+6. Write your complete meta-plan to /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-cfmjZO/capture-parameterization/phase1-metaplan.md

--- a/docs/history/nefario-reports/2026-03-16-120123-capture-parameterization/phase1-metaplan.md
+++ b/docs/history/nefario-reports/2026-03-16-120123-capture-parameterization/phase1-metaplan.md
@@ -1,0 +1,100 @@
+# Meta-Plan: Capture Parameterization Advisory
+
+## Task Summary
+
+Evaluate whether WRL should support parameterized capture requests -- allowing API callers to control browser behavior (cookie consent handling, viewport size, session state injection, wait conditions, etc.) during web page capture. This is an advisory-only engagement: produce recommendations and backlog items, no implementation.
+
+## Scope
+
+**In scope**: Cookie consent handling approaches, session state injection, viewport/rendering parameters, evidence integrity implications, API design for parameters, security implications, YAGNI assessment.
+
+**Out of scope**: Implementation, code changes, deployment. This is a planning advisory.
+
+---
+
+## Planning Consultations
+
+### Consultation 1: Evidence Integrity and Capture Fidelity Strategy
+
+- **Agent**: ux-strategy-minion
+- **Planning question**: WRL positions itself as an "evidence" product. Cookie consent banners currently dominate every screenshot, degrading capture fidelity. How should we think about the tension between "clean slate = reproducible evidence" and "parameterized = higher fidelity but caller-influenced"? What user jobs-to-be-done does parameterization serve, and which parameter categories (cookie handling, viewport, wait conditions, session injection) have the highest impact on the core evidence use case? Should WRL distinguish between "neutral" parameters (viewport size) and "opinion" parameters (cookie consent choice) in how they affect the evidence claim?
+- **Context to provide**: Current capture pipeline (`src/capture.js`) uses fixed 1280x720 viewport, no cookie handling, no session state. MVP.md positions WRL as "capture a URL, store it immutably, let a third party verify." Backlog parking lot has two capture fidelity items: "Screenshot timing / wait-for-load" and "Screenshot height cap configurability" -- both with demand-driven triggers. The 0017 prompt identifies cookie consent banners as "the single biggest fidelity issue for screenshots."
+- **Why this agent**: UX strategy can map parameterization to real user needs vs. speculative features. The evidence-vs-fidelity tension is fundamentally a user journey question: what does the person receiving the evidence expect to see?
+
+### Consultation 2: Security Attack Surface Analysis
+
+- **Agent**: security-minion
+- **Planning question**: What attack surface does capture parameterization open? Specifically evaluate: (1) Cookie/session injection as a vector for capturing authenticated content the API caller shouldn't access (e.g., injecting stolen session cookies). (2) Arbitrary JavaScript execution via wait-for conditions or page manipulation. (3) CSS injection or DOM manipulation to alter what the "evidence" shows. (4) Resource exhaustion via viewport size parameters (e.g., 10000x10000 viewport). (5) How do these risks differ between single-tenant (current) and multi-tenant (R12 planned) deployments? What's the minimum set of security constraints that would make parameterization safe?
+- **Context to provide**: Current security model: SSRF prevention via URL validation (`src/url-validation.js`), BrowserContext isolation per capture, cross-domain navigation blocking, subresource limits (200), page size limits (50MB), Set-Cookie redaction in captured headers, service workers blocked. Auth is single API key (`src/auth.js`), multi-tenant planned as R12. Playwright BrowserContext accepts cookies, localStorage, viewport, and other options at creation time. The capture runs in `ctx.waitUntil()` with a ~30s budget.
+- **Why this agent**: Parameterization directly expands the trust boundary -- callers move from providing only a URL to providing browser configuration. Security must evaluate whether this is a manageable expansion or a fundamental risk category change.
+
+### Consultation 3: API Design for Capture Parameters
+
+- **Agent**: api-design-minion
+- **Planning question**: How should capture parameters be exposed in the API? Evaluate: (1) Request body extension (add fields alongside `url`) vs. named presets vs. a separate configuration resource. (2) Which parameters should be top-level fields vs. nested objects? (3) How should the API communicate what parameters were actually applied (for evidence provenance)? (4) Backward compatibility: the current API accepts only `{ url }` -- how do we extend without breaking existing callers? (5) Should parameterized captures be a separate endpoint or the same `POST /v1/captures`? Consider that capture metadata is stored in KV and parameters may need to be recorded for evidence integrity.
+- **Context to provide**: Current API: `POST /v1/captures` accepts `{ url }` in JSON body, returns 202 with captureId. OpenAPI spec at `openapi.yaml`. KV stores capture metadata including url, status, timestamps, artifacts, wacz info. The `performCapture()` function signature is `(env, url, ip, captureId, tenantId, renderer)`. Relevant parking lot items: "Screenshot timing / wait-for-load" and "Screenshot height cap configurability."
+- **Why this agent**: API design determines the long-term contract. Getting the parameter model right (or deciding not to have one) is a high-blast-radius, hard-to-reverse decision that affects every future feature.
+
+### Consultation 4: Cookie Consent Technical Feasibility
+
+- **Agent**: frontend-minion
+- **Planning question**: How do the major cookie consent management platforms (OneTrust, Cookiebot, Didomi, TrustArc, custom implementations) work technically? Evaluate the feasibility and reliability of: (1) CSS-based banner hiding (inject stylesheet to `display:none` consent overlays). (2) Click-based automation (find and click accept/reject buttons via selectors). (3) CMP API calls (TCF v2 `__tcfapi()`, IAB GPP, direct CMP JavaScript APIs). (4) Pre-injection of consent cookies (set the appropriate cookies before navigation so the CMP never shows the banner). Which approach is most reliable across diverse sites? What's the failure rate for each? Can Playwright on Cloudflare Workers execute these approaches within the 25s navigation timeout?
+- **Context to provide**: Capture runs in Playwright BrowserContext on Cloudflare Browser Rendering. Navigation timeout is 25s, waitUntil is 'networkidle'. Context is fresh per capture -- no prior state. Playwright supports `context.addCookies()`, `page.addStyleTag()`, `page.evaluate()`, and `page.click()`. The capture pipeline is in `src/capture.js` -- the `defaultRenderer()` function is where any consent handling would execute.
+- **Why this agent**: Frontend expertise is needed to assess the technical landscape of cookie consent tools. This is a cross-browser, cross-CMP compatibility question that requires understanding the DOM manipulation and JavaScript API patterns these tools use.
+
+### Consultation 5: Strategic Technology Assessment
+
+- **Agent**: gru
+- **Planning question**: Is capture parameterization the right investment for WRL's current stage? Consider: (1) The competitive landscape -- how do archive.org's Wayback Machine, Stillio, Pagefreezer, URLBox, and similar services handle cookie consent and parameterization? (2) Is the "evidence" positioning strengthened or weakened by allowing caller-controlled parameters? (3) Should WRL invest in cookie consent handling specifically, or in general parameterization, or neither? (4) Are there emerging standards or tools (e.g., consent-o-matic, I Don't Care About Cookies browser extension approaches) that could be leveraged? (5) What does the market signal say -- is cookie consent handling a table-stakes feature or a differentiator?
+- **Context to provide**: WRL roadmap has three acts: "Solid Foundation" (near-term), "Evidence-Grade" (mid-term), "Infrastructure" (longer-horizon). Act 1 is still in progress (R2-R9 remaining). The product-marketing-minion previously recommended "evidence" over "archival" positioning. MCP server is in Act 3. Cookie consent is not currently in any backlog act. Cloudflare Browser Rendering provides Playwright API but runs in a Workers environment with constraints (30s budget, no persistent state, gVisor sandbox).
+- **Why this agent**: Gru can assess whether this is a strategically sound investment vs. a premature feature, and how competitors handle the same problem. The YAGNI question is especially important given WRL's early stage.
+
+### Consultation 6: Evidence Provenance and Metadata Architecture
+
+- **Agent**: data-minion
+- **Planning question**: If WRL supports parameterized captures, how should capture parameters be recorded for evidence provenance? Consider: (1) Should parameters be embedded in the WACZ bundle's `datapackage.json` manifest? (2) Should they be part of the KV capture record? (3) How does parameter recording interact with the Ed25519 signature -- should the signature cover the parameters to prove the capture was made with specific settings? (4) What's the schema for recording "this capture was made with viewport 1920x1080 and cookie consent auto-accepted"? (5) What's the KV storage impact if every capture record grows to include a parameter block?
+- **Context to provide**: Current KV capture record includes: captureId, url, ip, tenantId, status, createdAt, completedAt/failedAt, artifacts (R2 keys), wacz (key, bundleHash, size). WACZ `datapackage.json` includes per-artifact SHA-256 hashes, bundleHash, and Ed25519 signature. The signature covers the bundleHash which covers the manifest. KV has a 25 MiB value limit but current records are <1 KB.
+- **Why this agent**: Data architecture for parameter provenance is a hard-to-reverse decision. If parameters aren't recorded in the bundle, they can never be proven after the fact. If they are, the WACZ format and signing pipeline need to accommodate them.
+
+---
+
+## Cross-Cutting Checklist
+
+- **Testing**: Not included for planning. This is an advisory (no code produced). If the advisory recommends implementation, test-minion would be included in the execution plan for that phase.
+- **Security**: INCLUDED -- Consultation 2 (security-minion). Parameterization directly expands the trust boundary and attack surface. Security assessment is critical to the advisory recommendation.
+- **Usability -- Strategy**: INCLUDED -- Consultation 1 (ux-strategy-minion). Every advisory needs the user journey perspective to evaluate whether the feature serves real needs.
+- **Usability -- Design**: Not included for planning. No UI is being designed. If the advisory recommends a web UI for parameter configuration (unlikely at this stage), ux-design-minion would be relevant in execution.
+- **Documentation**: Not included for planning. Advisory output is the documentation. If the advisory recommends implementation, software-docs-minion would document the API changes. The advisory itself will produce the documentation (backlog items, decisions).
+- **Observability**: Not included for planning. No runtime components are being created. If parameterization is implemented, observability-minion would review logging of parameter usage.
+
+---
+
+## Anticipated Approval Gates
+
+None. This is an advisory-only orchestration (`ADVISORY: true`). The output is a recommendation report, not an execution plan. No code is produced, no architecture decisions are locked in. The user decides whether to act on the recommendations.
+
+---
+
+## Rationale
+
+Six specialists are consulted because capture parameterization spans multiple domains that rarely overlap:
+
+1. **ux-strategy-minion** -- The fundamental question is whether parameterization serves the user's evidence needs or undermines them. This is a product strategy question before it's a technical one.
+
+2. **security-minion** -- Moving from "caller provides URL" to "caller provides URL + browser configuration" is a category-level expansion of the trust boundary. The security assessment determines whether parameterization is safe at all.
+
+3. **api-design-minion** -- The API contract for parameters is a high-blast-radius, hard-to-reverse decision. Getting it wrong means breaking changes later or living with a bad interface forever.
+
+4. **frontend-minion** -- Cookie consent handling is the motivating use case, and it's a deeply technical frontend question. The feasibility assessment determines whether the most-wanted parameterization feature is even practical.
+
+5. **gru** -- Strategic calibration: is this the right investment for WRL's current stage? Competitive analysis and YAGNI assessment prevent premature feature building.
+
+6. **data-minion** -- Evidence provenance requires recording what parameters were used. The metadata/bundle schema decision is hard to reverse and affects the signing pipeline.
+
+**Not included**: mcp-minion (MCP is Act 3, not relevant yet), iac-minion (no infrastructure changes in advisory), ai-modeling-minion (no agent/prompt work), observability-minion (no runtime components), accessibility-minion (no UI), edge-minion (no CDN/edge changes), test-minion (no code to test), software-docs-minion (advisory is self-documenting), user-docs-minion (no user-facing changes yet), product-marketing-minion (evidence positioning was already established in the roadmap advisory -- ux-strategy covers the user-facing angle here).
+
+---
+
+## External Skill Integration
+
+No external skills detected in project.

--- a/docs/history/nefario-reports/2026-03-16-120123-capture-parameterization/phase2-api-design-minion-prompt.md
+++ b/docs/history/nefario-reports/2026-03-16-120123-capture-parameterization/phase2-api-design-minion-prompt.md
@@ -1,0 +1,33 @@
+You are contributing to the PLANNING phase of a multi-agent project.
+You are NOT executing yet — you are providing your domain expertise
+to help build a comprehensive plan.
+
+## Advisory Context
+This is an advisory-only orchestration. Your contribution will feed
+into a team recommendation, not an execution plan. Focus on analysis,
+trade-offs, and recommendations rather than implementation tasks.
+
+## Project Task
+
+Evaluate whether WRL (Web Resource Ledger) should support parameterized capture requests — allowing API callers to control browser behavior during web page capture.
+
+## Your Planning Question
+
+How should capture parameters be exposed in the API? Evaluate: (1) Request body extension (add fields alongside `url`) vs. named presets vs. a separate configuration resource. (2) Which parameters should be top-level fields vs. nested objects? (3) How should the API communicate what parameters were actually applied (for evidence provenance)? (4) Backward compatibility: the current API accepts only `{ url }` -- how do we extend without breaking existing callers? (5) Should parameterized captures be a separate endpoint or the same `POST /v1/captures`? Consider that capture metadata is stored in KV and parameters may need to be recorded for evidence integrity.
+
+## Context
+
+Current API: `POST /v1/captures` accepts `{ url }` in JSON body, returns 202 with captureId. KV stores capture metadata including url, status, timestamps, artifacts, wacz info. The `performCapture()` function signature is `(env, url, ip, captureId, tenantId, renderer)`. Relevant parking lot items: "Screenshot timing / wait-for-load" and "Screenshot height cap configurability."
+
+Read the following files for additional context:
+- /Users/ben/github/benpeter/web-resource-ledger/.claude/worktrees/capture-parameterization-advisory/src/index.js
+- /Users/ben/github/benpeter/web-resource-ledger/.claude/worktrees/capture-parameterization-advisory/src/capture.js
+- /Users/ben/github/benpeter/web-resource-ledger/.claude/worktrees/capture-parameterization-advisory/src/kv.js
+- /Users/ben/github/benpeter/web-resource-ledger/.claude/worktrees/capture-parameterization-advisory/openapi.yaml
+
+## Instructions
+1. Read relevant files to understand the current state
+2. Apply your domain expertise to the planning question
+3. Identify risks, dependencies, and requirements from your perspective
+4. Return your contribution in the standard format.
+5. Write your complete contribution to /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-cfmjZO/capture-parameterization/phase2-api-design-minion.md

--- a/docs/history/nefario-reports/2026-03-16-120123-capture-parameterization/phase2-api-design-minion.md
+++ b/docs/history/nefario-reports/2026-03-16-120123-capture-parameterization/phase2-api-design-minion.md
@@ -1,0 +1,339 @@
+# Domain Plan Contribution: api-design-minion
+
+## Recommendations
+
+### 1. Same Endpoint, Extended Request Body (not presets, not a separate resource)
+
+**Recommendation: Extend `POST /v1/captures` with optional fields alongside `url`.**
+
+Evaluated three approaches:
+
+**Option A: Request body extension** (recommended)
+Add optional fields to the existing `{ url }` request body. Callers who send `{ url }` today continue working unchanged. Callers who want parameters send `{ url, viewport: { width: 1280, height: 720 }, waitUntil: "networkidle" }`.
+
+- Pros: Zero breaking changes. Single endpoint. No extra KV/storage entities. Obvious to discover (the schema tells you what's possible). Maps 1:1 to SDK methods (`client.captures.create({ url, viewport })`). Aligns with KISS and YAGNI.
+- Cons: The request body grows over time. Parameters that don't apply to the current renderer are silently ignored or require version-aware validation.
+
+**Option B: Named presets** (`POST /v1/capture-presets` to CRUD, then `POST /v1/captures` references preset by ID)
+Callers define reusable configurations ("desktop-no-cookies", "mobile-iphone-14") and reference them.
+
+- Pros: Reusable across captures. Clean request body.
+- Cons: Two-resource lifecycle to manage. Presets need CRUD endpoints, storage, tenant scoping, versioning. Massive API surface expansion for a feature that has zero demonstrated demand. Violates YAGNI hard. Presets can also drift from the server's actual capabilities -- a preset created under v1 parameters may reference fields v2 removed.
+
+**Option C: Separate configuration resource** (`POST /v1/capture-configs`)
+Similar to presets but framed as "configurations" rather than "presets."
+
+- Cons: Same as presets. Different name, same problem.
+
+**Verdict: Option A.** The project philosophy is YAGNI and Lean and Mean. Presets add a resource lifecycle, storage, and CRUD endpoints for a problem that doesn't exist yet. If preset demand emerges later, presets can reference the same parameter schema -- the body extension is a prerequisite for presets anyway. Build the foundation (body extension) without the abstraction layer (presets).
+
+### 2. Parameter Structure: Top-Level Fields for Primitives, Nested Objects for Groups
+
+**Recommended request body shape:**
+
+```json
+{
+  "url": "https://example.com",
+  "viewport": {
+    "width": 1280,
+    "height": 720
+  },
+  "waitUntil": "networkidle",
+  "maxWaitMs": 25000,
+  "cookies": [
+    {
+      "name": "consent",
+      "value": "all",
+      "domain": ".example.com",
+      "path": "/"
+    }
+  ],
+  "screenshotMaxHeight": 8000
+}
+```
+
+**Structuring rationale:**
+
+- **`url`** (top-level, required): Unchanged. The resource being captured.
+- **`viewport`** (nested object, optional): Groups width and height because they are co-dependent. A viewport makes no sense with only one dimension. Default: `{ width: 1280, height: 720 }` (current hardcoded values).
+- **`waitUntil`** (top-level enum, optional): Single value, no nesting needed. Maps to Playwright's `waitUntil` option. Values: `"load"`, `"domcontentloaded"`, `"networkidle"`. Default: `"networkidle"` (current behavior).
+- **`maxWaitMs`** (top-level integer, optional): Navigation timeout in milliseconds. Default: `25000` (current `NAV_TIMEOUT_MS`). Constrained: min 5000, max 25000. The 25s ceiling is a hard infrastructure constraint (30s `ctx.waitUntil` budget minus 5s headroom).
+- **`cookies`** (top-level array, optional): Array of cookie objects to inject before navigation. Each cookie requires `name`, `value`, `domain`; `path`, `secure`, `httpOnly`, `sameSite`, `expires` are optional. This addresses the cookie consent banner problem directly.
+- **`screenshotMaxHeight`** (top-level integer, optional): Pixel height cap. Default: `8000` (current `MAX_PAGE_HEIGHT`). Constrained: min 720, max 16000.
+
+**Fields deliberately NOT proposed at this stage:**
+
+- **`localStorage`** / **`sessionStorage`**: Higher security risk (arbitrary JS execution context), more complex to validate, no demonstrated need. Park until demand.
+- **`userAgent`**: Tempting but opens fingerprinting and spoofing concerns. Park until demand.
+- **`deviceEmulation`**: Playwright supports it, but it's a large parameter surface (deviceScaleFactor, isMobile, hasTouch). Park until someone asks.
+- **`headers`**: Custom request headers create SSRF amplification risk. Park.
+- **`javascript`**: Arbitrary JS injection is a security red line for an evidence service. Never.
+
+**Why not a single `options` or `params` envelope?** An envelope like `{ url, options: { viewport, ... } }` adds a nesting level without information gain. The top level IS the options -- `url` is just the primary one. Flat-where-possible, nested-where-semantically-grouped.
+
+### 3. Communicating Applied Parameters (Evidence Provenance)
+
+**This is the most critical API design question for an evidence product.**
+
+When a capture completes, the response and KV record must communicate exactly what parameters were applied. This serves two purposes:
+
+1. **Reproducibility**: A verifier can see the conditions under which evidence was collected.
+2. **Transparency**: If cookies were injected, the capture's evidentiary weight is different from a clean-slate capture.
+
+**Recommendation: Add an `appliedParams` object to the CaptureRecord response and to the KV record.**
+
+```json
+{
+  "id": "cap_...",
+  "status": "complete",
+  "url": "https://example.com",
+  "appliedParams": {
+    "viewport": { "width": 1280, "height": 720 },
+    "waitUntil": "networkidle",
+    "maxWaitMs": 25000,
+    "screenshotMaxHeight": 8000,
+    "cookiesInjected": 2
+  },
+  "createdAt": "...",
+  "completedAt": "...",
+  "artifacts": { ... }
+}
+```
+
+**Design decisions for `appliedParams`:**
+
+- **Always present**: Even for default-parameter captures, `appliedParams` shows the defaults that were used. This eliminates ambiguity -- a missing `appliedParams` field on old captures means "captured before parameterization was available" (not "captured with defaults").
+- **Reflects actual values, not requested values**: If the caller requests `maxWaitMs: 30000` but the server clamps to `25000`, `appliedParams` shows `25000`. The response is ground truth.
+- **Cookie values are NOT echoed**: `cookiesInjected: 2` (count) instead of the full cookie array. Cookie values may contain session tokens, PII, or secrets. The count proves cookies were injected without leaking their contents. The cookie *names* could optionally be included (`cookieNames: ["consent", "lang"]`) but values must never appear in responses or KV records.
+- **Stored in KV**: `appliedParams` is part of the capture record. This means the WACZ bundle's provenance metadata can include it, making parameterization auditable at the evidence layer.
+
+**Impact on WACZ/signing**: The `appliedParams` should be included in the WACZ `datapackage.json` metadata so that verification can confirm what parameters were used. This is a WACZ-layer concern but the API design must ensure the data is available.
+
+### 4. Backward Compatibility
+
+The current API accepts `{ url }`. The extension must be strictly additive.
+
+**Compatibility guarantees:**
+
+1. **`{ url }` continues to work identically.** No new required fields. No behavioral change for callers who don't send new fields.
+2. **Unknown fields are ignored.** The current handler does `body.url` and ignores everything else. This behavior should be formalized: the API ignores unknown fields in the request body (lenient reader pattern). This is already the de facto behavior -- the code reads `body.url` and nothing else.
+3. **`appliedParams` in response is additive.** Existing callers that destructure `{ id, statusUrl, note }` from the 202 response will not break. `appliedParams` appears in the capture record (GET), not in the 202 acceptance response.
+4. **No version bump needed.** This is a purely additive change within v1. New optional request fields, new optional response fields. The OpenAPI spec version increments (0.2.0 -> 0.3.0 semver minor) but the URL path stays `/v1/captures`.
+
+**Validation behavior for new fields:**
+
+- If a caller sends a recognized parameter with an invalid value (e.g., `viewport: { width: -1 }`), return 400 with a field-specific error.
+- If a caller sends a recognized parameter with a valid-but-clamped value (e.g., `maxWaitMs: 50000`), silently clamp and record the actual value in `appliedParams`. Do NOT reject -- clamping is friendlier and the response shows what was actually used.
+- If a caller sends an unrecognized field (e.g., `foobar: true`), ignore it silently. This is the lenient reader pattern. The alternative (reject unknown fields) is stricter but breaks forward compatibility when clients add fields the server doesn't know about yet.
+
+**Tradeoff note on strict vs. lenient parsing:** A strict parser that rejects unknown fields catches typos (`viewprot` instead of `viewport`) at the cost of breaking clients that send fields from a newer spec version. For an evidence service where parameter correctness matters, I'd lean toward **warn-but-accept**: process the capture with recognized fields only, and include an `ignoredFields` array in the 202 response if any unrecognized fields were present. This catches typos without rejecting the request.
+
+```json
+{
+  "id": "cap_...",
+  "statusUrl": "...",
+  "note": "...",
+  "ignoredFields": ["viewprot"]
+}
+```
+
+### 5. Same Endpoint, Not Separate
+
+**Recommendation: Keep `POST /v1/captures` as the single capture submission endpoint.**
+
+Arguments against a separate `POST /v1/captures/parameterized` or `POST /v1/advanced-captures`:
+
+- **Splits the capture lifecycle in two.** Status polling, retrieval, verification, listing -- all of these work on capture IDs. Having two creation endpoints for the same resource type means both produce the same IDs, stored in the same KV, listed in the same endpoint. The only difference is input validation at creation time. That's not enough to justify a separate resource.
+- **SDK awkwardness.** `client.captures.create()` vs. `client.advancedCaptures.create()`? The resource IS a capture. Parameters are input to the capture, not a different kind of capture.
+- **Precedent.** Stripe doesn't have `POST /v1/simple-charges` and `POST /v1/parameterized-charges`. The charge endpoint accepts parameters. GitHub doesn't split issues by complexity of the creation payload.
+
+**The only scenario where a separate endpoint makes sense** is if parameterized captures have fundamentally different infrastructure requirements (different queue, different timeout budget, different billing). That's not the case here -- the same Playwright session pool handles both.
+
+### 6. Request Validation Schema (for spec handoff)
+
+For the api-spec-minion, the request body schema should be:
+
+```yaml
+CaptureRequest:
+  type: object
+  required: [url]
+  properties:
+    url:
+      type: string
+      format: uri
+      description: Public http or https URL to capture.
+    viewport:
+      type: object
+      properties:
+        width:
+          type: integer
+          minimum: 320
+          maximum: 3840
+          default: 1280
+          description: Viewport width in pixels.
+        height:
+          type: integer
+          minimum: 240
+          maximum: 2160
+          default: 720
+          description: Viewport height in pixels.
+      required: [width, height]
+      description: Browser viewport dimensions. Both width and height must be provided together.
+    waitUntil:
+      type: string
+      enum: [load, domcontentloaded, networkidle]
+      default: networkidle
+      description: Navigation wait condition. "networkidle" waits for network activity to settle.
+    maxWaitMs:
+      type: integer
+      minimum: 5000
+      maximum: 25000
+      default: 25000
+      description: >
+        Maximum time in milliseconds to wait for the page to load.
+        Clamped to 25000 (infrastructure ceiling). Values above the maximum
+        are silently clamped; the actual value is reported in appliedParams.
+    cookies:
+      type: array
+      maxItems: 50
+      items:
+        type: object
+        required: [name, value, domain]
+        properties:
+          name:
+            type: string
+            maxLength: 256
+          value:
+            type: string
+            maxLength: 4096
+          domain:
+            type: string
+            maxLength: 256
+            description: >
+              Cookie domain. Must match or be a parent domain of the capture URL's host.
+              Cross-domain cookies are rejected (400).
+          path:
+            type: string
+            maxLength: 256
+            default: /
+          secure:
+            type: boolean
+            default: false
+          httpOnly:
+            type: boolean
+            default: false
+          sameSite:
+            type: string
+            enum: [Strict, Lax, None]
+            default: Lax
+      description: >
+        Cookies to inject into the browser context before navigation.
+        Cookie domain must match the target URL's domain. Injected cookies
+        are recorded in evidence metadata (count only, not values).
+    screenshotMaxHeight:
+      type: integer
+      minimum: 720
+      maximum: 16000
+      default: 8000
+      description: >
+        Maximum screenshot height in pixels. Pages taller than this are
+        clipped. Values above 16000 are silently clamped.
+```
+
+Key schema design points for specifiability:
+- Every field has explicit `minimum`, `maximum`, `default`, and `description`.
+- `viewport` requires both fields when present (partial viewport is nonsensical).
+- `cookies` array has `maxItems: 50` to bound resource consumption.
+- Cookie `domain` validation is called out in the description (server-side enforcement against the capture URL).
+- Enum values for `waitUntil` and `sameSite` are explicit.
+
+### 7. operationId Convention
+
+The existing spec uses `createCapture` for `POST /v1/captures`. This doesn't change. The operation accepts more fields; the operationId stays the same. SDK method: `client.captures.create({ url, viewport, cookies, ... })`.
+
+### 8. Error Response Design for Parameter Validation
+
+Parameter validation errors should follow the existing RFC 9457 pattern but include field-level detail:
+
+```json
+{
+  "type": "about:blank",
+  "status": 400,
+  "title": "Bad Request",
+  "detail": "One or more capture parameters are invalid.",
+  "errors": [
+    { "field": "viewport.width", "detail": "Must be between 320 and 3840." },
+    { "field": "cookies[0].domain", "detail": "Cookie domain '.evil.com' does not match capture URL host 'example.com'." }
+  ]
+}
+```
+
+This extends the current pattern (single `detail` string) with an optional `errors` array for multi-field validation. The `errors` array is an RFC 9457 extension field -- it's allowed by the spec.
+
+**Cookie domain validation deserves special attention.** A caller should not be able to inject cookies for domains other than the target URL's domain (or parent domains). This is a security boundary: injecting cookies for `.google.com` when capturing `example.com` is either a mistake or an attack. Return 400 with a clear error.
+
+
+## Proposed Tasks
+
+1. **Define the `CaptureRequest` schema** in the OpenAPI spec, replacing the current inline `{ url }` schema with the full parameterized schema. All new fields optional. (api-spec-minion)
+
+2. **Define the `AppliedParams` schema** in the OpenAPI spec, add it to `CaptureRecord` and `CaptureSummary` responses. (api-spec-minion)
+
+3. **Implement request body parsing and validation** in `handleCreateCapture()`: extract new fields, validate constraints, clamp values, reject invalid cookie domains. (implementation)
+
+4. **Pass parameters through to `performCapture()`**: extend the function signature to accept a params object instead of individual positional args. (implementation)
+
+5. **Apply parameters in `defaultRenderer()`**: use caller-provided viewport, waitUntil, cookies, maxWaitMs, screenshotMaxHeight instead of hardcoded constants. (implementation)
+
+6. **Store `appliedParams` in KV**: extend `createCapture()` to write the params, extend `completeCapture()` to preserve them, extend response builders to include them. (implementation)
+
+7. **Include `appliedParams` in WACZ metadata**: add to `datapackage.json` so evidence provenance is cryptographically bound. (implementation)
+
+8. **Update the OpenAPI spec** to document the `ignoredFields` behavior in the 202 response. (api-spec-minion)
+
+9. **Add parameter validation tests**: viewport bounds, cookie domain matching, maxWaitMs clamping, unknown field warning. (testing)
+
+
+## Risks and Concerns
+
+### Cookie Injection and Evidence Integrity (HIGH)
+
+Injecting cookies fundamentally changes the meaning of a capture. A screenshot taken after injecting an auth cookie shows a different page than an anonymous visitor would see. The API design handles this by recording `cookiesInjected` count in `appliedParams`, but the **product** must decide how to frame this to users:
+- Should captures with injected cookies carry a different verification status?
+- Should the verification page display a warning like "This capture used injected cookies"?
+- Does the WACZ bundle need a different metadata field to flag non-clean-slate captures?
+
+This is a product/evidence-integrity question, not purely an API design question. The API provides the mechanism (transparent recording); the product decides the policy.
+
+### Cookie Domain Validation is a Security Boundary (MEDIUM)
+
+The API must enforce that injected cookies only target the domain being captured (or its parent domains). Without this, a caller could inject tracking cookies for unrelated domains, which the browser would send during subresource loading. This is a form of cross-site request forgery facilitated by the API.
+
+Implementation must validate: the cookie's `domain` field must be equal to, or a parent domain of, `new URL(url).hostname`. E.g., capturing `https://www.example.com` allows cookies for `.example.com` and `.www.example.com` but not `.evil.com`.
+
+### Parameter Clamping vs. Rejection (LOW)
+
+The recommendation is to clamp out-of-range values (e.g., `maxWaitMs: 50000` becomes `25000`) rather than reject. This is developer-friendly but means the caller might not realize their requested value wasn't honored. The `appliedParams` response mitigates this, but callers who don't check `appliedParams` may be surprised. An alternative is strict rejection (400 for any out-of-range value). The choice depends on the project's error philosophy.
+
+**Recommendation**: Clamp for values that have a natural ceiling imposed by infrastructure (maxWaitMs, screenshotMaxHeight). Reject for values that are structurally wrong (negative width, non-matching cookie domain).
+
+### KV Record Size Growth (LOW)
+
+Adding `appliedParams` to every KV record increases record size. With the proposed schema, the additional JSON is roughly 200-500 bytes per record. KV values can be up to 25 MB, so this is negligible. However, if cookie injection grows (50 cookies * ~300 bytes each = 15 KB of cookie data), and we decide to store cookie names in `appliedParams`, records could grow. The current design (count only, not values) keeps this bounded.
+
+### `performCapture()` Function Signature (LOW)
+
+The current signature is `(env, url, ip, captureId, tenantId, renderer)` -- six positional parameters. Adding more is unsustainable. The implementation should refactor to accept an options object: `performCapture(env, { url, ip, captureId, tenantId, params }, renderer)`. This is an internal refactor, not an API change, but it's a prerequisite for parameter support.
+
+### Forward Compatibility of `appliedParams` (LOW)
+
+As new parameters are added in future versions, `appliedParams` grows. Old captures lack fields that new captures have. Consumers of `appliedParams` must tolerate missing fields (treat absence as "not available at capture time"). This is standard additive evolution but should be documented.
+
+
+## Additional Agents Needed
+
+- **security-minion**: Cookie injection opens new attack surface. Cookie domain validation is a security boundary. The security implications of allowing callers to control browser state in an evidence-capture service need explicit review. Also: should injected cookies be considered in rate limiting or abuse detection?
+
+- **evidence-integrity specialist** (if one exists, or product owner): The interaction between parameterization and evidence claims needs a product decision. What does "evidence" mean when the capture was taken with injected state? This is not an API question.
+
+- **api-spec-minion**: For authoring the updated OpenAPI spec with the `CaptureRequest` schema, `AppliedParams` response schema, `ignoredFields` in the 202 response, and updated examples.

--- a/docs/history/nefario-reports/2026-03-16-120123-capture-parameterization/phase2-data-minion-prompt.md
+++ b/docs/history/nefario-reports/2026-03-16-120123-capture-parameterization/phase2-data-minion-prompt.md
@@ -1,0 +1,32 @@
+You are contributing to the PLANNING phase of a multi-agent project.
+You are NOT executing yet — you are providing your domain expertise
+to help build a comprehensive plan.
+
+## Advisory Context
+This is an advisory-only orchestration. Your contribution will feed
+into a team recommendation, not an execution plan. Focus on analysis,
+trade-offs, and recommendations rather than implementation tasks.
+
+## Project Task
+
+Evaluate whether WRL (Web Resource Ledger) should support parameterized capture requests — allowing API callers to control browser behavior during web page capture.
+
+## Your Planning Question
+
+If WRL supports parameterized captures, how should capture parameters be recorded for evidence provenance? Consider: (1) Should parameters be embedded in the WACZ bundle's `datapackage.json` manifest? (2) Should they be part of the KV capture record? (3) How does parameter recording interact with the Ed25519 signature -- should the signature cover the parameters to prove the capture was made with specific settings? (4) What's the schema for recording "this capture was made with viewport 1920x1080 and cookie consent auto-accepted"? (5) What's the KV storage impact if every capture record grows to include a parameter block?
+
+## Context
+
+Current KV capture record includes: captureId, url, ip, tenantId, status, createdAt, completedAt/failedAt, artifacts (R2 keys), wacz (key, bundleHash, size). WACZ `datapackage.json` includes per-artifact SHA-256 hashes, bundleHash, and Ed25519 signature. The signature covers the bundleHash which covers the manifest. KV has a 25 MiB value limit but current records are <1 KB.
+
+Read the following files for additional context:
+- /Users/ben/github/benpeter/web-resource-ledger/.claude/worktrees/capture-parameterization-advisory/src/wacz.js
+- /Users/ben/github/benpeter/web-resource-ledger/.claude/worktrees/capture-parameterization-advisory/src/kv.js
+- /Users/ben/github/benpeter/web-resource-ledger/.claude/worktrees/capture-parameterization-advisory/src/signing.js
+- /Users/ben/github/benpeter/web-resource-ledger/.claude/worktrees/capture-parameterization-advisory/src/capture.js
+
+## Instructions
+1. Read relevant files to understand the current state
+2. Apply your domain expertise to the planning question
+3. Return your contribution in the standard format.
+4. Write your complete contribution to /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-cfmjZO/capture-parameterization/phase2-data-minion.md

--- a/docs/history/nefario-reports/2026-03-16-120123-capture-parameterization/phase2-data-minion.md
+++ b/docs/history/nefario-reports/2026-03-16-120123-capture-parameterization/phase2-data-minion.md
@@ -1,0 +1,195 @@
+# Domain Plan Contribution: data-minion
+
+## Recommendations
+
+### 1. Parameters MUST be embedded in `datapackage.json` (primary provenance record)
+
+The WACZ bundle is the self-contained evidence artifact. Anyone who receives the `.wacz` file -- whether from R2, a court exhibit, or a forwarded email -- needs to know the conditions under which the capture was produced. If parameters live only in KV, the provenance chain breaks the moment the WACZ leaves WRL's infrastructure.
+
+**Proposed schema addition to `datapackage.json`**:
+
+```json
+{
+  "profile": "data-package",
+  "wacz_version": "1.1.1",
+  "title": "WRL capture of https://example.com",
+  "software": "WRL/0.1",
+  "created": "2026-03-16T12:00:00.000Z",
+  "mainPageUrl": "https://example.com",
+  "mainPageDate": "2026-03-16T12:00:00.000Z",
+  "captureSettings": {
+    "viewport": { "width": 1920, "height": 1080 },
+    "waitUntil": "networkidle",
+    "maxScreenshotHeight": 8000,
+    "userAgent": "WRL/0.1 (Web Resource Ledger)"
+  },
+  "resources": [ ... ]
+}
+```
+
+Key design decisions in this schema:
+
+- **Field name `captureSettings`** (not `parameters` or `options`). "Settings" communicates immutable configuration used at capture time, not tunable knobs. It is declarative and past-tense in spirit.
+- **Always present, even for default-only captures**. Every WACZ should self-document its conditions. A verifier should never have to guess whether viewport was 1280x720 or some other value. Omitting the block when defaults were used creates ambiguity -- "was this captured before parameterization existed, or were defaults used?" Always writing the block eliminates that question.
+- **Flat, strongly typed fields** (not arbitrary key-value pairs). Each field has a defined type and meaning. This avoids the "attribute pattern" anti-pattern where callers can inject arbitrary metadata that future code must handle defensively. A closed schema is auditable; an open one is not.
+- **Only records settings that affect the rendered output**. Browser internals like `NAV_TIMEOUT_MS`, `MAX_SUBRESOURCES`, or `KEEP_ALIVE_MS` are operational constraints, not capture parameters. They do not belong in `captureSettings` because they do not change what the page looks like -- they change whether the capture succeeds or fails.
+
+### 2. Parameters SHOULD also be stored in the KV capture record
+
+KV serves a different access pattern: fast lookups, listing, status checks. Embedding parameters in KV enables:
+
+- **Filtering by parameters** (future): "show me all captures at 1920x1080" without fetching and unzipping WACZ bundles
+- **Status endpoint enrichment**: the status and metadata endpoints can return the parameters a capture was made with, so callers can verify their request was honored
+- **Debugging**: when a capture fails, the KV record preserves what parameters were attempted
+
+**Proposed KV record shape** (additions in `captureSettings`):
+
+```json
+{
+  "status": "pending",
+  "url": "https://example.com",
+  "ip": "203.0.113.1",
+  "captureId": "cap_abc123...",
+  "tenantId": "default",
+  "createdAt": "2026-03-16T12:00:00.000Z",
+  "captureSettings": {
+    "viewport": { "width": 1920, "height": 1080 }
+  }
+}
+```
+
+Important distinction: **KV stores only the caller-specified overrides** (sparse), while **`datapackage.json` stores the full resolved settings** (dense, including defaults). This keeps KV records lean while making the WACZ self-documenting.
+
+**KV storage impact analysis**: Current records are under 1 KB. Adding a `captureSettings` block with caller-specified overrides adds at most 200-400 bytes for a realistic parameter set (viewport, waitUntil, maybe userAgent override). Even a generous 500-byte addition brings records to ~1.5 KB, which is 0.006% of the 25 MiB KV value limit. There is no storage concern whatsoever. Even if every field in a future expanded parameter schema were specified, we would not approach 5 KB total. KV storage pricing is per-key, not per-byte-within-key, so there is no cost impact either.
+
+### 3. The Ed25519 signature MUST cover the parameters
+
+This is the critical provenance question. The current signing chain is:
+
+```
+Ed25519 signature
+  covers -> bundleHash (sha256 of canonical datapackage.json)
+    covers -> per-artifact SHA-256 hashes
+      covers -> actual WARC, CDXJ, pages.jsonl bytes
+```
+
+If `captureSettings` is added to `datapackage.json`, it is automatically included in the canonical JSON that produces `bundleHash`. **No changes to the signing code are needed.** The existing chain already provides what we need:
+
+- `canonicalize(datapackage)` will include `captureSettings` because it serializes all keys
+- `bundleHash = sha256(canonicalize(datapackage))` covers the settings
+- `signature = sign(bundleHash)` covers the hash that covers the settings
+
+This means a verifier can confirm: "this WACZ was produced by a holder of the signing key, and at production time, the operator asserted these capture settings were used." The signature proves the settings were not tampered with post-capture.
+
+**What the signature does NOT prove**: that the browser actually used those settings. The operator could lie about viewport dimensions. This is an inherent limitation -- the signature is an operator attestation, not a third-party observation. RFC 3161 timestamps (backlog item R11) strengthen the temporal claim but not the parameter claim. This limitation should be documented but is acceptable: the alternative (a third-party observer of browser state) is impractical and not how any web archiving tool works.
+
+### 4. Schema design for `captureSettings`
+
+Define a closed, versioned schema with explicit fields for each parameter category:
+
+**Tier 1 -- ship with parameterization** (settings that already exist as hardcoded constants in `capture.js`):
+
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `viewport.width` | integer | 1280 | Current hardcoded value |
+| `viewport.height` | integer | 720 | Current hardcoded value |
+| `waitUntil` | string | "networkidle" | Playwright wait strategy |
+| `maxScreenshotHeight` | integer | 8000 | `MAX_PAGE_HEIGHT` constant |
+
+**Tier 2 -- future parameters** (do NOT implement yet, but ensure the schema can accommodate):
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `locale` | string | Browser locale (e.g., "en-US") |
+| `timezone` | string | IANA timezone |
+| `cookieConsent` | string | Auto-accept strategy (enum) |
+| `userAgent` | string | Custom UA string |
+| `javascript` | boolean | JS enabled/disabled |
+| `delay` | integer | Extra wait after load (ms) |
+
+**Why not use an extension/custom namespace pattern?** This is an evidence system, not a plugin framework. Every field that affects the capture output should be known, validated, and understood by verifiers. Unknown fields cannot be meaningfully verified.
+
+**Schema versioning**: Add a `settingsVersion` field (integer, starting at 1) to `captureSettings`. When fields are added in future phases, increment the version. Verifiers that encounter an unknown version know to check for updated field definitions. This is lighter than a full JSON Schema URI approach and consistent with the existing `wacz_version` pattern.
+
+```json
+"captureSettings": {
+  "settingsVersion": 1,
+  "viewport": { "width": 1280, "height": 720 },
+  "waitUntil": "networkidle",
+  "maxScreenshotHeight": 8000
+}
+```
+
+### 5. Backward compatibility and migration
+
+Existing WACZ bundles have no `captureSettings` field. This is fine:
+
+- **Verifiers**: absence of `captureSettings` means "captured before parameterization was available; settings unknown." Verifiers should treat missing `captureSettings` the same as `settingsVersion: 0` (implicit).
+- **KV records**: existing records have no `captureSettings`. The `getCapture()` and `listCaptures()` functions already handle sparse records (they spread `existing` and overlay new fields). No migration needed.
+- **API responses**: the metadata and list endpoints should include `captureSettings` only when present. For pre-parameterization captures, the field is simply absent.
+
+No backfill of existing records is needed or desirable. The absence is the historical record.
+
+### 6. Where parameters flow through the system
+
+The data flow for parameters should be:
+
+```
+API request body         -->  KV pending record (sparse: only caller overrides)
+                         -->  capture.js (resolve defaults + overrides)
+                         -->  browser context creation (use resolved settings)
+                         -->  wacz.js buildWacz() (receives resolved settings)
+                         -->  datapackage.json captureSettings (dense: full resolved)
+                         -->  KV complete record (captureSettings added with resolved values)
+```
+
+Key point: **resolve defaults at capture time, not at API ingestion time.** If a default changes between API versions, the WACZ should record what was actually used, not what was requested. The KV pending record stores the request; the WACZ and KV complete record store the reality.
+
+This means `createCapture()` in `kv.js` writes the caller's overrides (or an empty object if no overrides), and `completeCapture()` writes the full resolved settings that `capture.js` actually used.
+
+## Proposed Tasks
+
+These are scoped to the data layer. Other agents handle API validation, browser integration, and security review.
+
+1. **Define `captureSettings` canonical schema** (data-minion): Write a schema definition (can be a JSDoc typedef or a simple validator function) that enumerates allowed fields, types, defaults, and valid ranges. This becomes the single source of truth for what parameters exist.
+
+2. **Extend `buildWacz()` to accept and embed `captureSettings`** (data-minion + edge-minion): Add a `captureSettings` parameter to `buildWacz()`. Embed it in `datapackage.json` before hashing. No changes to signing code needed -- `canonicalize()` handles it automatically.
+
+3. **Extend KV record shape** (data-minion): Add `captureSettings` to `createCapture()` (sparse, caller overrides) and `completeCapture()` (dense, resolved settings). Update JSDoc comments.
+
+4. **Update `performCapture()` to thread parameters** (edge-minion with data-minion review): `performCapture()` must accept a settings object, use it to configure the browser context, and pass the resolved settings to `buildWacz()` and `completeCapture()`.
+
+5. **Update API response projections** (api-design-minion): The metadata endpoint (`handleGetCapture`) and list endpoint (`handleListCaptures`) should surface `captureSettings` when present.
+
+6. **Extend verification to report settings** (data-minion): The verify endpoint should include `captureSettings` in the verification response so verifiers can see what conditions were asserted.
+
+7. **Write migration note** (data-minion): Document in the evolution log that pre-parameterization captures lack `captureSettings` and how verifiers should interpret this.
+
+## Risks and Concerns
+
+### Risk 1: Parameter injection into signed manifests
+
+If caller-supplied parameters are embedded verbatim into `datapackage.json` without validation, an attacker could inject large or malicious payloads that bloat the WACZ or cause parsing issues for verifiers. **Mitigation**: strict schema validation at API ingestion. Only known fields with known types and bounded ranges are accepted. This is an API-layer concern but has data-layer consequences.
+
+### Risk 2: Schema evolution under immutable signatures
+
+Once a WACZ is signed with `settingsVersion: 1`, that signature is permanent. If we later discover a field was misnamed or semantically ambiguous, we cannot fix it in existing bundles. **Mitigation**: keep the initial schema minimal (Tier 1 only -- the four fields that already exist as constants). It is easier to add fields than to rename them. YAGNI applies strongly here.
+
+### Risk 3: False precision in settings reporting
+
+Recording `viewport: { width: 1920, height: 1080 }` suggests the capture precisely used that viewport. But Playwright's actual rendering may differ due to device pixel ratio, scrollbar behavior, or CSS viewport units. **Mitigation**: document clearly that `captureSettings` records the *requested* configuration passed to the browser API, not a measurement of the rendered output. The screenshot itself is the ground truth.
+
+### Risk 4: Defaulting strategy creates implicit contract
+
+If the API accepts `{}` (no overrides) and the WACZ records the defaults, changing defaults in a future version changes what captures look like without any API change. Callers who relied on "the default viewport" may be surprised. **Mitigation**: document defaults in the API spec and consider whether defaults are versioned per API version or always "latest." My recommendation: defaults are operational and NOT promised -- the WACZ records what was used, and callers who care about specific settings should specify them explicitly.
+
+### Risk 5: KV record growth with future parameters
+
+While the current impact is negligible (analysis above), if future parameters include large values (e.g., custom CSS injection, cookie jar contents), KV records could grow significantly. **Mitigation**: the schema should define maximum sizes per field, and the KV pending record stores only caller overrides (sparse). If a future parameter is large, it can be stored in R2 and referenced by key rather than inlined in KV.
+
+## Additional Agents Needed
+
+- **api-design-minion**: Define the request body schema for capture parameters, validate inputs, design the error response for invalid parameters, update the OpenAPI spec.
+- **security-minion**: Review parameter validation for injection risks, evaluate whether any proposed parameters create new attack surface (e.g., custom User-Agent enabling impersonation, cookie consent creating interaction with third-party consent management platforms).
+- **edge-minion**: Implement the browser context configuration changes in `capture.js` -- translating validated parameters into Playwright `newContext()` options.
+- **test-minion**: Extend WACZ verification tests to confirm parameters are covered by the signature chain. Add tests for default-only captures vs. parameterized captures.

--- a/docs/history/nefario-reports/2026-03-16-120123-capture-parameterization/phase2-frontend-minion-prompt.md
+++ b/docs/history/nefario-reports/2026-03-16-120123-capture-parameterization/phase2-frontend-minion-prompt.md
@@ -1,0 +1,30 @@
+You are contributing to the PLANNING phase of a multi-agent project.
+You are NOT executing yet — you are providing your domain expertise
+to help build a comprehensive plan.
+
+## Advisory Context
+This is an advisory-only orchestration. Your contribution will feed
+into a team recommendation, not an execution plan. Focus on analysis,
+trade-offs, and recommendations rather than implementation tasks.
+
+## Project Task
+
+Evaluate whether WRL (Web Resource Ledger) should support parameterized capture requests — allowing API callers to control browser behavior during web page capture. The biggest pain point is cookie consent banners dominating every screenshot.
+
+## Your Planning Question
+
+How do the major cookie consent management platforms (OneTrust, Cookiebot, Didomi, TrustArc, custom implementations) work technically? Evaluate the feasibility and reliability of: (1) CSS-based banner hiding (inject stylesheet to `display:none` consent overlays). (2) Click-based automation (find and click accept/reject buttons via selectors). (3) CMP API calls (TCF v2 `__tcfapi()`, IAB GPP, direct CMP JavaScript APIs). (4) Pre-injection of consent cookies (set the appropriate cookies before navigation so the CMP never shows the banner). Which approach is most reliable across diverse sites? What's the failure rate for each? Can Playwright on Cloudflare Workers execute these approaches within the 25s navigation timeout?
+
+## Context
+
+Capture runs in Playwright BrowserContext on Cloudflare Browser Rendering. Navigation timeout is 25s, waitUntil is 'networkidle'. Context is fresh per capture -- no prior state. Playwright supports `context.addCookies()`, `page.addStyleTag()`, `page.evaluate()`, and `page.click()`. The capture pipeline is in src/capture.js -- the `defaultRenderer()` function is where any consent handling would execute.
+
+Read the following files for additional context:
+- /Users/ben/github/benpeter/web-resource-ledger/.claude/worktrees/capture-parameterization-advisory/src/capture.js
+
+## Instructions
+1. Read relevant files to understand the current state
+2. Apply your domain expertise to the planning question
+3. Evaluate each technical approach (CSS hiding, click automation, CMP APIs, cookie pre-injection) with specific reliability estimates
+4. Return your contribution in the standard format.
+5. Write your complete contribution to /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-cfmjZO/capture-parameterization/phase2-frontend-minion.md

--- a/docs/history/nefario-reports/2026-03-16-120123-capture-parameterization/phase2-frontend-minion.md
+++ b/docs/history/nefario-reports/2026-03-16-120123-capture-parameterization/phase2-frontend-minion.md
@@ -1,0 +1,289 @@
+# Domain Plan Contribution: frontend-minion
+
+## How Cookie Consent Management Platforms Work Technically
+
+### The Major CMPs and Their DOM Footprint
+
+**OneTrust** (market leader, ~30% of top sites using a CMP): Injects a banner container with ID `onetrust-banner-sdk` and a preference center with `onetrust-pc-sdk`. Accept button: `#onetrust-accept-btn-handler`. Reject: `#onetrust-reject-all-handler`. Consent state is stored in two cookies: `OptanonConsent` (contains category groups like `C0001:1,C0002:1`) and `OptanonAlertBoxClosed` (ISO date string). Also exposes `window.OneTrust` JS API and is TCF v2 compliant via `__tcfapi()`.
+
+**Cookiebot (Usercentrics)**: Banner in `#CookieConsentDialog` or `#CybotCookiebotDialog`. Accept button: `#CybotCookiebotDialogBodyLevelButtonLevelOptinAllowAll` (this selector changes between versions). Consent stored in `CookieConsent` cookie (JSON-encoded, contains `stamp`, `necessary`, `preferences`, `statistics`, `marketing` booleans). TCF v2 compliant. Also exposes `window.Cookiebot` API.
+
+**Didomi**: Banner container in `#didomi-host`, notice in `#didomi-notice`. Accept button: `#didomi-notice-agree-button`. Exposes `window.Didomi` API (`Didomi.setUserAgreeToAll()`). TCF v2 compliant via `__tcfapi()`. Consent stored in `didomi_token` cookie and `euconsent-v2` for TCF.
+
+**TrustArc**: Banner in `#consent-banner` or `#truste-consent-content`. Cookie settings via `#teconsent`. Consent stored across multiple cookies: `TAconsentID`, `notice_preferences`, `cmapi_cookie_privacy`, `cmapi_gtm_bl`, `notice_gdpr_prefs`. Exposes `truste.eu` API. Less standardized than others.
+
+**Quantcast Choice**: Banner in `#qc-cmp2-main` or `.qc-cmp2-container`. Consent in `euconsent_v2` cookie and `addtl_consent`. Multiple localStorage entries (`CMPList`, `noniabvendorconsent`, `_cmpRepromptHash`).
+
+**Custom implementations**: Roughly 40-50% of cookie banners are bespoke, site-specific implementations with no standardized DOM structure, cookie names, or APIs. These are the hardest to handle generically.
+
+### The TCF v2 Standard API
+
+The IAB Transparency and Consent Framework v2 defines `window.__tcfapi()`, a standardized JavaScript API that all TCF-registered CMPs must expose. Key commands:
+- `__tcfapi('getTCData', 2, callback)` -- read current consent state
+- `__tcfapi('addEventListener', 2, callback)` -- listen for consent changes
+- `__tcfapi('ping', 2, callback)` -- check CMP presence and loaded state
+
+The `__tcfapi` is read-only by design. It does not expose a "set consent" or "accept all" command. CMPs expose their own proprietary APIs for programmatic consent (e.g., `OneTrust.AllowAll()`, `Didomi.setUserAgreeToAll()`, `Cookiebot.submitCustomConsent()`), but each is different.
+
+---
+
+## Evaluation of Each Approach
+
+### Approach 1: CSS-Based Banner Hiding
+
+**How it works**: After navigation, inject a stylesheet via `page.addStyleTag()` that hides known consent overlays with `display: none !important`. Target well-known selectors: `#onetrust-banner-sdk`, `#CybotCookiebotDialog`, `#didomi-notice`, `#consent-banner`, `#qc-cmp2-main`, plus common generic patterns like `[class*="cookie-consent"]`, `[class*="consent-banner"]`, `[id*="cookie"]`.
+
+**Reliability estimate: 60-70% for known CMPs, 30-40% for custom banners**
+
+**Strengths**:
+- Trivially fast to execute (single `addStyleTag` call, <5ms)
+- Zero risk of triggering unintended side effects on the page
+- No JavaScript execution in the page context required
+- Composable: easy to maintain a growing selector list
+- Works within Cloudflare Workers constraints perfectly
+
+**Weaknesses**:
+- The banner is hidden but still in the DOM and still triggers layout effects. Many CMP banners use `position: fixed` with a full-viewport overlay (`pointer-events: all`) that blocks the page content. Hiding the banner visually does not remove the overlay, so screenshots may show content behind a transparent barrier that still receives pointer events. Some CMPs also add `overflow: hidden` to `<body>`, leaving the page content truncated.
+- Consent has NOT been given. The page may be in a degraded state: third-party scripts (analytics, embeds, social widgets, video players) that are gated on consent will not load. The captured page may be missing substantial interactive content.
+- Selector drift: CMP vendors change DOM IDs/classes between versions. A selector that works today may break silently in 3 months.
+- Does not handle the growing pattern of "cookie walls" (content hidden behind a mandatory consent interaction).
+- Custom banners (40-50% of all consent banners) have unpredictable DOM structure.
+
+**Timing within 25s budget**: Trivially fits. Adding a stylesheet after `networkidle` takes <10ms.
+
+**Verdict**: Good as a cosmetic quick-fix for screenshots specifically, but produces a misleading capture -- the page is not in the state a real user would see after interacting with consent. Not suitable as a primary strategy if capture fidelity matters.
+
+### Approach 2: Click-Based Automation
+
+**How it works**: After navigation and `networkidle`, detect which CMP is present by checking for known DOM elements, then click the appropriate accept/reject button using Playwright's `page.click()`.
+
+**Reliability estimate: 70-80% for known CMPs, 15-25% for custom banners**
+
+**Strengths**:
+- Simulates real user behavior; consent IS actually granted
+- Page enters its fully-consented state (all scripts fire, embeds load)
+- Well-understood pattern -- projects like `@duckduckgo/autoconsent` and `Consent-O-Matic` maintain rulesets for 200+ CMPs
+- The captured page represents what a consenting user would see
+
+**Weaknesses**:
+- Button selectors are fragile. CMP vendors change button text, IDs, and class names between minor versions. `#CybotCookiebotDialogBodyLevelButtonLevelOptinAllowAll` is representative of how unstable these selectors are.
+- Timing sensitivity: the banner may not be in DOM at `networkidle`. Many CMPs lazy-load their banner via a separate script, so there can be a 500ms-2s delay after initial page load. This requires `waitForSelector` with a timeout, adding to the 25s budget.
+- Click may trigger animations (banner slide-out) that take 300-500ms before the page is "clean" for screenshot. Need to wait after clicking.
+- iframes: some CMPs (TrustArc, some Quantcast configs) render in cross-origin iframes, making click targeting difficult or impossible via top-level `page.click()`.
+- Regional variation: the same CMP may show different banners (or no banner) depending on the visitor's geolocation. Cloudflare Workers egress from specific regions, which may or may not trigger a banner.
+- Multiple modals: some sites chain consent (first a cookie wall, then a newsletter popup, then a notification permission). Handling the full sequence is complex.
+- Custom banners require site-specific selectors or heuristic text matching ("Accept", "I agree", "Got it").
+
+**Timing within 25s budget**: Marginal. Assuming navigation takes 5-15s for a typical page, that leaves 10-20s. Banner detection (`waitForSelector` with 3-5s timeout) + click + post-click settle (500ms-1s) totals 4-6s, fitting within budget for most pages. For slow pages that approach the 25s navigation timeout, there is no headroom.
+
+**Verdict**: Most accurate approach when it works, but maintenance burden is high. The existing open-source rulesets (`autoconsent`, `Consent-O-Matic`) are the only viable path -- building this from scratch would be prohibitive.
+
+### Approach 3: CMP API Calls via `page.evaluate()`
+
+**How it works**: After navigation, use `page.evaluate()` to call CMP-specific JavaScript APIs: `OneTrust.AllowAll()`, `Didomi.setUserAgreeToAll()`, `Cookiebot.submitCustomConsent(preferences, statistics, marketing)`, etc.
+
+**Reliability estimate: 80-85% for TCF-compliant CMPs, 0% for custom banners**
+
+**Strengths**:
+- Most "correct" approach -- calls the CMP's own public API
+- No DOM selector fragility; API methods are more stable than DOM IDs
+- Consent is properly registered in the CMP's internal state
+- Triggers all downstream effects (cookie setting, script unblocking)
+- Fast execution (<50ms per API call)
+
+**Weaknesses**:
+- Every CMP has a different API. There is no universal "accept all" command.
+- The `__tcfapi` standard is read-only. There is no TCF standard for *setting* consent -- each CMP implements its own proprietary method.
+- CMP JavaScript may not be loaded at `networkidle`. Many CMPs load asynchronously and may need additional waiting.
+- Race condition: calling `OneTrust.AllowAll()` before OneTrust's internal state is initialized can silently fail or throw.
+- Zero coverage for custom banners (no JS API to call).
+- API method names can change between CMP versions (though less frequently than DOM selectors).
+- Need to detect WHICH CMP is present before knowing which API to call.
+
+**Timing within 25s budget**: Fits well. API detection (check `window.OneTrust`, `window.Didomi`, etc.) is instant. API call is <50ms. Post-call page settle may take 500ms-1s as gated scripts fire.
+
+**Verdict**: More reliable than click automation for the CMPs it covers, but requires maintaining a map of CMP-to-API-call. Combined with CMP detection, this is a strong approach for the major platforms.
+
+### Approach 4: Pre-Injection of Consent Cookies
+
+**How it works**: Before navigation, use `context.addCookies()` to set the cookies that each CMP checks on page load. If the consent cookies are already present and valid, the CMP reads them, skips showing the banner, and immediately unblocks gated scripts.
+
+**Reliability estimate: 85-90% for known CMPs (when cookie format is correct), 0% for custom banners**
+
+**Specific cookie requirements by CMP**:
+
+| CMP | Cookies Required | Format Complexity |
+|-----|------------------|-------------------|
+| OneTrust | `OptanonConsent`, `OptanonAlertBoxClosed` | Medium: `groups=C0001:1,C0002:1,...` URL-encoded; date ISO string |
+| Cookiebot | `CookieConsent` | Medium: JSON with `stamp`, `necessary`, `preferences`, `statistics`, `marketing` |
+| TrustArc | `TAconsentID`, `notice_preferences`, `cmapi_cookie_privacy`, `cmapi_gtm_bl`, `notice_gdpr_prefs` | High: 5 cookies with interdependent values |
+| Quantcast | `euconsent_v2`, `addtl_consent` + localStorage | High: TCF consent string encoding + localStorage entries |
+| Didomi | `didomi_token`, `euconsent-v2` | High: proprietary token format + TCF string |
+
+**Strengths**:
+- Fastest approach: cookies are set before navigation, so the page loads in its fully-consented state from the start. No post-navigation interaction needed.
+- No DOM interaction, no JavaScript execution in page context.
+- The CMP never shows a banner, so there is zero visual artifact in screenshots.
+- No timing issues -- consent is established before the CMP script even loads.
+- Perfectly compatible with `context.addCookies()` in the existing pipeline.
+
+**Weaknesses**:
+- **Cookie format fragility is the critical risk.** Each CMP has its own cookie format, and these formats change between versions. OneTrust's `OptanonConsent` contains a versioned format with group IDs that are site-specific (the site owner configures which categories exist). A generic `C0001:1,C0002:1,C0003:1,C0004:1` works for most sites but not all.
+- **Domain scoping**: `context.addCookies()` requires specifying the cookie domain. For the target URL this is straightforward, but some CMPs set cookies on a different subdomain or path.
+- **localStorage requirements**: Quantcast Choice, LiveRamp, and Usercentrics v2/v3 store consent in localStorage, not cookies. `context.addCookies()` cannot set localStorage. Would need `page.evaluate()` + `page.goto('about:blank')` + set localStorage + navigate to URL, which adds complexity.
+- **Site-specific category IDs**: OneTrust group codes are configured per-site. The "accept all" cookie value for Site A may not match Site B's category structure. A generic all-categories-accepted value works in ~90% of cases but not always.
+- **TCF consent string**: For TCF v2 CMPs, the `euconsent-v2` cookie contains a Base64-encoded consent string with a specific binary format (vendor list version, purpose consents bitmap, vendor consents bitmap). Generating a valid TC string requires knowing the current Global Vendor List version. An outdated string may be rejected by the CMP, causing it to show the banner anyway.
+- **Validation on load**: Some CMPs validate cookie freshness (timestamp, version hash). Stale or structurally invalid cookies trigger a re-prompt.
+- Zero coverage for custom banners.
+
+**Timing within 25s budget**: Best of all approaches. Zero additional time -- cookies are set before `page.goto()`, within the existing pipeline.
+
+**Verdict**: Highest reliability for the specific CMPs it supports, but the maintenance burden of keeping cookie formats current is significant. Best suited for a curated, limited set of major CMPs rather than a comprehensive solution.
+
+---
+
+## Comparative Analysis
+
+| Criterion | CSS Hiding | Click Automation | CMP API Calls | Cookie Pre-injection |
+|-----------|-----------|------------------|---------------|---------------------|
+| Known CMP reliability | 60-70% | 70-80% | 80-85% | 85-90% |
+| Custom banner coverage | 30-40% | 15-25% | 0% | 0% |
+| Consent actually granted | No | Yes | Yes | Yes |
+| Page in consented state | No | Yes | Yes | Yes |
+| Time within 25s budget | Trivial | Marginal | Good | Best |
+| Selector/format fragility | Medium | High | Low-Medium | Medium-High |
+| Maintenance burden | Low | High | Medium | Medium-High |
+| Implementation complexity | Very Low | High | Medium | Medium |
+| Open-source library support | Minimal | Strong (autoconsent) | Partial | Minimal |
+
+---
+
+## Recommendations
+
+### 1. Do not build a general-purpose consent handler -- it is a maintenance trap
+
+The fundamental tension: every approach that actually grants consent (and thus produces a faithful capture) requires CMP-specific knowledge that drifts over time. This is a maintenance treadmill, not a one-time implementation. The existing open-source projects (`@duckduckgo/autoconsent` with 200+ CMP rules, `Consent-O-Matic` with similar coverage) each have teams dedicated to keeping rulesets current. WRL should not compete with them.
+
+### 2. Recommended architecture: layered, caller-controlled, opt-in
+
+The question frames consent handling as a WRL responsibility. I recommend reframing it as a **caller-controlled capture parameter** instead. The API caller knows their target sites and can specify what consent strategy to apply:
+
+**Layer 0 (default, current behavior)**: No consent handling. Capture the page as-is. Banner visible if present. This is the honest baseline and should remain the default -- it captures what an unauthenticated, first-visit user sees.
+
+**Layer 1 (CSS cosmetic hiding)**: Caller sends `"consentHandling": "hide"`. WRL injects a stylesheet that hides known consent overlays via a curated selector list. Fast, safe, no side effects. The banner is hidden in the screenshot but consent is NOT granted. Appropriate when the caller wants a "clean" screenshot and does not care about consent state. Trivial to implement: ~20 lines of CSS, injected after `networkidle` via `page.addStyleTag()`.
+
+**Layer 2 (caller-provided cookies)**: Caller sends `"cookies": [...]` with an array of cookie objects matching Playwright's `addCookies()` format. WRL sets them via `context.addCookies()` before navigation. The caller is responsible for knowing which cookies their target site needs. This is the most flexible and maintainable approach because it pushes site-specific knowledge to the caller, who already has it (they know which sites they're capturing).
+
+**Layer 3 (future, not MVP)**: Integrate `@duckduckgo/autoconsent` or similar. This is the only way to get broad CMP coverage without caller-provided cookies. But it adds a dependency (~50-80KB), increases execution time, and requires ongoing maintenance. Evaluate only if Layer 2 proves insufficient.
+
+### 3. For the capture pipeline specifically
+
+The insertion point in `defaultRenderer()` is clean:
+
+```javascript
+// Before page.goto() -- for cookie pre-injection (Layer 2)
+if (options.cookies?.length) {
+  await context.addCookies(options.cookies);
+}
+
+await page.goto(url, { timeout: NAV_TIMEOUT_MS, waitUntil: 'networkidle' });
+
+// After goto, before screenshot -- for CSS hiding (Layer 1)
+if (options.consentHandling === 'hide') {
+  await page.addStyleTag({ content: CONSENT_HIDE_CSS });
+}
+```
+
+This requires `defaultRenderer` to accept an `options` parameter, which means `performCapture` must thread options from the API request body through to the renderer. The renderer injection pattern already supports this -- it is just a function signature change.
+
+### 4. CSS hiding selector list (for Layer 1)
+
+A minimal, high-coverage selector list:
+
+```css
+/* OneTrust */
+#onetrust-banner-sdk,
+#onetrust-consent-sdk,
+/* Cookiebot / Usercentrics */
+#CybotCookiebotDialog,
+#CookieConsentDialog,
+/* Didomi */
+#didomi-notice,
+#didomi-notice-backdrop,
+/* TrustArc */
+#consent-banner,
+#truste-consent-content,
+#truste-consent-track,
+/* Quantcast */
+.qc-cmp2-container,
+#qc-cmp2-main,
+/* Osano */
+.osano-cm-dialog,
+/* Generic patterns */
+[class*="cookie-consent"],
+[class*="consent-banner"],
+[class*="cookie-banner"],
+[id*="cookie-consent"],
+[id*="gdpr"],
+/* Overlay backdrops */
+.onetrust-pc-dark-filter,
+#didomi-notice-backdrop {
+  display: none !important;
+  visibility: hidden !important;
+}
+/* Restore body scroll that CMPs often lock */
+body.ot-overflow-hidden,
+body[style*="overflow: hidden"] {
+  overflow: auto !important;
+}
+```
+
+This covers the top 5 CMPs (OneTrust, Cookiebot, Didomi, TrustArc, Quantcast) plus common generic patterns. Estimated coverage: 60-70% of cookie banners encountered in the wild.
+
+---
+
+## Proposed Tasks
+
+1. **API schema extension** -- Add optional `consentHandling` enum (`"none"` | `"hide"`) and optional `cookies` array to the `POST /v1/captures` request body. Validate cookie objects against Playwright's schema (name, value, domain required; path, expires, httpOnly, secure, sameSite optional). Default: `"none"`.
+
+2. **Capture pipeline plumbing** -- Thread the new options from `handleCreateCapture()` through `performCapture()` to `defaultRenderer()`. Modify `defaultRenderer` signature to accept an options object.
+
+3. **CSS consent hiding** -- Create a `consent-hide.css` module exporting the curated selector string. Inject via `page.addStyleTag()` after `networkidle` when `consentHandling === 'hide'`.
+
+4. **Cookie pre-injection** -- Call `context.addCookies()` before `page.goto()` when `cookies` array is provided. Validate cookie count and total size (prevent abuse).
+
+5. **Documentation** -- Document the new parameters in the API spec with examples for OneTrust, Cookiebot, and Didomi cookie formats.
+
+---
+
+## Risks and Concerns
+
+### Security: Caller-provided cookies require validation
+
+Cookies are set in the browser context that navigates to the target URL. If a caller provides cookies with `domain: ".evil.com"` and the target URL is `example.com`, Playwright's `addCookies()` will set them -- but they will only be sent to `evil.com`, not `example.com`. This is browser-standard behavior and is not a security risk per se, but it could be confusing. Consider restricting cookie domains to match the target URL's domain.
+
+More importantly: cookies with `httpOnly: false` could theoretically be read by page JavaScript, and if the target page is hostile, it could exfiltrate those cookie values. Since WRL already captures untrusted URLs, this is within the existing threat model, but document it.
+
+### Cookie size and count limits
+
+Set reasonable limits to prevent abuse: max 20 cookies, max 4KB per cookie value, max 50KB total cookie payload. These are well within Playwright's capabilities and prevent callers from using the cookie parameter as an arbitrary data channel.
+
+### GDPR/legal implications of consent automation
+
+Automatically accepting cookies on behalf of the API caller has legal implications. WRL is capturing a public web page -- it is not acting as a user who has rights under GDPR. But the page's behavior changes when consent is granted (tracking scripts fire, third-party beacons load). Document that cookie pre-injection and consent handling affect the capture's fidelity and legal character.
+
+### `autoconsent` dependency risk (if Layer 3 is pursued)
+
+`@duckduckgo/autoconsent` is designed for browser extensions, not Workers. It requires DOM access via content scripts. Using it with Playwright requires either:
+- Injecting the autoconsent bundle into the page via `page.addScriptTag()` (works, but adds 50-80KB to every page load)
+- Running autoconsent's detection logic on the Worker side and sending page.evaluate commands (requires significant adaptation)
+
+Either path adds complexity and a dependency on a project with its own release cadence. Do not pursue for MVP.
+
+---
+
+## Additional Agents Needed
+
+- **api-design-minion**: Design the request body schema for `consentHandling` and `cookies` parameters, including validation rules, error responses, and OpenAPI spec updates.
+- **security-minion**: Review the threat model for caller-provided cookies being set in a browser context navigating to untrusted URLs. Evaluate cookie domain restriction policy.
+- **data-minion**: If capture records should track which consent handling strategy was used (for auditability and fidelity metadata), advise on KV schema changes.

--- a/docs/history/nefario-reports/2026-03-16-120123-capture-parameterization/phase2-gru-prompt.md
+++ b/docs/history/nefario-reports/2026-03-16-120123-capture-parameterization/phase2-gru-prompt.md
@@ -1,0 +1,30 @@
+You are contributing to the PLANNING phase of a multi-agent project.
+You are NOT executing yet — you are providing your domain expertise
+to help build a comprehensive plan.
+
+## Advisory Context
+This is an advisory-only orchestration. Your contribution will feed
+into a team recommendation, not an execution plan. Focus on analysis,
+trade-offs, and recommendations rather than implementation tasks.
+
+## Project Task
+
+Evaluate whether WRL (Web Resource Ledger) should support parameterized capture requests — allowing API callers to control browser behavior during web page capture.
+
+## Your Planning Question
+
+Is capture parameterization the right investment for WRL's current stage? Consider: (1) The competitive landscape -- how do archive.org's Wayback Machine, Stillio, Pagefreezer, URLBox, and similar services handle cookie consent and parameterization? (2) Is the "evidence" positioning strengthened or weakened by allowing caller-controlled parameters? (3) Should WRL invest in cookie consent handling specifically, or in general parameterization, or neither? (4) Are there emerging standards or tools (e.g., consent-o-matic, I Don't Care About Cookies browser extension approaches) that could be leveraged? (5) What does the market signal say -- is cookie consent handling a table-stakes feature or a differentiator?
+
+## Context
+
+WRL roadmap has three acts: "Solid Foundation" (near-term), "Evidence-Grade" (mid-term), "Infrastructure" (longer-horizon). Act 1 is still in progress (R2-R9 remaining). The product-marketing-minion previously recommended "evidence" over "archival" positioning. MCP server is in Act 3. Cookie consent is not currently in any backlog act. Cloudflare Browser Rendering provides Playwright API but runs in a Workers environment with constraints (30s budget, no persistent state, gVisor sandbox).
+
+Read the following files for additional context:
+- /Users/ben/github/benpeter/web-resource-ledger/.claude/worktrees/capture-parameterization-advisory/docs/backlog.md
+- /Users/ben/github/benpeter/web-resource-ledger/.claude/worktrees/capture-parameterization-advisory/CLAUDE.md
+
+## Instructions
+1. Read relevant files to understand the current state
+2. Apply your domain expertise to the planning question
+3. Return your contribution in the standard format.
+4. Write your complete contribution to /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-cfmjZO/capture-parameterization/phase2-gru.md

--- a/docs/history/nefario-reports/2026-03-16-120123-capture-parameterization/phase2-gru.md
+++ b/docs/history/nefario-reports/2026-03-16-120123-capture-parameterization/phase2-gru.md
@@ -1,0 +1,192 @@
+## Domain Plan Contribution: gru
+
+### TL;DR
+
+Cookie consent handling is table-stakes for screenshot-focused services but operates in fundamental tension with WRL's evidence positioning. The competitive landscape splits cleanly: screenshot APIs (URLBox, ScreenshotOne) offer extensive parameterization because they are *rendering* tools; evidence/archival services (Wayback Machine, Page Vault, Pagefreezer) deliberately limit caller control because they are *attestation* tools. WRL should pursue a narrow, two-tier approach: (1) a server-controlled cookie consent dismissal feature (no caller injection) as a [should] parking lot item, and (2) defer general parameterization entirely. The investment priority is wrong for Act 1, manageable in Act 2, and the right time is only when a user reports cookie banners as a blocking problem.
+
+---
+
+### Recommendations
+
+#### 1. Ring Classification: Capture Parameterization -- Hold
+
+General capture parameterization (caller-provided cookies, custom JS injection, arbitrary headers, session state) is **Hold** for WRL.
+
+**Rationale across the six hype filters:**
+
+1. **Production usage**: No evidence-grade capture service offers caller-controlled JS injection or arbitrary cookie injection. Page Vault, Pagefreezer/WebPreserver, and forensic tools like FAW (Forensics Acquisition of Websites) deliberately operate with controlled browser state. The services that offer extensive parameterization (URLBox, ScreenshotOne, Scrnify) are screenshot/rendering APIs -- they compete on visual fidelity, not evidentiary integrity. They do not sign captures, do not provide verification endpoints, and do not claim legal admissibility.
+
+2. **Community velocity**: No standard or protocol exists for "parameterized evidence capture." The web archiving community (IIPC, Webrecorder, WACZ spec) does not address parameterization because the standard assumption is that archival captures reflect the public-facing state of a URL.
+
+3. **Second-order signals**: Job postings and conference tracks for "digital forensics" and "e-discovery" emphasize chain-of-custody and reproducibility -- not customization. The legal-tech market (which product-marketing-minion identified as WRL's strongest wedge) values attestation of what *was* publicly visible, not what *could be rendered* under specific conditions.
+
+4. **Failure stories**: URLBox documents edge cases where cookie handling caused rendering errors (secure attribute cookies on non-secure sites). ScreenshotOne documents that `block_cookie_banners` uses CSS `display: none !important` -- a cosmetic hack that can break page layout. These are acceptable trade-offs for a screenshot API but unacceptable for an evidence tool where visual accuracy is the entire value proposition.
+
+5. **Benchmark independence**: No benchmarks exist for parameterized capture quality. Each service defines its own success criteria.
+
+6. **Revenue signal**: Screenshot APIs charge $0.01-0.05 per capture. Evidence-grade services (Page Vault, Pagefreezer) charge per-seat or enterprise pricing -- 10-100x higher. The value is in the attestation, not the rendering flexibility.
+
+**The core tension**: Every parameter a caller controls is a parameter they could use to fabricate evidence. If a caller injects cookies to simulate a logged-in state, the capture no longer proves what was publicly visible -- it proves what was visible *under conditions the caller chose*. This is not inherently invalid (capturing a personalized view has legitimate uses), but it fundamentally changes the evidentiary claim. An evidence tool must be transparent about this distinction or it undermines its core positioning.
+
+#### 2. Ring Classification: Server-Controlled Cookie Consent Dismissal -- Assess
+
+A server-controlled (not caller-controlled) mechanism to dismiss cookie consent banners is **Assess** ring.
+
+**Rationale:**
+
+- Cookie consent banners are a genuine fidelity problem. The prompt correctly identifies this as the single biggest screenshot quality issue. Every capture of a European website (and increasingly, global sites) shows a consent overlay obscuring the actual content.
+- The competitive landscape confirms this is a recognized problem. Stillio hides cookie banners by default. URLBox offers `hide_cookie_banners` and `click_accept`. ScreenshotOne offers `block_cookie_banners`. Even the Wayback Machine suffers from this (users report persistent consent popups on archived pages).
+- Mature open-source tooling exists. DuckDuckGo's `autoconsent` library (MPLv2, 1,464 commits, active development) provides rule-based CMP detection and dismissal for 100+ consent management platforms including OneTrust, Cookiebot, TrustArc, and Quantcast. Apify has published `idcac-playwright`, a compiled version of "I Don't Care About Cookies" specifically for Playwright integration. Consent-O-Matic covers 200+ CMPs with auto-updating rule lists. The npm package `playwright-autoconsent` wraps DuckDuckGo's library for direct Playwright use.
+- The critical distinction: server-controlled means WRL decides how to handle consent (dismiss/reject all, per its own policy) and **records** this action in the capture metadata. The caller does not choose. This preserves the attestation model -- WRL is saying "we captured this URL and we dismissed cookie consent banners using method X" -- not "the caller told us to click specific buttons."
+
+#### 3. Strategic Assessment: Evidence Positioning Impact
+
+Parameterization and evidence positioning are in tension, not alignment. The product-marketing-minion's recommendation to use "evidence" over "archival" is correct and should inform this decision:
+
+**Strengthened by clean-slate default**: The fact that WRL captures with a fresh browser context, no prior state, no cookies, no login -- this is a *feature* for evidence. It means captures reflect the anonymous public view. This is what a neutral third party would see. This is what courts and regulators expect. Every evidence-grade capture tool (Page Vault, FAW, Forensic OSINT) operates this way.
+
+**Weakened by caller-controlled parameters**: If WRL accepts caller-provided cookies, JS, or session state, captures become attestations of a *constructed* state. The verification endpoint can confirm the bundle was not tampered with, but it cannot confirm the captured content was what a neutral visitor would have seen. This opens the door to challenges: "The opposing party injected cookies to make the page show X, but a normal visitor would see Y."
+
+**The metadata transparency approach**: If parameterization is ever added, every parameter must be recorded in the WACZ manifest and visible in the verification result. The verification page should display "This capture was made with custom cookies: [list]" or "Cookie consent was auto-dismissed using autoconsent v1.2.3." This preserves integrity by making the capture conditions explicit and verifiable.
+
+#### 4. Competitive Landscape Analysis
+
+| Service | Category | Cookie Handling | General Parameterization | Evidence Claims |
+|---------|----------|----------------|-------------------------|-----------------|
+| **Wayback Machine** | Archival | None (banners persist in archives) | None | None (no integrity proof) |
+| **Page Vault** | Legal evidence | Not documented (captures "exactly as it appears") | Limited (capture what browser shows) | Strong (FRE 901(b)(9), digital signing, timestamping) |
+| **Pagefreezer** | Compliance archival | Not documented | Limited | Strong (tamper-proof archives for compliance/eDiscovery) |
+| **Stillio** | Monitoring screenshots | Hides banners by default; IP whitelisting option | Element hiding, wait conditions | Weak (screenshots, no cryptographic proof) |
+| **URLBox** | Screenshot API | `hide_cookie_banners`, `click_accept`, custom cookies | Extensive (60+ options: JS, CSS, headers, proxy, geo, clicks) | None |
+| **ScreenshotOne** | Screenshot API | `block_cookie_banners`, custom cookies | Extensive (JS, CSS, headers, selectors, proxy, geo) | None |
+| **FAW** | Forensic capture | Captures as-is | Minimal | Strong (forensic acquisition with third-party validation) |
+| **WRL (current)** | Evidence capture | None (banners appear) | None | Moderate (Ed25519 signing, WACZ, no TSA yet) |
+
+**Key insight**: There is a clean market segmentation. Services that offer extensive parameterization do not make evidence claims. Services that make evidence claims offer minimal parameterization. WRL is positioned in the evidence category. Adding extensive parameterization would push it toward the screenshot API category where it cannot compete on features (URLBox has a decade head start and 60+ options) and would not need to compete (WRL's value is attestation, not rendering).
+
+#### 5. Cookie Consent Technical Landscape
+
+Three viable approaches exist for automated cookie consent handling:
+
+**Approach A: CSS hiding (`display: none !important`)**
+- Used by: ScreenshotOne (`block_cookie_banners`), Stillio
+- Pro: Simple, no interaction with page logic
+- Con: Hides but does not dismiss; consent state remains "undecided"; some CMPs overlay the entire page with a non-scrollable backdrop; page content may still be partially obscured; "I Don't Care About Cookies" notes it "mostly blocks or hides" banners
+- Evidence impact: Screenshot shows content without banner, but the banner exists in the HTML capture. Inconsistency between artifacts.
+
+**Approach B: CMP detection and click-to-dismiss**
+- Used by: URLBox (`click_accept`), DuckDuckGo autoconsent, Consent-O-Matic
+- Pro: Properly dismisses consent; page reaches its "after consent" state; 100-200+ CMPs supported
+- Con: Requires maintaining CMP rule lists; "accept" vs. "reject" is a policy choice; some CMPs require multi-step interaction; iframe and shadow DOM piercing needed for some implementations
+- Evidence impact: Capture shows the page in its post-consent state. This is what most human visitors see. Must be recorded in metadata.
+
+**Approach C: Cookie injection (pre-set consent cookies)**
+- Used by: Playwright `context.addCookies()` approach; documented at programmablebrowser.com
+- Pro: Fastest; no page interaction; works for known CMPs
+- Con: Cookie names and values are CMP-specific and change frequently; maintaining a cookie database is brittle; consent state may not match what the CMP would set via its own UI
+- Evidence impact: Introduces caller-provided state into the browser context. Weakest from an evidence perspective.
+
+**Recommendation**: Approach B (CMP detection and dismiss) is the right choice for WRL if this feature is ever built. It results in captures that show what a consenting visitor sees, the action is auditable and recordable in metadata, and mature open-source tooling (DuckDuckGo autoconsent) handles the CMP detection. The consent action should be "reject all" by default -- this minimizes tracking state and keeps the browser context closest to a neutral observer.
+
+#### 6. Cloudflare Browser Rendering Constraints
+
+Important platform constraints for any consent handling implementation:
+
+- **30-second `ctx.waitUntil` budget**: Consent dismissal adds time. DuckDuckGo's autoconsent typically completes in 1-3 seconds but some CMPs require multiple interaction steps. With 25s already allocated to navigation (`NAV_TIMEOUT_MS`), adding consent handling eats into the 5s headroom. This may require reducing `NAV_TIMEOUT_MS` or waiting for the Queue migration (R16) to remove the 30s ceiling.
+- **No persistent browser extensions**: Cloudflare Browser Rendering does not support loading browser extensions (no .crx files). Consent-O-Matic and "I Don't Care About Cookies" cannot be loaded as extensions. The autoconsent library must be injected via `page.evaluate()` or `context.addInitScript()`.
+- **`serviceWorkers: 'block'`**: WRL already blocks service workers. This is correct and should remain -- some CMPs register service workers, and these would persist across contexts in a session-reused browser.
+- **gVisor sandbox**: No filesystem access, no extension installation directory. All consent logic must be injectable JavaScript.
+
+#### 7. What WRL Should Do
+
+**Now (Act 1)**: Nothing. Finish the Solid Foundation items. Cookie consent is not blocking any current use case because there are no external users reporting it as a problem. YAGNI applies.
+
+**Add to Parking Lot**: "Server-controlled cookie consent dismissal" with activation trigger: "When a user reports cookie consent banners as a blocking problem for capture quality, OR when the Web UI (R17) ships and screenshots are visible to non-technical users."
+
+**When triggered, the implementation should**:
+1. Integrate DuckDuckGo's `autoconsent` library via `context.addInitScript()` injection
+2. Default behavior: reject-all (minimal tracking, closest to neutral observer)
+3. Record the consent action in WACZ metadata: `captureOptions.consentHandling: "autoconsent-reject"` (or `"none"` for current default behavior)
+4. Display consent handling status on the verification page: "Cookie consent banners were automatically dismissed (reject all) using autoconsent"
+5. Make it a server-wide configuration (operator chooses the policy), not a per-request caller parameter
+6. Scope: [S] to [M] -- autoconsent injection is ~50 lines; the metadata and verification UI changes are the bulk of the work
+
+**Do not build**:
+- Caller-provided cookie injection
+- Caller-provided JavaScript injection (severe security risk: arbitrary code execution in the browser context)
+- Caller-provided header overrides
+- Viewport parameterization (the current 1280x720 is a reasonable default; make it a parking lot item with trigger "when a user reports viewport as a problem")
+- Wait condition parameterization (current `networkidle` is the right default; parking lot with trigger "when a user reports incomplete renders")
+
+---
+
+### Proposed Tasks
+
+No implementation tasks -- this is an advisory. Backlog items to create:
+
+#### Backlog Item 1: Server-Controlled Cookie Consent Dismissal
+**Where**: Parking Lot > Capture Fidelity
+**Tier**: [should]
+**Condition**: When a user reports cookie consent banners as a blocking problem for capture quality, OR when Web UI (R17) ships
+**Scope**: S-M
+**Dependencies**: None technically, but should wait for Act 1 completion
+**Notes**: Use DuckDuckGo autoconsent via addInitScript(). Server policy (reject-all), not caller parameter. Record in WACZ metadata. Display on verification page.
+
+#### Backlog Item 2: Viewport Parameterization
+**Where**: Parking Lot > Capture Fidelity
+**Tier**: [consider]
+**Condition**: When a user reports viewport size as a problem
+**Notes**: Current 1280x720 is reasonable. If added, offer presets (desktop/mobile/tablet), not arbitrary dimensions. Record viewport in WACZ metadata.
+
+#### Backlog Item 3: Capture Options Metadata Schema
+**Where**: Parking Lot > Capture Fidelity
+**Tier**: [consider]
+**Condition**: When any capture parameterization feature ships
+**Notes**: Define a `captureOptions` object in the WACZ manifest that records all non-default capture conditions. This is prerequisite infrastructure for any parameterization. Must be visible in verification results.
+
+---
+
+### Risks and Concerns
+
+1. **Cookie consent dismissal reliability is inherently fragile.** CMPs update their markup frequently. DuckDuckGo's autoconsent has 1,464 commits -- that is not a sign of stability; it is a sign of continuous adaptation to a moving target. Any consent handling in WRL will occasionally fail, producing captures with banners despite the feature being enabled. Mitigation: make consent handling best-effort, not guaranteed. Record whether consent dismissal succeeded or failed. Never block a capture because consent dismissal failed.
+
+2. **"Reject all" vs. "Accept all" is a policy decision with legal implications.** Rejecting all cookies means the captured page may differ from what most visitors see (many visitors accept cookies). Accepting all cookies means the capture includes tracking state, which may be undesirable for an evidence tool. There is no neutral choice -- both are policy positions. Recommendation: default to reject-all (closest to minimal-state observer), but make it operator-configurable (reject-all / accept-all / off).
+
+3. **Parameterization scope creep risk.** Once the door is opened to "the caller can control X," every user will request control over Y. The backlog already has "screenshot height cap configurability" and "wait-for-load" in the parking lot. Each parameter individually seems small, but collectively they transform WRL from an evidence service into a screenshot API. Mitigation: every parameterization request must pass the test: "Does this strengthen or weaken the evidence claim?" Server-controlled features that improve capture quality pass. Caller-controlled features that change capture content fail.
+
+4. **Autoconsent library size and Workers bundle limits.** DuckDuckGo's autoconsent includes rules for 100+ CMPs. The compiled JavaScript may be significant. Cloudflare Workers have a 10MB script size limit (paid plan). The autoconsent library needs to be evaluated for bundle size impact. Mitigation: evaluate actual bundle size before committing. If too large, consider a curated subset of the most common CMPs (OneTrust, Cookiebot, TrustArc cover ~70% of sites).
+
+5. **30-second budget pressure.** Adding consent handling to the existing 25s navigation + 5s headroom budget is tight. If a page takes 20s to load and consent dismissal takes 3s, the capture has 2s left for screenshot and HTML extraction. Mitigation: implement consent dismissal as a racing timeout -- if consent is not dismissed within 3s of page load, proceed without it. Do not let consent handling cause capture timeouts.
+
+6. **Evidence claim transparency.** If WRL dismisses cookie consent silently and does not record it, the "evidence" claim is weaker -- the capture does not reflect what a first-time visitor actually saw (they would have seen the banner). If WRL records it, the verification page must explain it to non-technical verifiers. This adds UX complexity to the verification flow. Both paths have costs.
+
+---
+
+### Additional Agents Needed
+
+- **security-minion**: Must review any consent handling implementation for injection risks. The `addInitScript()` path runs JavaScript in the page context -- if the autoconsent library is compromised (supply chain attack), it could exfiltrate page content or manipulate the DOM before capture. Needs lockfile pinning, integrity checking, or vendoring strategy.
+
+- **api-design-minion**: If capture options metadata is added to the WACZ manifest and verification response, the API contract changes. The `captureOptions` schema needs design before implementation. The question of whether the POST /v1/captures request body should ever accept capture options (even if initially server-only) affects API versioning.
+
+- **ux-strategy-minion**: The verification page needs to communicate capture conditions to non-technical users. "Cookie consent was automatically dismissed" must be understandable and not undermine confidence in the capture's authenticity. This is a UX design problem, not a technical one.
+
+No additional agents beyond what is already in the team are required.
+
+---
+
+### Sources Consulted
+
+- [URLBox Render Options](https://urlbox.com/docs/options) -- comprehensive parameterization reference
+- [ScreenshotOne Options](https://screenshotone.com/docs/options/) -- block_cookie_banners and related options
+- [DuckDuckGo autoconsent](https://github.com/duckduckgo/autoconsent) -- MPLv2, rule-based CMP handling for 100+ CMPs
+- [Apify idcac-playwright](https://github.com/apify/idcac) -- compiled "I Don't Care About Cookies" for Playwright
+- [Consent-O-Matic](https://github.com/cavi-au/Consent-O-Matic) -- 200+ CMPs, auto-updating rules
+- [Stillio Cookie Handling](https://support.stillio.com/article/14-hide-cookie-alerts-modals-pop-ups) -- hides banners by default
+- [Cloudflare Playwright docs](https://developers.cloudflare.com/browser-rendering/playwright/) -- @cloudflare/playwright v1.1.0 capabilities
+- [Page Vault](https://www.page-vault.com/) -- legal evidence capture, FRE 901(b)(9) admissibility
+- [Pagefreezer WebPreserver](https://www.pagefreezer.com/webpreserver/) -- compliance-grade web capture
+- [Courtroom-Ready CIPA & GDPR Evidence Reports](https://www.auditzo.com/blog/courtroom-ready-cipa-gdpr-evidence-reports-2025/) -- HAR logs, evidence layers for legal admissibility
+- [Forensic OSINT](https://www.forensicosint.com/) -- user-controlled forensic captures
+- [Digital Evidence Preservation Toolkit](https://digitalevidencetoolkit.org/tools/webpage-archiving/) -- cryptographic proof for web archives
+- [Screenshots as Evidence (Visualping)](https://visualping.io/blog/screenshots-as-evidence) -- legal documentation automation
+- [Are Screenshots Admissible (Pagefreezer)](https://blog.pagefreezer.com/collecting-online-evidence-dont-let-screenshots-sink-your-case) -- evidence authentication best practices

--- a/docs/history/nefario-reports/2026-03-16-120123-capture-parameterization/phase2-security-minion-prompt.md
+++ b/docs/history/nefario-reports/2026-03-16-120123-capture-parameterization/phase2-security-minion-prompt.md
@@ -1,0 +1,42 @@
+You are contributing to the PLANNING phase of a multi-agent project.
+You are NOT executing yet — you are providing your domain expertise
+to help build a comprehensive plan.
+
+## Advisory Context
+This is an advisory-only orchestration. Your contribution will feed
+into a team recommendation, not an execution plan. Focus on analysis,
+trade-offs, and recommendations rather than implementation tasks.
+
+## Project Task
+
+Evaluate whether WRL (Web Resource Ledger) should support parameterized capture requests — allowing API callers to control browser behavior during web page capture. WRL is a web evidence/archival service running on Cloudflare Workers with Playwright-based browser rendering.
+
+## Your Planning Question
+
+What attack surface does capture parameterization open? Specifically evaluate: (1) Cookie/session injection as a vector for capturing authenticated content the API caller shouldn't access (e.g., injecting stolen session cookies). (2) Arbitrary JavaScript execution via wait-for conditions or page manipulation. (3) CSS injection or DOM manipulation to alter what the "evidence" shows. (4) Resource exhaustion via viewport size parameters (e.g., 10000x10000 viewport). (5) How do these risks differ between single-tenant (current) and multi-tenant (R12 planned) deployments? What's the minimum set of security constraints that would make parameterization safe?
+
+## Context
+
+Current security model: SSRF prevention via URL validation (src/url-validation.js), BrowserContext isolation per capture, cross-domain navigation blocking, subresource limits (200), page size limits (50MB), Set-Cookie redaction in captured headers, service workers blocked. Auth is single API key (src/auth.js), multi-tenant planned as R12. Playwright BrowserContext accepts cookies, localStorage, viewport, and other options at creation time. The capture runs in ctx.waitUntil() with a ~30s budget.
+
+Read the following files for additional context:
+- /Users/ben/github/benpeter/web-resource-ledger/.claude/worktrees/capture-parameterization-advisory/src/capture.js
+- /Users/ben/github/benpeter/web-resource-ledger/.claude/worktrees/capture-parameterization-advisory/src/url-validation.js
+- /Users/ben/github/benpeter/web-resource-ledger/.claude/worktrees/capture-parameterization-advisory/src/auth.js
+- /Users/ben/github/benpeter/web-resource-ledger/.claude/worktrees/capture-parameterization-advisory/src/index.js
+
+## Instructions
+1. Read relevant files to understand the current state
+2. Apply your domain expertise to the planning question
+3. Identify risks, dependencies, and requirements from your perspective
+4. If you believe additional specialists should be involved that aren't already part of the planning, say so and explain why
+5. Return your contribution in this format:
+
+## Domain Plan Contribution: security-minion
+
+### Recommendations
+### Proposed Tasks
+### Risks and Concerns
+### Additional Agents Needed
+
+6. Write your complete contribution to /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-cfmjZO/capture-parameterization/phase2-security-minion.md

--- a/docs/history/nefario-reports/2026-03-16-120123-capture-parameterization/phase2-security-minion.md
+++ b/docs/history/nefario-reports/2026-03-16-120123-capture-parameterization/phase2-security-minion.md
@@ -1,0 +1,296 @@
+# Domain Plan Contribution: security-minion
+
+## Recommendations
+
+### Executive Summary
+
+Capture parameterization is a controlled expansion of the attack surface. The
+current architecture has strong isolation properties (BrowserContext per
+capture, SSRF prevention, subresource/size limits, Set-Cookie redaction,
+cross-domain navigation blocking). Parameterization is safe **if** every
+parameter category is independently threat-modeled and constrained. The
+biggest risk is not any single parameter -- it is the combinatorial explosion
+of parameters interacting in ways that bypass individual constraints.
+
+The fundamental tension: WRL is an **evidence** product. Every parameter the
+caller controls is a parameter that makes the capture less "objective" and
+more "caller-directed." Security constraints must protect not just against
+exploitation, but against evidence fabrication -- a malicious caller
+constructing a capture that shows content that never existed on the real site.
+
+### Parameter-by-Parameter Threat Analysis
+
+#### 1. Cookie / Session Injection
+
+**Risk: CRITICAL in multi-tenant, HIGH in single-tenant**
+
+Playwright's `browser.newContext({ storageState: { cookies: [...] } })` accepts
+arbitrary cookies that get set before navigation. This is the most dangerous
+parameter category because:
+
+**Attack: Authenticated content exfiltration**
+- Attacker obtains stolen session cookies (phishing, XSS on target site, etc.)
+- Submits capture request with those cookies injected
+- WRL faithfully captures the authenticated view (email inbox, bank account, admin panel)
+- Attacker retrieves artifacts via capture ID
+- WRL has now become a **proxy for unauthorized access**, with the added "bonus" of creating a signed, timestamped evidence record of the stolen content
+
+**Attack: Session fixation via captured evidence**
+- Attacker injects crafted cookies that alter content rendering (locale cookies, A/B test buckets, feature flags)
+- Capture shows a version of the page that most users never see
+- The "evidence" is technically accurate (the page did render that way) but misleading
+
+**Attack: Cookie-based SSRF amplification**
+- Some web applications redirect authenticated users to internal dashboards
+- Cookie injection could cause the browser to follow an auth-gated redirect to an internal URL
+- Current cross-domain navigation blocking mitigates this for top-level navigation, but same-origin redirects (e.g., `example.com/login` -> `example.com/internal-dashboard`) are not blocked
+
+**Minimum constraints:**
+1. **Cookies MUST be scoped to the target URL's domain.** Reject any cookie whose `domain` attribute does not match or is not a subdomain of the capture URL's hostname. This prevents cross-site cookie injection.
+2. **Cookie names and values MUST be length-capped** (e.g., 4096 bytes per cookie, 20 cookies max). Prevents memory exhaustion and header overflow attacks.
+3. **Cookie metadata MUST be logged** in the capture record: number of cookies injected, domains used. This creates an audit trail showing the capture was not "clean."
+4. **Capture record MUST flag parameterized captures** with a `parameters` field that is visible in the capture metadata and embedded in the WACZ manifest. Consumers of WRL evidence must be able to distinguish "clean" from "parameterized" captures.
+5. **In multi-tenant (R12):** consider requiring elevated permissions for cookie injection -- not every API key should be able to use this feature.
+6. **HttpOnly, Secure, SameSite attributes on injected cookies** should be stripped/ignored -- the caller is not the origin server, so these attributes have no meaning and could confuse Playwright's behavior.
+
+**What cannot be mitigated:** WRL cannot determine whether a session cookie is legitimately owned by the API caller. This is a fundamental limitation. The mitigation is transparency (flagging the capture as parameterized) and, in multi-tenant, per-tenant audit logging.
+
+#### 2. JavaScript Execution via Wait Conditions
+
+**Risk: HIGH**
+
+Wait conditions are the second most dangerous parameter because they can be
+a vector for arbitrary code execution within the browser context.
+
+**Attack: Arbitrary JS via `page.waitForFunction()`**
+- Playwright's `page.waitForFunction(expr)` evaluates arbitrary JavaScript in the page context
+- If the API accepts a user-supplied expression like `waitFor: "document.querySelector('.loaded')"`, the caller controls code that runs inside the page
+- This enables: DOM manipulation before screenshot (evidence fabrication), data exfiltration via injected fetch calls, cookie/storage theft from the target site
+
+**Attack: CSS selector injection via `page.waitForSelector()`**
+- Safer than `waitForFunction`, but complex CSS selectors can still cause performance issues (e.g., `*:has(*:has(*:has(*)))` creates exponential matching)
+- Not a code execution vector, but a DoS vector
+
+**Attack: Navigation-based wait bypass**
+- A `waitFor` that triggers navigation (via injected JS) could bypass cross-domain blocking if timed to execute after the route interceptor considers the page "loaded"
+
+**Minimum constraints:**
+1. **NEVER expose `waitForFunction` or any mechanism that evaluates caller-supplied JavaScript.** This is the single most important constraint in the entire advisory. Arbitrary JS in the page context is game over for evidence integrity and site security.
+2. **Use an enum of predefined wait strategies**, not caller-supplied expressions:
+   - `networkidle` (current default)
+   - `domcontentloaded`
+   - `load`
+   - `commit`
+   These are Playwright's built-in `waitUntil` options. They are safe because they do not evaluate caller-supplied code.
+3. **If `waitForSelector` is offered**, restrict to simple CSS selectors. Reject selectors containing `:has()`, `:not()` with complex arguments, or selectors exceeding 200 characters. Better yet: offer only a handful of preset selectors (e.g., `body`, `#content`, `[data-loaded]`) via an enum.
+4. **Additional wait-after-load delay** (e.g., `waitMs: 2000`) is safe as a simple `setTimeout` wrapper, but MUST be capped (max 10000ms, since the total budget is ~25s for navigation + wait).
+5. **Never use `page.evaluate()`, `page.addScriptTag()`, or `page.addInitScript()` with caller-supplied content.** These are all equivalent to `waitForFunction` in terms of code execution risk.
+
+#### 3. CSS Injection / DOM Manipulation
+
+**Risk: MEDIUM (with current architecture), HIGH (if JS execution is allowed)**
+
+Without JavaScript execution, the caller cannot directly manipulate the DOM
+or inject CSS. The risk exists only through indirect channels:
+
+**Attack: Cookie-driven CSS/content changes**
+- Many sites serve different CSS or content based on cookie values (themes, A/B tests, locale)
+- Cookie injection indirectly enables CSS/content manipulation
+- This is by design (the whole point of cookie injection) but creates evidence fabrication risk
+
+**Attack: URL-parameter-driven content manipulation**
+- The URL itself can contain query parameters that alter page content (e.g., `?debug=true`, `?theme=dark`, `?preview=1`)
+- This is already possible today -- the caller controls the URL
+- Parameterization does not change this risk, but it is worth noting as context
+
+**Attack: If JavaScript execution is ever allowed (see section 2)**
+- `page.addStyleTag()` with caller CSS could hide/show elements, change text colors to match backgrounds, overlay fake content
+- This is why section 2's constraints are critical -- they are the firewall that prevents CSS/DOM manipulation
+
+**Minimum constraints:**
+1. **Do not offer `addStyleTag` or `addScriptTag` parameters.** There is no legitimate evidence use case for injecting custom CSS or JS.
+2. **Record the full URL (including query parameters) in the capture manifest.** This is already done -- good.
+3. **Flag cookie-injected captures** (see section 1, point 4). This alerts evidence consumers that content may differ from the "default" view.
+
+#### 4. Resource Exhaustion via Viewport Parameters
+
+**Risk: MEDIUM**
+
+The current code hardcodes viewport at 1280x720 and caps screenshot height
+at 8000px. Caller-controlled viewport opens resource exhaustion vectors.
+
+**Attack: Memory exhaustion via oversized viewport**
+- `viewport: { width: 10000, height: 10000 }` creates a 10000x10000 canvas
+- PNG screenshot of a 10000x10000 viewport at 4 bytes/pixel = ~400MB uncompressed bitmap
+- This exceeds the 50MB page size limit because the limit applies to downloaded content, not rendered bitmap size
+- Cloudflare Workers have a 128MB memory limit; a single oversized screenshot could OOM the worker
+
+**Attack: Pixel-count amplification with `fullPage: true`**
+- Viewport width * page scroll height determines the screenshot bitmap size
+- A 5000px-wide viewport on a page with 8000px scroll height = 160 million pixels = ~640MB bitmap
+- Current `MAX_PAGE_HEIGHT` cap of 8000 helps, but only if viewport width is also capped
+
+**Attack: Device scale factor multiplication**
+- Playwright's `deviceScaleFactor` multiplies pixel dimensions
+- `{ width: 3000, height: 3000, deviceScaleFactor: 3 }` = 9000x9000 effective pixels = ~324MB bitmap
+- If `deviceScaleFactor` is exposed as a parameter, it must be capped
+
+**Minimum constraints:**
+1. **Cap viewport width**: 320 <= width <= 1920. No legitimate evidence use case requires wider than 1920.
+2. **Cap viewport height**: 480 <= height <= 1080. Height above 1080 is redundant with `fullPage: true`.
+3. **Cap device scale factor**: 1 <= deviceScaleFactor <= 2. Retina (2x) is legitimate; 3x is wasteful.
+4. **Compute a pixel budget** before rendering: `width * min(pageHeight, MAX_PAGE_HEIGHT) * deviceScaleFactor^2 <= MAX_PIXELS`. A reasonable cap is 50 million pixels (equivalent to ~6250x8000 at 1x scale).
+5. **Enforce the pixel budget after page load but before screenshot**, in the same location as the current `pageHeight > MAX_PAGE_HEIGHT` check. If the budget is exceeded, fail the capture rather than attempting the screenshot.
+6. **Maintain the existing `MAX_PAGE_HEIGHT` cap** as defence-in-depth. Do not remove it when adding viewport parameters.
+
+#### 5. Single-Tenant vs. Multi-Tenant Risk Differential
+
+**Single-tenant (current):**
+- The API caller is the service operator. They already have R2 access, KV access, and the signing key. Cookie injection does not give them access to anything they couldn't obtain by running Playwright directly.
+- Evidence fabrication via parameterization is a risk to the *credibility* of WRL evidence, but not a security risk per se -- the operator is fabricating evidence against their own interests.
+- Resource exhaustion is a self-inflicted DoS. Rate limiting already exists.
+- **Risk level: LOW-MEDIUM.** The main value of constraints in single-tenant is defense-in-depth and establishing the correct patterns before multi-tenant arrives.
+
+**Multi-tenant (R12, planned):**
+- Tenant A can now capture authenticated views of Tenant B's sites using stolen cookies. WRL becomes a credentialed proxy.
+- Tenant A can exhaust browser sessions, memory, or rate limit budgets that affect Tenant B's captures.
+- Tenant A's parameterized captures are stored alongside Tenant B's "clean" captures in the same R2 bucket (with different prefixes, but shared physical infrastructure).
+- Audit trails become critical: who injected what cookies, when, and what did they capture?
+- **Risk level: HIGH.** Multi-tenant transforms every parameter into a potential cross-tenant attack vector.
+
+**Key multi-tenant prerequisites for parameterization:**
+1. Per-tenant rate limiting (separate from global rate limiting)
+2. Per-tenant resource budgets (browser sessions, R2 storage, pixel budgets)
+3. Per-tenant audit logging of all parameterized captures
+4. Permission tiers: basic captures vs. parameterized captures as separately grantable capabilities
+5. Tenant isolation verification: ensure Tenant A's cookies are not leaking into Tenant B's contexts (this is already guaranteed by BrowserContext isolation, but must be explicitly tested when parameterization is added)
+
+### Minimum Security Constraints for Safe Parameterization
+
+The following is the minimum set that makes parameterization safe. Removing
+any one of these opens a concrete attack path.
+
+| # | Constraint | Protects Against |
+|---|-----------|-----------------|
+| 1 | **No caller-supplied JavaScript execution** -- no `waitForFunction`, `evaluate`, `addScriptTag`, `addInitScript` with user content | Evidence fabrication, data exfiltration, arbitrary code execution in page context |
+| 2 | **No caller-supplied CSS injection** -- no `addStyleTag` with user content | Evidence fabrication via visual manipulation |
+| 3 | **Cookie domain scoping** -- injected cookies must match capture URL domain | Cross-site cookie injection, session hijacking of unrelated sites |
+| 4 | **Cookie count and size limits** -- max 20 cookies, max 4096 bytes each | Memory exhaustion, header overflow |
+| 5 | **Viewport dimension caps** -- width [320, 1920], height [480, 1080] | Memory exhaustion via oversized bitmap |
+| 6 | **Pixel budget enforcement** -- max 50M pixels post-layout | OOM kills from fullPage screenshots |
+| 7 | **Device scale factor cap** -- max 2x | Pixel budget bypass via scale multiplication |
+| 8 | **Wait strategy enum** -- only Playwright built-in `waitUntil` values + optional capped delay | Code execution via expression evaluation |
+| 9 | **Parameterization flag in capture metadata and WACZ manifest** -- visible, immutable | Evidence integrity: consumers can distinguish clean vs. parameterized captures |
+| 10 | **Strict input validation on all parameter fields** -- JSON Schema with `additionalProperties: false`, type checks, range checks | Unexpected parameter injection, prototype pollution |
+| 11 | **`serviceWorkers: 'block'` remains hardcoded** -- never caller-controllable | Route interception bypass |
+| 12 | **Cross-domain navigation blocking remains hardcoded** -- never caller-controllable | SSRF via redirect chains |
+
+### Architecture Recommendation
+
+Do not implement parameterization as a passthrough to Playwright's
+`newContext()` options. Instead, build a **parameter validation and
+normalization layer** that:
+
+1. Accepts a defined schema of WRL-specific parameters (not Playwright parameters)
+2. Validates every field against explicit allowlists and ranges
+3. Normalizes values (e.g., clamps viewport dimensions)
+4. Produces a sanitized Playwright options object internally
+5. Logs the full parameter set in the capture record
+
+This insulates WRL from Playwright API changes (new options that might be
+dangerous) and ensures the validation layer is the single source of truth for
+what parameters are accepted.
+
+---
+
+## Proposed Tasks
+
+These are not implementation tasks (this is advisory-only). They are
+recommended backlog items.
+
+1. **Define parameterization JSON Schema** -- strict schema with `additionalProperties: false` for the request body extension. Include viewport, waitStrategy, cookies, and locale. Exclude anything that evaluates caller-supplied code.
+
+2. **Add `parameters` field to capture KV record and WACZ manifest** -- every capture records whether and how it was parameterized. This is prerequisite to any parameter support.
+
+3. **Implement pixel budget enforcement** -- compute and enforce a pixel budget before calling `page.screenshot()`. This is valuable even without parameterization (a tall page at 1280px width can already approach limits).
+
+4. **Cookie validation module** -- domain scoping, count limits, size limits, attribute stripping. Separate module with its own test suite, analogous to `url-validation.js`.
+
+5. **Security tests for parameterization boundaries** -- test that oversized viewports are rejected, cross-domain cookies are rejected, JS-evaluating wait conditions are rejected. These tests should exist before the feature is implemented, as a safety net.
+
+6. **Multi-tenant parameterization risk assessment** -- when R12 is planned, revisit this advisory with the specific multi-tenant architecture to evaluate cross-tenant attack paths.
+
+---
+
+## Risks and Concerns
+
+### CRITICAL: Evidence Integrity vs. Feature Richness Trade-off
+
+WRL's value proposition is **trustworthy evidence**. Every parameter the caller
+controls weakens the objectivity claim. The WACZ manifest MUST distinguish
+parameterized captures from clean captures, and the verification endpoint
+MUST surface this distinction. If a verifier cannot tell whether cookies were
+injected, WRL's evidence is no more trustworthy than a screenshot taken in a
+regular browser.
+
+**Recommendation:** Consider a two-tier evidence model:
+- **Level 1 (Verified)**: Clean-slate capture, no parameters. Full evidence integrity claim.
+- **Level 2 (Documented)**: Parameterized capture. Evidence shows what was captured with stated parameters. Integrity claim is limited to "this is what the page showed given these inputs."
+
+Both levels are signed and timestamped. The distinction is in what the evidence *proves*.
+
+### HIGH: Cookie Injection as a Credentialed Proxy
+
+In multi-tenant, WRL with cookie injection is functionally a **credentialed web
+scraping service**. This has legal, ethical, and abuse implications beyond
+technical security. Consider whether Terms of Service should explicitly
+address:
+- Prohibition on injecting stolen/unauthorized session credentials
+- Requirement that the API caller has legitimate authority to access the content being captured
+- Indemnification clause for misuse
+
+### MEDIUM: Playwright API Surface Drift
+
+Playwright regularly adds new context options. If parameterization is
+implemented as a passthrough to `newContext()`, any new Playwright option
+becomes automatically available to API callers. The validation layer
+(recommendation above) prevents this, but only if it uses an allowlist
+approach -- validate known-good parameters and reject everything else.
+
+### MEDIUM: Timeout Budget Erosion
+
+Adding a `waitMs` delay eats into the 25s navigation timeout budget. If a
+caller specifies `waitMs: 10000` and the page takes 20s to load, the capture
+will time out. This is not a security risk but an operational concern that
+will generate support tickets. Cap `waitMs` to `NAV_TIMEOUT_MS - 5000` (i.e.,
+max 20s total for navigation + wait).
+
+### LOW: Screenshot Height Cap Interaction
+
+Current code caps `pageHeight` at 8000 after load. If viewport height is
+caller-controlled, the interaction between initial viewport height, scroll
+height, and the cap needs to be re-evaluated. The cap should apply to the
+final screenshot dimensions regardless of how they were derived.
+
+---
+
+## Additional Agents Needed
+
+1. **legal-minion** (if one exists or can be consulted) -- the cookie injection
+   / credentialed proxy question has legal dimensions (CFAA in the US,
+   Computer Misuse Act in the UK, GDPR right of access vs. unauthorized
+   access) that go beyond technical security. At minimum, the Terms of
+   Service implications should be reviewed by someone with legal domain
+   knowledge.
+
+2. **api-design-minion** -- the parameter schema design needs to balance
+   expressiveness with safety. The security constraints above define the
+   ceiling; API design determines the actual shape within that ceiling.
+   Coordination is needed to ensure the API is usable without opening
+   security holes.
+
+3. **evidence-integrity-minion** or **domain expert for digital evidence** --
+   the two-tier evidence model recommendation needs evaluation from someone
+   who understands evidentiary standards (FRCP, eIDAS, chain of custody).
+   The question "is a parameterized capture still evidence?" is not purely
+   a security question.

--- a/docs/history/nefario-reports/2026-03-16-120123-capture-parameterization/phase2-ux-strategy-minion-prompt.md
+++ b/docs/history/nefario-reports/2026-03-16-120123-capture-parameterization/phase2-ux-strategy-minion-prompt.md
@@ -1,0 +1,49 @@
+You are contributing to the PLANNING phase of a multi-agent project.
+You are NOT executing yet — you are providing your domain expertise
+to help build a comprehensive plan.
+
+## Advisory Context
+This is an advisory-only orchestration. Your contribution will feed
+into a team recommendation, not an execution plan. Focus on analysis,
+trade-offs, and recommendations rather than implementation tasks.
+
+## Project Task
+
+Evaluate whether WRL (Web Resource Ledger) should support parameterized capture requests — allowing API callers to control browser behavior during web page capture. WRL is a web evidence/archival service running on Cloudflare Workers with Playwright-based browser rendering. It captures web pages (HTML + screenshot + metadata) and stores them in R2 with Ed25519 signatures for integrity. Currently, every capture starts with a completely blank browser session.
+
+## Your Planning Question
+
+WRL positions itself as an "evidence" product. Cookie consent banners currently dominate every screenshot, degrading capture fidelity. How should we think about the tension between "clean slate = reproducible evidence" and "parameterized = higher fidelity but caller-influenced"? What user jobs-to-be-done does parameterization serve, and which parameter categories (cookie handling, viewport, wait conditions, session injection) have the highest impact on the core evidence use case? Should WRL distinguish between "neutral" parameters (viewport size) and "opinion" parameters (cookie consent choice) in how they affect the evidence claim?
+
+## Context
+
+Current capture pipeline (src/capture.js) uses fixed 1280x720 viewport, no cookie handling, no session state. The product positions WRL as "capture a URL, store it immutably, let a third party verify." Backlog parking lot has two capture fidelity items: "Screenshot timing / wait-for-load" and "Screenshot height cap configurability" -- both with demand-driven triggers. The 0017 prompt identifies cookie consent banners as "the single biggest fidelity issue for screenshots."
+
+Read the following files for additional context:
+- /Users/ben/github/benpeter/web-resource-ledger/.claude/worktrees/capture-parameterization-advisory/src/capture.js
+- /Users/ben/github/benpeter/web-resource-ledger/.claude/worktrees/capture-parameterization-advisory/docs/backlog.md
+
+## Instructions
+1. Read relevant files to understand the current state
+2. Apply your domain expertise to the planning question
+3. Identify risks, dependencies, and requirements from your perspective
+4. If you believe additional specialists should be involved that aren't already part of the planning, say so and explain why
+5. Return your contribution in this format:
+
+## Domain Plan Contribution: ux-strategy-minion
+
+### Recommendations
+<your expert recommendations for this aspect of the task>
+
+### Proposed Tasks
+<specific tasks that should be in the execution plan>
+For each task: what to do, deliverables, dependencies
+
+### Risks and Concerns
+<things that could go wrong from your domain perspective>
+
+### Additional Agents Needed
+<any specialists not yet involved who should be, and why>
+(or "None" if the current team is sufficient)
+
+6. Write your complete contribution to /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-cfmjZO/capture-parameterization/phase2-ux-strategy-minion.md

--- a/docs/history/nefario-reports/2026-03-16-120123-capture-parameterization/phase2-ux-strategy-minion.md
+++ b/docs/history/nefario-reports/2026-03-16-120123-capture-parameterization/phase2-ux-strategy-minion.md
@@ -1,0 +1,164 @@
+## Domain Plan Contribution: ux-strategy-minion
+
+### Recommendations
+
+#### 1. The core tension is a false dichotomy -- resolve it with transparency, not restriction
+
+The framing of "clean slate = reproducible evidence" versus "parameterized = higher fidelity but caller-influenced" presents a false choice. A screenshot dominated by a cookie consent modal is not higher-integrity evidence of a page's content -- it is evidence of a cookie banner. The current "clean slate" does not produce a neutral view; it produces a systematically biased view (first-visit, no-consent, banner-occluded). Parameterization, when recorded transparently, produces *more honest* evidence because it declares its conditions rather than pretending conditions don't exist.
+
+The design principle: **evidence integrity comes from declaring what you did, not from restricting what you can do.** A photograph is evidence whether taken with a wide-angle or telephoto lens -- what makes it admissible is that the lens choice is documented. WRL should adopt the same philosophy: any parameter the caller provides must be recorded immutably alongside the capture artifacts.
+
+#### 2. Jobs-to-be-Done analysis reveals three distinct user jobs
+
+**Job A: "Capture what this page looks like to the public"** (current primary job)
+- JTBD: "When I need to preserve evidence of what a web page shows, I want to capture a faithful rendering, so I can prove the page's content at a point in time."
+- This job is *broken* by cookie consent banners. The user doesn't want evidence of the banner -- they want evidence of the content behind it. A cookie banner is interference, not signal.
+- This is a must-be feature gap (Kano): users expect the screenshot to show the page, not an overlay. Its absence actively degrades the core value proposition.
+
+**Job B: "Capture what this page looks like in a specific context"** (emerging job)
+- JTBD: "When I need to document how a page appears on mobile / in a specific region / to a logged-in user, I want to control the capture conditions, so I can prove what a specific audience sees."
+- This is a performance feature (Kano): more control yields proportionally more satisfaction.
+- This job is secondary to Job A and should be deferred until Job A is solidly served.
+
+**Job C: "Capture this page without thinking about browser details"** (implicit job for all users)
+- JTBD: "When I submit a URL, I want sensible defaults, so I don't have to configure anything to get a useful result."
+- This is a must-be: the zero-parameter capture must remain the primary path and produce good results. Parameterization must not become mandatory complexity.
+
+#### 3. Parameter categories ranked by impact on the evidence use case
+
+I rank parameter categories by how much they affect the core evidence job (Job A), using a Kano-informed lens:
+
+**Tier 1: Must-fix (addresses a broken must-be)**
+
+1. **Cookie consent handling** -- The single highest-impact intervention. Cookie banners degrade every capture on EU-targeted sites (which is most of the web). This isn't a nice-to-have; it's the difference between "evidence of a page" and "evidence of a cookie banner." However, *how* WRL handles this matters enormously -- see the neutrality framework below.
+
+**Tier 2: Performance features (proportional satisfaction gain)**
+
+2. **Wait conditions** -- "Wait for network idle" is already implemented, but some pages need "wait for selector" or a brief delay after load. Incomplete renders undermine evidence. The backlog already flags this ("Screenshot timing / wait-for-load" in parking lot). Low API complexity (one field), high fidelity impact.
+
+3. **Viewport size** -- Currently hardcoded at 1280x720. Mobile viewport captures serve a real evidence need (responsive design claims, mobile-specific content). Already partially acknowledged in the backlog ("Screenshot height cap configurability"). Low risk, purely "neutral" in the evidence sense.
+
+**Tier 3: Excitement features (delight, but adds complexity)**
+
+4. **Full-page vs. above-the-fold** -- Currently always full-page with an 8000px cap. Offering "viewport only" as an option is low-effort and occasionally valuable.
+
+5. **Device emulation** -- User-agent string + viewport + pixel ratio. Useful for mobile evidence but significantly more complex to validate and document.
+
+**Tier 4: Defer (high complexity, niche demand, evidence complications)**
+
+6. **Session/cookie injection** -- Injecting arbitrary cookies or localStorage to capture authenticated/personalized views. Powerful but creates a fundamentally different evidence claim ("this is what the page showed *when I presented these credentials*"). Defer until Job B demand materializes. When implemented, it must be gated and clearly distinguished in the evidence record.
+
+#### 4. WRL should distinguish "neutral" vs. "opinion" parameters -- and the distinction should be visible to verifiers
+
+This is the most important UX-strategic recommendation. Not all parameters are epistemically equal:
+
+**Neutral parameters** change *how* you observe without changing *what* the page decides to show you. They are analogous to choosing a camera angle.
+- Viewport dimensions
+- Wait conditions (timeout, selector)
+- Screenshot options (full-page vs. viewport, format)
+- Device pixel ratio
+
+**Opinion parameters** change *what the page decides to show you*. They inject caller intent into the page's behavior. They are analogous to staging a photograph.
+- Cookie consent choice (accept/reject/dismiss)
+- Injected cookies or session state
+- Geolocation spoofing
+- Language/locale override
+
+This distinction should be **visible in the capture metadata and verification response.** A verifier looking at the evidence should immediately understand: "This capture used a 375x812 viewport [neutral] and auto-dismissed cookie consent banners [opinion]." The verification endpoint should surface these parameters with clear labels.
+
+For the API, this means:
+- Neutral parameters can be part of a flat `options` object -- they're uncontroversial.
+- Opinion parameters should be in a separate, clearly-named namespace (e.g., `behavior` or `interventions`) so the API structure itself communicates that these affect what the page shows.
+- Opinion parameters should always appear in capture status/verification output, even when set to defaults.
+
+#### 5. Cookie consent handling deserves a special design, not just a parameter
+
+Cookie consent is uniquely important because it is the only category where *not* intervening actively degrades evidence quality for the majority of captures. For all other parameters, the default (no parameter) produces a reasonable result. For cookie consent, the default (no handling) produces a degraded result.
+
+Recommended approach from a UX strategy perspective:
+
+**Default behavior should be "dismiss without accepting or rejecting."** The goal is to remove the overlay so the page content is visible, without making a consent choice that changes what tracking/personalization the page performs. This is the closest thing to a "neutral" cookie consent action. Technically, this means:
+- Detect common consent manager patterns (OneTrust, Cookiebot, CMP frameworks)
+- Click the dismiss/close button or remove the overlay DOM elements
+- Do NOT click "accept all" -- accepting consent changes the page's behavior (ads load, tracking fires, personalized content may appear)
+- Record in capture metadata: `cookieConsent: "dismissed"` so verifiers know intervention occurred
+
+This should be the **default**, not an opt-in parameter. The reasoning: for Job A (capture what the page looks like to the public), a consent-dismissed view is closer to "what the public sees after making any consent choice" than a consent-banner-occluded view. The banner is transient UX, not the page's content.
+
+Callers who specifically want the banner (testing consent UX, for instance) should be able to set `cookieConsent: "none"` to disable the default dismissal.
+
+#### 6. Progressive disclosure should govern the parameterization rollout
+
+Apply progressive disclosure in two dimensions:
+
+**API surface:** Start with 2-3 parameters maximum. Cookie consent handling (as a default behavior, not a parameter -- users shouldn't have to ask for it). Viewport width (one number). Wait timeout override (one number). That's it for v1. Additional parameters are added only when a user requests them.
+
+**Documentation and cognitive load:** The capture API should remain a one-field operation for the common case. `POST /v1/captures { "url": "..." }` must continue to work exactly as it does today, but produce better results (because cookie consent dismissal is now default). Parameters are optional fields that most callers never need to know about.
+
+This follows the YAGNI principle from the project manifesto. Don't build viewport configuration because it seems useful -- build it when a user reports that the default viewport doesn't work for their job.
+
+#### 7. The evidence claim needs a clear mental model for callers and verifiers
+
+WRL's evidence positioning requires that both the person who requested the capture and the person who later verifies it share a mental model of what the capture represents. Today that model is simple: "a screenshot of what a fresh browser saw." With parameterization, the model becomes: "a screenshot of what a browser saw under declared conditions."
+
+This is fine -- and arguably more honest -- but only if the conditions are:
+1. **Immutably recorded** alongside the capture (in KV metadata, in the WACZ bundle, in the verification response)
+2. **Presented in human-readable terms** at verification time (not raw Playwright config)
+3. **Clearly distinguished** from the URL and timestamp as a separate axis of provenance
+
+The verification page/response should show something like:
+```
+URL:       https://example.com/article
+Captured:  2026-03-16T14:22:00Z
+Viewport:  1280x720 (default)
+Cookie consent: dismissed (default)
+Wait:      network idle (default)
+```
+
+When parameters are non-default:
+```
+URL:       https://example.com/article
+Captured:  2026-03-16T14:22:00Z
+Viewport:  375x812 (caller-specified)
+Cookie consent: dismissed (default)
+Wait:      selector '.article-body' (caller-specified)
+```
+
+The "(default)" and "(caller-specified)" labels are critical. They let a verifier distinguish between WRL's standard behavior and the caller's intent.
+
+### Proposed Tasks
+
+These are UX-strategy-level tasks (analysis, specification, validation), not implementation:
+
+1. **Define the parameter taxonomy** -- Formalize the neutral/opinion distinction. For each candidate parameter, classify it and document its evidence implications. This becomes the design constraint for API and metadata design.
+
+2. **Design the capture provenance display** -- Specify how parameters appear in capture status, verification response, and (future) verification page. Ensure verifiers can understand capture conditions without technical knowledge.
+
+3. **Validate cookie consent as default behavior** -- Confirm through testing that auto-dismissal (not auto-accept) is technically feasible for the major CMP frameworks and produces results closer to "what the page looks like" than the banner-occluded alternative.
+
+4. **Define the "evidence claim" language** -- Write the one-paragraph explanation of what a WRL capture represents, accounting for parameterization. This becomes copy for the API docs and verification page. It should be precise enough that a lawyer or journalist can understand the claim and its limitations.
+
+5. **User journey: parameterized capture** -- Map the journey for a caller who needs a non-default capture (e.g., mobile viewport). Identify the minimum information they need to provide and the minimum feedback they need to receive. Ensure progressive disclosure: the common case (default capture) remains effortless.
+
+### Risks and Concerns
+
+**Risk 1: Parameterization becomes the excuse for poor defaults.**
+If WRL adds parameters, there's a temptation to leave defaults broken and tell users to "just pass the right parameters." Cookie consent handling should be a *default improvement*, not an opt-in. If a caller has to know about cookie consent parameters to get a useful screenshot, the product has failed at Job C.
+
+**Risk 2: Evidence claim becomes confusing or untrustworthy.**
+Every parameter makes the evidence claim harder to explain. If WRL exposes 15 parameters, verifiers won't understand what they're looking at. Strict progressive disclosure and the neutral/opinion distinction mitigate this, but it requires discipline to resist adding parameters "because Playwright supports them."
+
+**Risk 3: The neutral/opinion distinction is contested.**
+Viewport size seems clearly neutral, and session injection seems clearly opinion, but cookie consent dismissal sits in a gray zone. Dismissing without accepting is *less* opinionated than accepting, but it's still an intervention. WRL should be transparent about this rather than pretending it's neutral. Call it "cookie banner dismissal" in the metadata, not "no cookie intervention."
+
+**Risk 4: Scope creep from "parameterization" to "headless browser as a service."**
+The further WRL goes down the parameterization path, the closer it gets to competing with generic screenshot APIs (URLBox, Screenshotone, etc.) rather than differentiating on evidence. The evidence positioning requires restraint: only add parameters that serve the evidence use case, not parameters that make WRL a general-purpose rendering tool.
+
+**Risk 5: Cookie consent auto-dismissal has a long reliability tail.**
+There are dozens of CMP implementations, custom consent UIs, and edge cases. A dismissal mechanism that works on 80% of sites is valuable, but the 20% failure rate creates a confusing experience ("why did this capture have a banner but the other didn't?"). WRL should record whether dismissal was attempted, succeeded, or failed -- and surface this in capture metadata.
+
+### Additional Agents Needed
+
+**product-marketing-minion** -- The evidence claim language is a marketing/positioning question as much as a UX one. The neutral/opinion parameter distinction has implications for how WRL positions itself. The product-marketing perspective should validate that "evidence under declared conditions" is a coherent market position and doesn't dilute the evidence brand.
+
+No other agents needed beyond those already assigned (security, API design, gru, data, frontend). The frontend-minion's involvement is appropriate for the future verification page display of parameter provenance. The security-minion's analysis of cookie injection and session state is essential and already scoped.

--- a/docs/history/nefario-reports/2026-03-16-120123-capture-parameterization/phase3-synthesis-prompt.md
+++ b/docs/history/nefario-reports/2026-03-16-120123-capture-parameterization/phase3-synthesis-prompt.md
@@ -1,0 +1,81 @@
+MODE: SYNTHESIS
+ADVISORY: true
+
+You are synthesizing specialist planning contributions into a
+team recommendation. This is an advisory-only orchestration --
+no code will be written, no branches created, no PRs opened.
+
+Do NOT produce task prompts, agent assignments, execution order,
+approval gates, or delegation plan structure. Produce an advisory
+report using the advisory output format.
+
+## Original Task
+
+Evaluate whether WRL (Web Resource Ledger) should support parameterized capture requests — allowing API callers to control browser behavior during web page capture. The biggest pain point is cookie consent banners dominating every screenshot. Broader question extends to viewport, wait conditions, session state injection, and how parameterization interacts with WRL's evidence mission.
+
+## Specialist Contributions
+
+Read the following scratch files for full specialist contributions:
+- /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-cfmjZO/capture-parameterization/phase2-ux-strategy-minion.md
+- /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-cfmjZO/capture-parameterization/phase2-security-minion.md
+- /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-cfmjZO/capture-parameterization/phase2-api-design-minion.md
+- /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-cfmjZO/capture-parameterization/phase2-frontend-minion.md
+- /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-cfmjZO/capture-parameterization/phase2-gru.md
+- /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-cfmjZO/capture-parameterization/phase2-data-minion.md
+
+## Key consensus across specialists:
+
+## Summary: ux-strategy-minion
+Phase: planning
+Recommendation: The clean-slate vs. parameterized tension is a false dichotomy. Evidence integrity comes from declaring conditions, not restricting them. Cookie consent handling should be a default behavior (dismiss, not accept), not an opt-in parameter. Distinguish "neutral" parameters (viewport) from "opinion" parameters (cookie consent) and surface the distinction to verifiers.
+Tasks: 5 -- Define parameter taxonomy; Design capture provenance display; Validate cookie consent as default behavior; Define evidence claim language; Map parameterized capture user journey
+Risks: Poor defaults hiding behind parameters; Evidence claim confusion; Contested neutral/opinion boundary; Scope creep toward generic screenshot API; Cookie consent long tail
+Conflicts: Disagrees with gru on whether cookie consent should be a caller parameter vs. server-controlled default; recommends "dismiss without accepting" while frontend-minion and gru propose "reject all"
+Full output: phase2-ux-strategy-minion.md
+
+## Summary: security-minion
+Phase: planning
+Recommendation: Parameterization is safe IF every parameter category is independently threat-modeled and constrained. 12 minimum security constraints including: no caller-supplied JS execution, cookie domain scoping, viewport caps, pixel budget enforcement, wait strategy enum, parameterization flag in metadata. Two-tier evidence model recommended.
+Tasks: 6 -- Define parameterization JSON Schema; Add parameters to KV/WACZ; Pixel budget enforcement; Cookie validation module; Security boundary tests; Multi-tenant risk reassessment
+Risks: Cookie injection as credentialed proxy (CRITICAL in multi-tenant); Evidence fabrication; Playwright API drift; Timeout budget erosion
+Conflicts: None -- largely aligned with other specialists on constraints
+Full output: phase2-security-minion.md
+
+## Summary: api-design-minion
+Phase: planning
+Recommendation: Extend existing POST /v1/captures with optional fields (not presets, not separate endpoint). Six initial parameters: viewport, waitUntil, maxWaitMs, cookies, screenshotMaxHeight. Add appliedParams to responses showing actual values used. Cookie values never echoed (count only). Backward compatible.
+Tasks: 9 -- Define CaptureRequest schema; Define AppliedParams schema; Request body parsing; Extend performCapture(); Apply in renderer; Store in KV; Include in WACZ; Document ignoredFields; Validation tests
+Risks: Cookie injection changes evidentiary meaning; Cookie domain validation security boundary; Clamping vs rejection; KV size growth (minor)
+Conflicts: None significant
+Full output: phase2-api-design-minion.md
+
+## Summary: frontend-minion
+Phase: planning
+Recommendation: Do not build a general-purpose consent handler. Use layered, caller-controlled approach: Layer 0 (default, no handling), Layer 1 (CSS cosmetic hiding, ~60-70% coverage), Layer 2 (caller-provided cookies). Cookie pre-injection most reliable for known CMPs (85-90%). Defer autoconsent (Layer 3) to post-MVP.
+Tasks: 5 -- API schema extension; Pipeline plumbing; CSS consent hiding module; Cookie pre-injection; Documentation
+Risks: Selector drift; Custom banners uncoverable; GDPR implications; autoconsent bundle size
+Conflicts: Recommends caller-controlled approach; gru argues server-controlled only
+Full output: phase2-frontend-minion.md
+
+## Summary: gru
+Phase: planning
+Recommendation: General parameterization: Hold. Server-controlled cookie consent dismissal: Assess. Market splits cleanly: screenshot APIs offer parameterization, evidence services limit it. WRL is in evidence category. Cookie consent should be server-controlled using autoconsent with "reject all" default. Timing: not now (Act 1 still in progress), add to Parking Lot.
+Tasks: 3 backlog items -- Server-controlled cookie consent dismissal [should]; Viewport parameterization [consider]; Capture options metadata schema [consider]
+Risks: Autoconsent fragility; reject-all vs accept-all policy; Scope creep; Bundle size; 30s budget; Evidence transparency
+Conflicts: Strongest YAGNI voice; argues against caller-controlled parameterization
+Full output: phase2-gru.md
+
+## Summary: data-minion
+Phase: planning
+Recommendation: Parameters go in both datapackage.json (dense) AND KV (sparse). Ed25519 signature automatically covers parameters through existing chain -- no signing changes needed. Schema should be closed, minimal (4 fields Tier 1), with settingsVersion. KV impact negligible.
+Tasks: 7 -- Define captureSettings schema; Extend buildWacz(); Extend KV; Thread through performCapture(); Update API responses; Extend verification; Migration note
+Risks: Parameter injection into manifests; Schema evolution under immutable signatures; False precision; Defaulting implicit contract; KV growth
+Conflicts: None
+Full output: phase2-data-minion.md
+
+## Instructions
+1. Review all specialist contributions
+2. Resolve any conflicts between recommendations
+3. Identify consensus and dissent -- preserve minority positions
+4. Produce an advisory report with executive summary, team consensus, dissenting views, supporting evidence, risks, next steps, and conflict resolutions
+5. Write your complete advisory synthesis to /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-cfmjZO/capture-parameterization/phase3-synthesis.md

--- a/docs/history/nefario-reports/2026-03-16-120123-capture-parameterization/phase3-synthesis.md
+++ b/docs/history/nefario-reports/2026-03-16-120123-capture-parameterization/phase3-synthesis.md
@@ -1,0 +1,166 @@
+# Advisory Report
+
+**Question**: Should WRL support parameterized capture requests -- allowing API callers to control browser behavior (viewport, wait conditions, cookies, consent handling) during web page capture? How should cookie consent banners be addressed?
+
+**Confidence**: HIGH
+
+**Recommendation**: Do not build general capture parameterization now. Address cookie consent banners through a server-controlled dismissal mechanism as a [should] parking lot item. When parameterization eventually ships, adopt a narrow, metadata-transparent design where every setting is recorded immutably in the WACZ bundle and visible to verifiers.
+
+## Executive Summary
+
+Six specialists evaluated capture parameterization across security, API design, UX strategy, frontend engineering, data architecture, and technology landscape. The team reached strong consensus on the core question: WRL is an evidence service, not a screenshot API, and this identity should govern every parameterization decision.
+
+The biggest pain point -- cookie consent banners obscuring page content -- is real and universally acknowledged. But the team diverges on *how* to solve it. The strongest YAGNI voice (gru) argues for deferring entirely until a user reports it, then implementing a server-controlled solution using an open-source library (autoconsent). The UX strategy perspective argues cookie consent handling should be a default behavior (dismiss without accepting), not an opt-in parameter. The frontend analysis provides detailed technical feasibility for four approaches, ranking cookie pre-injection highest for reliability (85-90%) but recommending a layered caller-controlled architecture. The resolution: server-controlled consent dismissal is the right first step, with caller-provided cookies as a future escape hatch for edge cases -- but neither belongs in Act 1.
+
+On general parameterization (viewport, wait conditions, screenshot height), consensus is clear: defer until demand materializes. The current defaults (1280x720 viewport, networkidle wait, 8000px screenshot cap) are reasonable. When parameterization does ship, the data architecture is ready -- adding a `captureSettings` block to `datapackage.json` flows through the existing Ed25519 signature chain automatically, requiring zero changes to the signing code.
+
+The security analysis identifies cookie injection as the highest-risk parameter category (CRITICAL in multi-tenant), establishes 12 minimum security constraints for safe parameterization, and recommends a two-tier evidence model distinguishing "verified" (clean-slate) from "documented" (parameterized) captures. This distinction should be visible to verifiers and is the most important design principle for whenever parameterization ships.
+
+## Team Consensus
+
+1. **WRL is an evidence service, not a screenshot API.** Every specialist independently arrived at this conclusion. The competitive landscape splits cleanly: screenshot APIs (URLBox, ScreenshotOne) compete on parameterization breadth; evidence services (Page Vault, Pagefreezer) deliberately limit caller control. WRL should stay in the evidence lane.
+
+2. **Cookie consent banners are a real fidelity problem.** The current clean-slate capture systematically produces screenshots dominated by consent overlays on European and increasingly global sites. This degrades the core value proposition -- users want evidence of page content, not evidence of a cookie banner.
+
+3. **Every parameter must be recorded immutably in the WACZ bundle.** The `captureSettings` block in `datapackage.json` is automatically covered by the existing Ed25519 signature chain. No signing code changes needed. The data architecture is ready whenever parameterization ships.
+
+4. **No caller-supplied JavaScript execution, ever.** This is the single hardest security constraint. `waitForFunction`, `evaluate`, `addScriptTag`, and `addInitScript` with user content are all vectors for evidence fabrication and data exfiltration. The team unanimously agrees this is a non-negotiable red line.
+
+5. **Parameters should be visible to verifiers.** Whether through `appliedParams` in API responses, `captureSettings` in WACZ metadata, or provenance labels on a verification page, the conditions under which a capture was produced must be transparent to anyone evaluating the evidence.
+
+6. **General parameterization should not ship in Act 1.** YAGNI applies. No external user has reported cookie banners, viewport size, or wait conditions as blocking problems. The current Act 1 backlog (CORS, HSTS, hashed IP logging, remaining hardening) is the right priority.
+
+7. **The API extension design is straightforward when the time comes.** Extend `POST /v1/captures` with optional fields alongside `url`. No separate endpoint, no presets system, no new resource lifecycle. Backward compatible. The schema, validation approach, and response shape are well-defined.
+
+## Dissenting Views
+
+### Cookie consent: server-controlled vs. caller-controlled
+
+**gru** recommends server-controlled only: WRL decides the consent policy (reject-all via autoconsent), applies it uniformly, and records the action. The caller has no control. This maximizes evidence integrity -- the capture reflects WRL's documented policy, not the caller's preference.
+
+**frontend-minion** recommends a layered, caller-controlled architecture: Layer 0 (no handling), Layer 1 (CSS hiding via caller opt-in), Layer 2 (caller-provided cookies). This pushes site-specific knowledge to the caller, who already knows their target sites.
+
+**ux-strategy-minion** recommends server-controlled default dismissal (not acceptance) with a `cookieConsent: "none"` override for callers who specifically want the banner. The default should be "dismiss without accepting or rejecting" to remain maximally neutral.
+
+**Resolution**: Start with server-controlled. gru's argument is most aligned with the evidence positioning: a server-controlled policy is an attestable, documented behavior that WRL can explain to verifiers. Caller-controlled consent handling can be added later as an escape hatch (Layer 2 cookie injection), but only after the server-controlled default proves insufficient. The specific consent action (dismiss vs. reject-all vs. accept-all) is a policy decision that should be deferred to implementation time -- both "dismiss without choosing" (ux-strategy) and "reject all" (gru) have merit, and the choice depends on technical feasibility with the selected library.
+
+### Consent handling: "dismiss" vs. "reject all"
+
+**ux-strategy-minion** argues for "dismiss without accepting or rejecting" -- removing the overlay without making a consent choice. This is the most neutral action because it does not change what tracking/personalization the page performs.
+
+**gru** argues for "reject all" -- actively declining consent. This minimizes tracking state and keeps the browser context closest to a neutral observer.
+
+**Resolution**: Unresolved -- presented for user judgment. Both positions have merit. "Dismiss" is more neutral but technically harder (not all CMPs have a dismiss/close button; some are cookie walls). "Reject all" is cleaner from a state perspective but is an active choice that changes page behavior (some consent-gated content may not load). The implementation team should evaluate which action the selected library (autoconsent or equivalent) supports more reliably and choose based on technical feasibility. The chosen action must be recorded in capture metadata regardless.
+
+### Timing: now vs. parking lot
+
+**gru** is the strongest YAGNI voice: do nothing now, add to parking lot, build only when triggered by user demand.
+
+**ux-strategy-minion** considers cookie consent handling a "must-fix" that addresses a broken must-be quality: "users expect the screenshot to show the page, not an overlay."
+
+**Resolution**: Parking lot wins. The project philosophy (Helix Manifesto, YAGNI) is clear: don't build until needed. No external user has reported this as a problem. However, the parking lot item should be [should] tier (not [consider]) reflecting the team's consensus that this is a real problem that will need solving. Activation trigger: when a user reports cookie consent banners as a blocking problem for capture quality, OR when the Web UI (R17) ships and screenshots become visible to non-technical users.
+
+## Supporting Evidence
+
+### Technology Landscape (gru)
+
+The competitive analysis reveals a clean market segmentation. Screenshot APIs (URLBox with 60+ options, ScreenshotOne) compete on rendering flexibility. Evidence services (Page Vault at FRE 901(b)(9) admissibility, Pagefreezer for compliance) deliberately limit caller control. No evidence-grade service offers caller-controlled JS injection or arbitrary cookie injection. Revenue signals confirm the positioning: evidence services charge 10-100x more per capture than screenshot APIs. The value is in attestation, not rendering flexibility.
+
+Mature open-source tooling exists for consent handling: DuckDuckGo autoconsent (MPL-2.0, 1,464 commits, 100+ CMPs), Consent-O-Matic (200+ CMPs), Apify's idcac-playwright. None are designed for Cloudflare Workers -- they require injection via `addInitScript()` or `addScriptTag()`.
+
+### Security (security-minion)
+
+Cookie injection is the highest-risk parameter category. In the current single-tenant deployment, the API caller is the operator -- cookie injection does not grant access to anything they could not obtain by running Playwright directly. In multi-tenant (R12), cookie injection transforms WRL into a credentialed proxy: an attacker with stolen session cookies could capture authenticated views of victim sites, creating signed evidence records of unauthorized access.
+
+Twelve minimum security constraints are defined for safe parameterization. The most critical: no caller-supplied JavaScript execution (constraint #1), cookie domain scoping (constraint #3), pixel budget enforcement (constraint #6), and parameterization flags in capture metadata (constraint #9). The recommended architecture is a parameter validation and normalization layer that accepts WRL-specific parameters, validates against allowlists, and produces sanitized Playwright options internally -- never a passthrough to `newContext()`.
+
+The two-tier evidence model (Level 1: Verified clean-slate, Level 2: Documented parameterized) is the strongest framework for preserving evidence integrity while enabling parameterization.
+
+### API Design (api-design-minion)
+
+The recommended approach is extending `POST /v1/captures` with optional fields -- not presets, not a separate endpoint. Six initial parameters: `viewport`, `waitUntil`, `maxWaitMs`, `cookies`, `screenshotMaxHeight`. An `appliedParams` object in responses shows actual values used (reflecting clamping, not just requested values). Cookie values are never echoed (count only). The `ignoredFields` array in 202 responses catches typos without rejecting requests. This is fully backward compatible -- existing `{ url }` requests work unchanged.
+
+### Frontend / Consent Engineering (frontend-minion)
+
+Four consent handling approaches evaluated with reliability estimates: CSS hiding (60-70% known CMPs), click automation (70-80%), CMP API calls (80-85%), cookie pre-injection (85-90%). All approaches have 0% coverage for custom banners (~40-50% of all consent banners). Cookie pre-injection is fastest (zero added time to capture budget) and most reliable for known CMPs, but has high format fragility -- each CMP's cookie format changes between versions. The autoconsent library (click automation approach) has the broadest coverage through maintained rulesets but adds 1-3 seconds to the capture budget and requires injection as JavaScript.
+
+Key constraint: Cloudflare Browser Rendering does not support browser extensions. All consent logic must be injectable JavaScript via `addInitScript()` or `addScriptTag()`. The 30-second `ctx.waitUntil` budget is tight -- consent handling must be racing-timeout guarded.
+
+### Data Architecture (data-minion)
+
+Parameters belong in both `datapackage.json` (dense, full resolved settings) and KV (sparse, caller overrides only). The `captureSettings` block with `settingsVersion: 1` is the proposed schema. The Ed25519 signature chain automatically covers parameters through `canonicalize(datapackage)` -- no signing changes needed. Backward compatibility is clean: pre-parameterization WACZs simply lack `captureSettings`; verifiers treat absence as "captured before parameterization existed."
+
+KV impact is negligible: ~200-500 bytes per record, well within the 25 MiB value limit.
+
+### UX Strategy (ux-strategy-minion)
+
+Three user jobs identified: (A) capture what the page looks like to the public (primary, currently broken by banners), (B) capture in a specific context (emerging, defer), (C) capture without thinking about browser details (implicit, must remain effortless). The neutral/opinion parameter taxonomy is the most important UX insight: viewport is neutral (changes observation angle), cookie consent is opinion (changes page behavior). This distinction should be visible to verifiers.
+
+The evidence claim mental model shifts from "what a fresh browser saw" to "what a browser saw under declared conditions" -- this is more honest but requires that conditions are immutably recorded, presented in human-readable terms, and clearly distinguished from URL and timestamp.
+
+## Risks and Caveats
+
+1. **Consent handling is inherently fragile.** CMPs update their markup frequently. Autoconsent's 1,464 commits reflect continuous adaptation, not stability. Any consent handler will occasionally fail. WRL must treat consent handling as best-effort, record success/failure in metadata, and never block a capture because consent dismissal failed.
+
+2. **Cookie injection in multi-tenant is a credentialed proxy risk.** When R12 (per-tenant keys) ships, cookie injection must be gated behind elevated permissions with per-tenant audit logging. Terms of Service should address prohibition on injecting stolen credentials. This is a legal and ethical concern beyond technical security.
+
+3. **Scope creep from parameterization to "headless browser as a service."** Each parameter individually seems small. Collectively, they transform WRL from an evidence service into a screenshot API competing with URLBox and ScreenshotOne on features where WRL cannot win. Every parameterization request should pass the test: "Does this strengthen or weaken the evidence claim?"
+
+4. **The neutral/opinion boundary is contested.** Viewport seems clearly neutral. Session injection seems clearly opinion. Cookie consent dismissal is a gray zone -- it is an intervention that changes what the page shows, even if the intent is to reveal content behind an overlay. WRL should be transparent about this rather than pretending any intervention is neutral.
+
+5. **30-second budget pressure.** The Cloudflare Workers `ctx.waitUntil` budget is 30 seconds. Navigation already takes up to 25 seconds. Consent handling adds 1-3 seconds. This leaves minimal headroom for screenshot and HTML extraction. The Queue migration (R16) would remove this ceiling, but R16 is Act 3.
+
+6. **Autoconsent bundle size is unknown.** The library needs evaluation for Cloudflare Workers compatibility. The 10MB script size limit (paid plan) may be a constraint. A curated subset of the top CMPs (OneTrust, Cookiebot, TrustArc, Didomi, Quantcast -- covering ~60-70% of sites) may be necessary if the full library is too large.
+
+7. **"Reject all" may hide consent-gated content.** If WRL rejects all cookies, some sites may withhold content that loads only after consent. The capture would show a page that no real visitor ever sees (neither the banner view nor the consented view). This is a fidelity risk that should be evaluated during implementation.
+
+## Next Steps
+
+If the recommendation is adopted, the implementation path is:
+
+### Immediate (this session)
+
+1. **Update `docs/backlog.md`** -- Add three items to the Parking Lot under "Capture Fidelity":
+   - [should] Server-controlled cookie consent dismissal (trigger: user reports banners as blocking, OR R17 ships)
+   - [consider] Viewport parameterization (trigger: user reports viewport as a problem)
+   - [consider] Capture options metadata schema (trigger: when any capture parameterization ships)
+
+2. **Create evolution log entry** for this advisory phase.
+
+### When triggered (future phase)
+
+3. **Evaluate autoconsent bundle size** and Cloudflare Workers compatibility. Determine whether the full library or a curated subset is viable within the 10MB script limit and 30-second execution budget.
+
+4. **Design `captureSettings` schema** (Tier 1: viewport, waitUntil, maxScreenshotHeight, settingsVersion). Keep it minimal -- four fields that already exist as hardcoded constants.
+
+5. **Implement server-controlled consent dismissal** with autoconsent via `addInitScript()`. Record the action in `captureSettings.consentHandling` in the WACZ manifest.
+
+6. **Extend verification to report settings** -- display capture conditions on the verification endpoint so verifiers can see what parameters were asserted.
+
+### When multi-tenant (R12) ships
+
+7. **Revisit parameterization threat model** with the specific multi-tenant architecture. Cookie injection requires elevated permissions, per-tenant audit logging, and Terms of Service updates.
+
+8. **Consider caller-provided cookies** as an escape hatch for edge cases the server-controlled consent handler cannot cover. Apply all 12 security constraints from the security analysis.
+
+## Conflict Resolutions
+
+### Server-controlled vs. caller-controlled consent (gru vs. frontend-minion)
+
+gru argues consent handling must be server-controlled to preserve the attestation model. frontend-minion argues for a layered, caller-controlled approach because the caller knows their target sites best. **Resolution**: server-controlled first, with the door open for caller-controlled cookie injection as a future layer. The evidence positioning argument (gru) is stronger for the initial implementation. Caller control can be added when specific edge cases demonstrate its necessity.
+
+### Do nothing now vs. fix a broken must-be (gru vs. ux-strategy-minion)
+
+gru applies YAGNI strictly: no user has reported this. ux-strategy-minion considers the consent banner problem a must-fix for the core value proposition. **Resolution**: parking lot at [should] tier -- a compromise that respects YAGNI (don't build yet) while acknowledging the problem is real and well-understood (not [consider] tier). The activation trigger is concrete and user-driven.
+
+### Consent action: dismiss vs. reject-all (ux-strategy-minion vs. gru)
+
+ux-strategy-minion argues "dismiss without choosing" is maximally neutral. gru argues "reject all" minimizes tracking state. **Resolution**: deferred to implementation time. Both have merit; the choice depends on which action the selected consent library supports more reliably. The chosen action must be recorded in metadata regardless.
+
+### Cookie injection scope: 20 cookies (security) vs. 50 cookies (API design)
+
+security-minion recommends max 20 cookies. api-design-minion proposes maxItems: 50. **Resolution**: adopt 20 (security recommendation). The evidence use case for cookie injection is narrow -- consent state and locale preferences. 20 cookies is generous for this purpose and limits the abuse surface. If a legitimate use case for more emerges, the limit can be raised.
+
+### Viewport caps: 1920 max (security) vs. 3840 max (API design)
+
+security-minion recommends capping viewport width at 1920. api-design-minion proposes up to 3840 to support 4K displays. **Resolution**: adopt 1920 initially (security recommendation). The pixel budget constraint (50M pixels max) provides defense-in-depth regardless of the viewport cap. A 4K viewport with fullPage: true could exceed the pixel budget, so the effective constraint is the budget, not the cap. Starting conservative is safer; the cap can be raised if demand materializes.

--- a/docs/history/nefario-reports/2026-03-16-120123-capture-parameterization/prompt.md
+++ b/docs/history/nefario-reports/2026-03-16-120123-capture-parameterization/prompt.md
@@ -1,0 +1,43 @@
+## Task: Capture Request Parameterization Advisory
+
+Evaluate whether WRL (Web Resource Ledger) should support parameterized capture requests — allowing API callers to control browser behavior during web page capture.
+
+### Context
+
+WRL is a web evidence/archival service running on Cloudflare Workers with Playwright-based browser rendering. It captures web pages (HTML + screenshot + metadata) and stores them in R2 with Ed25519 signatures for integrity. Currently, every capture starts with a completely blank browser session — no cookies, no localStorage, no prior state.
+
+**The core problem**: Cookie consent banners (GDPR/ePrivacy) appear on virtually every capture because the browser has no prior consent state. This dominates screenshots and reduces capture fidelity. The question extends beyond cookies to broader capture parameterization.
+
+### Key areas to evaluate
+
+1. **Cookie consent handling**: Auto-accept, auto-reject, skip/dismiss cookie banners. Technical approaches (CSS hiding, click automation, consent management platform APIs). Reliability across different CMP implementations (OneTrust, Cookiebot, Didomi, custom).
+
+2. **Session state injection**: Should callers be able to inject cookies, localStorage values, or other session state? Use cases: capturing personalized views, authenticated pages, A/B test variants.
+
+3. **Viewport and rendering parameters**: Device emulation, viewport size, wait-for conditions, JavaScript execution toggle, dark mode, etc.
+
+4. **Evidence integrity implications**: How does parameterization interact with WRL's evidence/archival mission? If someone injects cookies or dismisses consent banners, is the result still valid evidence? Should parameters be recorded in capture metadata?
+
+5. **API design**: How should parameters be passed? Request body fields vs query params vs presets. Versioning. Backward compatibility with existing captures.
+
+6. **Security implications**: What attack surface does parameterization open? Cookie injection, JavaScript execution, SSRF via session state, resource exhaustion via complex parameters.
+
+7. **Complexity vs value tradeoff**: Is this worth building at all? YAGNI considerations. Could a simpler approach (e.g., just CSS-hiding cookie banners) solve 80% of the problem?
+
+### Technical constraints
+
+- Runs on Cloudflare Workers with Browser Rendering (Playwright)
+- Captures must complete within Workers CPU/wall-time limits
+- Browser sessions are ephemeral (no session reuse between captures)
+- Ed25519 signatures cover all capture artifacts
+- Current API: POST /v1/captures with { url } body
+- Single-tenant today, multi-tenant planned (R12)
+
+### What I want from the advisory
+
+- Clear recommendation on whether to pursue parameterization
+- If yes: phased approach with priority ordering
+- Cookie consent handling as a specific deep-dive (biggest pain point)
+- Security model for accepting browser-controlling parameters
+- Backlog items with sizing and dependencies
+- Honest assessment of complexity vs value


### PR DESCRIPTION
## Summary

Advisory report from 6-specialist nefario team on whether WRL should support parameterized capture requests (cookie consent handling, viewport, wait conditions, session injection).

**Recommendation**: Don't build general parameterization. Address cookie banners with dual-screenshot approach (before + after consent dismissal) using `@duckduckgo/autoconsent`. Sequenced as Wave 3 after #53 and #41 merge.

## Changes

- Advisory report + companion directory with all specialist contributions
- Evolution log entry (0021-capture-parameterization-advisory)
- Three new backlog parking lot items (consent dismissal [should], viewport [consider], captureSettings schema [consider])
- Backlog updated: R17 dependency dropped from consent dismissal trigger

## Related

- Created #58 (dual-screenshot cookie consent dismissal)
- Advisory report: `docs/history/nefario-reports/2026-03-16-120123-capture-parameterization.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
