### PR TITLE
chore: add fail-loudly and test-real-boundaries principles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,4 +96,17 @@ Key principles that apply to all work here:
   unless a framework adds specific, demonstrable value.
   Don't default to React, Vue, Tailwind CSS, jQuery, etc. just because they're popular.
   Always ask: "What does this dependency give me that I can't do simply without it?"
+- **Fail loudly, degrade intentionally** -- silent `catch {}` blocks are forbidden.
+  Every catch must either log the error or handle a specific, named error type.
+  When a feature degrades (e.g., timestamp unavailable), the system must distinguish
+  "service unavailable" from "misconfigured" in both logs and API responses. Use
+  distinct status values (e.g., `'error'` vs `'skipped'`) so operators can tell
+  the difference. If you swallow an error, you own the next incident it hides.
+- **Test the real boundaries** -- this product captures web pages with headless
+  browsers. Mocking out the browser is like testing an HTTP server without sending
+  requests. Unit tests with mocked renderers are fine for orchestration logic, but
+  integration tests must exercise the real external boundaries (browser, network,
+  third-party services). When adding a feature that depends on an external service,
+  the test suite must include at least one assertion that the integration actually
+  works end-to-end.
 


### PR DESCRIPTION
## Summary

- Adds two engineering principles to CLAUDE.md based on post-mortem of #66 and #67:
  - **Fail loudly, degrade intentionally** — no silent `catch {}` blocks; distinguish "unavailable" from "misconfigured" in logs and API responses
  - **Test the real boundaries** — integration tests must exercise actual browser, network, and third-party service paths, not just mocked orchestration

## Related issues

- #69 — Integration tests with real browser captures (`test:integration`)
- #70 — Eliminate silent catch blocks

## Context

Both #66 (TSA HTTPS misconfiguration invisible due to silent catch) and #67 (networkidle timeout budget invisible due to mocked renderers) shipped through a test suite with 449 passing tests. The tests are good at orchestration logic but never exercise the two external boundaries that matter most: real browsers and real network calls.

## Test plan

- [x] CLAUDE.md renders correctly
- [x] No functional code changes — principles only

🤖 Generated with [Claude Code](https://claude.com/claude-code)
