### PR TITLE
fix(wacz): log TSA errors instead of silently swallowing

### DIFF
--- a/src/wacz.js
+++ b/src/wacz.js
@@ -25,6 +25,7 @@ import { buildWarc, sha256 } from './warc.js';
 import { buildCdxj } from './cdxj.js';
 import { canonicalize } from './canonical-json.js';
 import { requestTimestamp } from './rfc3161.js';
+import { log } from './log.js';
 
 const enc = new TextEncoder();
 
@@ -108,8 +109,8 @@ export async function buildWacz(url, captureDate, artifacts, env) {
   if (env.TSA_URL) {
     try {
       tsaResult = await requestTimestamp(env.TSA_URL, bundleHash);
-    } catch {
-      // TSA unreachable -- capture continues without timestamp
+    } catch (err) {
+      log(env, 4, 'capture', { event: 'capture.tsa_fail', errorClass: err?.constructor?.name, errorMessage: String(err?.message ?? '').slice(0, 256) });
     }
   }
 


### PR DESCRIPTION
## Summary
- Replace empty `catch {}` block in TSA timestamp request with error logging to Coralogix
- Enables diagnosing why Sectigo TSA fails in production (Cloudflare Workers) despite working from curl/Node.js

## Context
After merging #68 (TSA switch to Sectigo), production captures show `timestampStatus: absent` -- the TSA call fails silently. This adds observability so we can see the actual error.

## Test plan
- [x] `test/wacz.test.js` passes (15 tests)
- [ ] After deploy: trigger capture, check Coralogix for `capture.tsa_fail` event

Resolves the silent failure described in CLAUDE.md "Fail loudly, degrade intentionally" principle.