### PR TITLE
feat(capture): switch navigation from networkidle to load + settle delay

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -77,7 +77,7 @@ Deferred items with explicit activation triggers. Revisit when condition is met.
 
 | Item | Condition | Source |
 |------|-----------|--------|
-| [should] Screenshot timing / wait-for-load | When a user reports incomplete renders | kickoff |
+| ~~[should] Screenshot timing / wait-for-load~~ | ~~When a user reports incomplete renders~~ | DONE (0029-load-settle-strategy, #67) |
 | ~~[should] Dual-screenshot cookie consent dismissal (#58)~~ | ~~After Act 1 and Wave 2 merge~~ | DONE (0025-dual-screenshot-consent) |
 | [consider] Screenshot height cap configurability | When a user reports capped screenshots as a problem | edge-minion, capture-endpoint |
 | [consider] Viewport parameterization | When a user reports viewport size as a problem | 0017-advisory: api-design, security |

--- a/docs/evolution/0029-load-settle-strategy/decisions.md
+++ b/docs/evolution/0029-load-settle-strategy/decisions.md
@@ -1,0 +1,58 @@
+# Decisions: 0029-load-settle-strategy
+
+## D1: NAV_TIMEOUT_MS stays at 20s (not 25s)
+
+Issue #67 said "restored to 25s (or justified if kept at 20s)." Both planning
+specialists (debugger-minion and test-minion) independently flagged budget
+overrun risk with 25s.
+
+**The math**: With `waitUntil: 'load'`, NAV_TIMEOUT_MS now covers only the
+`load` event (DOM + sync subresources), not network idle. For healthy sites,
+`load` fires in 1-5s. For pathological sites, 10-15s. A 20s timeout is
+generous.
+
+**Budget at 25s**: 25 (goto) + 3 (settle) + 8 (consent) + 2 (post) = 38s.
+Exceeds the 30s `ctx.waitUntil` hard limit.
+
+**Budget at 20s**: 20 (goto) + 3 (settle) + 8 (consent) + 2 (post) = 33s.
+Still tight worst-case, but if `goto` takes 20s, `TimeoutError` fires and
+the staged fallback runs (settle delay never executes). Realistic worst:
+10 + 3 + 8 + 2 = 23s.
+
+**Why 25s saves nothing**: Any site needing >20s to fire the `load` event is
+broken. The `load` event is not `networkidle` -- it fires when the DOM and
+images/CSS/iframes are loaded, before tracking scripts settle. 20s is already
+generous for this narrower event.
+
+**Alternatives rejected**:
+- 25s with budget check before consent: adds complexity, fragile, YAGNI
+- 25s with shorter settle: defeats the purpose of the settle delay
+
+## D2: Plain timer (`setTimeout`) for settle delay
+
+Three options were evaluated:
+- **Option A: `page.waitForTimeout(3000)`** -- deterministic, no hang risk
+- **Option B: `page.waitForLoadState('networkidle')` with 3s timeout** -- could
+  succeed early on clean sites, but risks TimeoutError confusion with the staged
+  fallback's catch block
+- **Option C: Custom idle detection** -- monitors network activity, MutationObserver,
+  returns early when "settled". Over-engineered for the problem.
+
+Chose Option A (implemented via `setTimeout` since `@cloudflare/playwright` may
+not expose `waitForTimeout`). Deterministic, zero risk, simple.
+
+## D3: Post-settle limitExceeded re-check (security advisory)
+
+security-minion flagged during Phase 3.5: the response listener continues
+processing during the 3s settle window. A malicious page could stream large
+responses during settle to bypass the 50MB size cap. Added a second
+`if (limitExceeded) throw` after the settle delay. Two-line fix, closes the
+gap completely.
+
+## D4: categorizeError template literal refactor
+
+Changed hardcoded `"Page did not finish loading within 20 seconds"` to
+`` `Page did not finish loading within ${NAV_TIMEOUT_MS / 1000} seconds` ``.
+Since NAV_TIMEOUT_MS stays at 20000, the output is identical. This is a
+single-point-of-truth improvement that prevents drift if the timeout ever
+changes. All 4 error message assertions continue to pass unchanged.

--- a/docs/evolution/0029-load-settle-strategy/outcome.md
+++ b/docs/evolution/0029-load-settle-strategy/outcome.md
@@ -1,0 +1,48 @@
+# Outcome: 0029-load-settle-strategy
+
+## What was built
+
+Switched `defaultRenderer()` in `src/capture.js` from `waitUntil: 'networkidle'`
+to `waitUntil: 'load'` with a 3-second post-load settle delay. This eliminates
+the 20s wait for network silence on ad-heavy sites whose tracking scripts keep
+connections alive indefinitely.
+
+## Files changed
+
+| File | Lines | Description |
+|------|-------|-------------|
+| `src/capture.js` | +17/-8 | New `SETTLE_DELAY_MS` constant, `waitUntil: 'load'`, 3s settle delay with post-settle `limitExceeded` re-check, `categorizeError()` template literal, updated comments |
+| `test/fixtures.js` | +3/-3 | 3 renderers: `waitUntilReached` from `'networkidle'` to `'load'` |
+| `test/capture.test.js` | +2/-2 | Inline renderer and assertion: `'networkidle'` to `'load'` |
+| `openapi.yaml` | +16/-13 | RenderInfo and CaptureRecord descriptions updated; enum preserved for backward compat |
+
+Total: 4 files, +38/-26 lines.
+
+## Test results
+
+497 tests pass, 0 failures. No test regressions.
+
+## What changed from the issue
+
+- **NAV_TIMEOUT_MS kept at 20s** instead of the issue's default 25s. See
+  `decisions.md` D1 for justification. Both planning specialists and the
+  synthesis agent agreed 20s is correct.
+- **Post-settle `limitExceeded` re-check** added per security-minion advisory
+  during Phase 3.5 review. Not in the original issue scope but closes a
+  real gap.
+
+## What didn't change
+
+- Staged fallback path (lines 404-452) -- structurally identical
+- Consent dismissal logic -- unmodified
+- WACZ/signing pipeline -- unmodified
+- Partial capture behavior -- unmodified
+- `waitUntilReached` enum in OpenAPI -- all three values preserved
+
+## Backlog changes
+
+- **Updated**: `[should] Screenshot timing / wait-for-load` in Capture Fidelity
+  parking lot -- this is effectively resolved by this phase. Should be marked
+  done with a reference to 0029.
+- No items added.
+- No items removed.

--- a/docs/evolution/0029-load-settle-strategy/process.md
+++ b/docs/evolution/0029-load-settle-strategy/process.md
@@ -1,0 +1,134 @@
+# Process: 0029-load-settle-strategy
+
+## TL;DR
+
+Two planning specialists, five architecture reviewers, and one execution agent
+turned a well-scoped issue (#67) into a 4-file, +38/-26 line change in about
+25 minutes of agent time. The interesting moment: both specialists independently
+flagged that the issue's suggested NAV_TIMEOUT_MS value (25s) would break the
+30s budget ceiling -- the synthesis resolved this by keeping 20s with documented
+justification. Security review caught a real gap (post-settle size limit bypass)
+that wasn't in anyone's plan.
+
+## Which specialists were consulted and why
+
+**Phase 1 (Meta-plan)**: Nefario identified this as a narrow timing change in a
+single source file (`src/capture.js`) with mechanical test and spec updates.
+Selected only two specialists:
+
+- **debugger-minion**: Core question was a runtime performance problem -- choosing
+  the right settle mechanism for ad-heavy pages. Three options existed
+  (`waitForTimeout`, `waitForLoadState('networkidle')` with short timeout, custom
+  idle detection) with real tradeoffs.
+- **test-minion**: The `networkidle` string appeared in 5 test locations across
+  2 files. Needed systematic identification of all assertion updates and a
+  judgment call on whether the settle delay warranted its own test coverage.
+
+No other specialists were selected for planning. The exclusion rationale was
+explicit: security, observability, docs, and UX agents would participate in
+Phase 3.5 review, but adding them to planning would not materially improve the
+plan for this narrowly-scoped change.
+
+## What each specialist argued
+
+**debugger-minion** recommended `page.waitForTimeout(3000)` (Option A, plain
+timer) over the alternatives. The key argument: Option B
+(`waitForLoadState('networkidle')` with a 3s timeout) would throw a
+`TimeoutError` on ad-heavy sites when the 3s settle expired, and this error
+could leak into the staged fallback's catch block at line 405. The staged
+fallback catches `TimeoutError` by name and attempts partial capture -- a
+settle-phase timeout would trigger partial capture logic for a page that
+actually loaded successfully. This was the strongest technical argument in
+the planning phase.
+
+debugger-minion also flagged the budget overrun: NAV_TIMEOUT_MS at 25s creates
+a worst case of 25 + 3 + 8 + 2 = 38s, exceeding the 30s hard limit.
+
+**test-minion** completed the fixture audit: 3 renderers in `fixtures.js`,
+1 inline renderer and 1 assertion in `capture.test.js`, plus 4 error message
+assertions that would stay unchanged since NAV_TIMEOUT_MS stays at 20s. The
+key judgment: no new renderer variant for the settle delay. The settle is an
+implementation detail that doesn't surface in the renderer's output contract
+(`{ screenshot, html, partial, render, consent, screenshotBefore }`) -- the
+only observable change is `render.waitUntilReached` switching from
+`'networkidle'` to `'load'`, which is a value update, not a shape change.
+
+test-minion raised the same budget concern independently.
+
+## Where they disagreed
+
+No substantive disagreements. Both specialists converged on the same
+recommendations. The only difference was in emphasis: debugger-minion focused
+on the settle mechanism tradeoffs (why Option A beats B and C), while
+test-minion focused on the mechanical update surface and whether to add settle
+delay test coverage (answer: no, it's a passive timer with no branching logic).
+
+## How conflicts were resolved in synthesis
+
+**NAV_TIMEOUT_MS (25s vs 20s)**: The issue said "restored to 25s (or justified
+if kept at 20s)." Both specialists flagged overrun risk. Nefario's synthesis
+resolved this by keeping 20s with explicit justification: the `load` event is
+a much narrower target than `networkidle`. For healthy sites, `load` fires in
+1-5s. A 20s timeout is generous. Raising to 25s saves zero real-world captures
+(any site needing >20s for `load` is broken) but creates a genuine overrun
+window (pages where `load` fires at 22-24s succeed but settle + consent push
+past 30s).
+
+This is a case where the issue author's default expectation was wrong but
+they explicitly provided an escape hatch ("or justified if kept at 20s"). The
+justification is documented in `decisions.md` D1 and in a code comment.
+
+## What the architecture reviewers found
+
+Five mandatory reviewers (security-minion, test-minion, ux-strategy-minion,
+lucy, margo) ran in Phase 3.5:
+
+- **security-minion (ADVISE)**: Caught a real gap. The `limitExceeded` flag is
+  set by an async response listener. The plan checks it before the settle delay
+  but not after. During the 3s settle window, a malicious page could stream
+  large chunked responses to push `totalBytes` past `MAX_PAGE_BYTES` without
+  triggering the guard. Fix: add a second `if (limitExceeded) throw` after the
+  settle delay. This was incorporated into the execution task.
+
+- **test-minion (APPROVE)**: Confirmed all fixture and assertion updates were
+  accounted for.
+
+- **ux-strategy-minion (APPROVE)**: Noted the `waitUntilReached` value change
+  from `networkidle` to `load` actually reduces conceptual leakage -- `load`
+  is a standard browser lifecycle concept that API consumers understand, while
+  `networkidle` is a Playwright abstraction.
+
+- **lucy (APPROVE with 2 advisories)**: Verified CLAUDE.md compliance and
+  alignment with Helix Manifesto. Both advisories were procedural: ensure
+  backlog update and NAV_TIMEOUT_MS justification are captured in the evolution
+  log.
+
+- **margo (APPROVE)**: Confirmed proportionate complexity. Called out the
+  `waitForTimeout` choice as "the simplest possible implementation."
+
+## What the human changed at approval gates
+
+All gates were auto-approved per the human's directive ("skip all approval
+gates -- defer decisions to gru and lucy"). The human's only intervention
+during the orchestration was checking that merging PR #68 to main didn't
+create conflicts in the worktree (it didn't).
+
+## What the human chose NOT to intervene on
+
+- **NAV_TIMEOUT_MS at 20s**: The human did not override the synthesis decision
+  to keep 20s despite the issue suggesting 25s. Both specialists' budget
+  analysis was convincing.
+- **The security advisory**: The post-settle `limitExceeded` re-check was
+  incorporated without human review. It was a two-line addition with clear
+  rationale and no controversy.
+- **Code review NITs**: 4 NITs from code-review-minion. One (comment arithmetic
+  error) was fixed. Three (variable naming, DRY opportunity, Playwright
+  `networkidle` definition precision) were left for future cleanup.
+
+## Where to read more
+
+- Specialist contributions: `docs/history/nefario-reports/` companion directory
+  (phase2-debugger-minion.md, phase2-test-minion.md)
+- Architecture review verdicts: companion directory (phase3.5-*.md)
+- Full synthesis/delegation plan: companion directory (phase3-synthesis.md)
+- Execution report: `docs/history/nefario-reports/` (timestamped .md file)

--- a/docs/evolution/0029-load-settle-strategy/prompt.md
+++ b/docs/evolution/0029-load-settle-strategy/prompt.md
@@ -1,0 +1,27 @@
+# Phase 0029: Switch navigation wait strategy from networkidle to load + settle delay
+
+Source: GitHub issue #67
+
+## Outcome
+
+Captures complete reliably for ad-heavy sites (tagesschau.de, adobe.com) that visually load in 2-3s but whose tracking scripts keep network connections alive indefinitely. Currently `page.goto()` uses `waitUntil: 'networkidle'` which burns 20s of the 30s `ctx.waitUntil` budget waiting for network silence that never comes, leaving the partial capture fallback too little time to succeed (tall page screenshots exceed the 2s deadline, cold browser sessions push total time past 30s).
+
+## Success criteria
+
+- tagesschau.de and adobe.com captures complete successfully (not timeout/pending)
+- Navigation phase completes in under 10s for typical sites (currently 20s+)
+- Sufficient time budget remains for consent dismissal (8s), screenshots, WACZ building, and R2/KV writes
+- All existing tests pass
+- Staged fallback from #53 remains functional as safety net for pages that don't reach the load event
+- NAV_TIMEOUT_MS restored to 25s (or justified if kept at 20s)
+
+## Scope
+
+**In:** `page.goto()` wait strategy in `defaultRenderer()`, settle delay after load event, NAV_TIMEOUT_MS value, related test assertions
+
+**Out:** Consent dismissal logic, WACZ/signing pipeline, partial capture fallback rewrite, general capture parameterization
+
+## Constraints
+
+- Use `waitUntil: 'load'` with a post-load settle delay (~3s) to allow late-rendering JS to complete
+- Must fit within the 30s `ctx.waitUntil` hard limit including all downstream work

--- a/docs/evolution/README.md
+++ b/docs/evolution/README.md
@@ -37,3 +37,4 @@ software development.
 | [0026-secrets-env-docs-onboarding](0026-secrets-env-docs-onboarding/) | Secrets and environment documentation for fork-ready onboarding |
 | [0027-dual-screenshot-consent](0027-dual-screenshot-consent/) | Dual-screenshot cookie consent dismissal via autoconsent (Issue #58) |
 | [0028-tsa-sectigo](0028-tsa-sectigo/) | Switch RFC 3161 TSA from DigiCert to Sectigo (Issue #66) |
+| [0029-load-settle-strategy](0029-load-settle-strategy/) | Switch navigation from networkidle to load + settle delay (Issue #67) |

--- a/docs/history/nefario-reports/2026-03-16-183802-load-settle-strategy.md
+++ b/docs/history/nefario-reports/2026-03-16-183802-load-settle-strategy.md
@@ -1,0 +1,157 @@
+---
+task: "Switch navigation from networkidle to load + settle delay"
+date: 2026-03-16
+source-issue: 67
+status: complete
+mode: execution
+task-count: 1
+gate-count: 0
+agents-consulted: [debugger-minion, test-minion, security-minion, ux-strategy-minion, lucy, margo, code-review-minion]
+compaction-events: 0
+---
+
+## Summary
+
+Switched `page.goto()` from `waitUntil: 'networkidle'` to `waitUntil: 'load'`
+with a 3s post-load settle delay in `defaultRenderer()`. Ad-heavy sites
+(tagesschau.de, adobe.com) that visually load in 2-3s but whose tracking
+scripts keep network connections alive indefinitely no longer burn the full
+NAV_TIMEOUT_MS budget waiting for network silence. 4 files changed (+38/-26
+lines), 497 tests pass.
+
+NAV_TIMEOUT_MS kept at 20s (not raised to 25s per issue suggestion) because
+the `load` event is a much narrower target than `networkidle` and 25s creates
+a real budget overrun window. Both planning specialists independently flagged
+this risk.
+
+## Original Prompt
+
+Switch navigation wait strategy from networkidle to load + settle delay
+(GitHub issue #67). Ad-heavy sites burn 20s waiting for network silence that
+never comes, leaving insufficient budget for consent dismissal, screenshots,
+and WACZ packaging.
+
+## Key Design Decisions
+
+1. **NAV_TIMEOUT_MS stays at 20s** -- 25s creates budget overrun
+   (25+3+8+2=38s > 30s limit). 20s is generous for the `load` event.
+2. **Plain `setTimeout` for settle delay** -- deterministic, no hang risk,
+   avoids TimeoutError confusion with staged fallback catch block.
+3. **Post-settle `limitExceeded` re-check** -- security advisory from
+   Phase 3.5. Closes async size-limit bypass window during settle.
+4. **Template literal in `categorizeError()`** -- derives message from
+   constant. Single point of truth.
+
+## Phases
+
+### Phase 1: Meta-Plan
+Nefario selected 2 planning specialists: debugger-minion (settle mechanism
+tradeoffs) and test-minion (fixture/assertion audit). Excluded security, docs,
+UX, and observability from planning -- narrow scope, Phase 3.5 provides
+architectural coverage.
+
+### Phase 2: Specialist Planning
+Two specialists ran in parallel. Both independently flagged the NAV_TIMEOUT_MS
+budget overrun risk. debugger-minion evaluated three settle options (plain
+timer, networkidle-with-timeout, custom idle detection) and recommended the
+simplest. test-minion identified all 5 test locations needing updates and
+determined no new renderer variants were needed.
+
+### Phase 3: Synthesis
+Consolidated into 1 task, 0 gates. Resolved NAV_TIMEOUT_MS conflict by
+keeping 20s with documented justification (issue explicitly allowed this).
+Single-task structure appropriate for 4-file change.
+
+### Phase 3.5: Architecture Review
+5 mandatory reviewers. security-minion caught a real gap (post-settle size
+limit bypass) and recommended a 2-line fix. All others approved. lucy
+reminded about evolution log completeness.
+
+### Phase 4: Execution
+Single batch, single agent (debugger-minion on sonnet). All changes applied
+cleanly. 497 tests pass. Security advisory incorporated (second
+`limitExceeded` check after settle delay).
+
+### Phase 5: Code Review
+code-review-minion: APPROVE with 4 NITs. One fixed (comment arithmetic).
+Three deferred (variable naming, DRY opportunity, Playwright definition
+precision).
+
+### Phase 6: Test Execution
+497 tests pass, 0 failures.
+
+### Phase 7: Deployment
+Skipped (not requested).
+
+### Phase 8: Documentation
+Phase 8a: 0 documentation items identified. OpenAPI spec updated inline
+during execution. Evolution log entries written.
+
+## Agent Contributions
+
+| Agent | Phase | Role | Verdict |
+|-------|-------|------|---------|
+| debugger-minion | planning | Settle mechanism analysis, budget math | -- |
+| test-minion | planning | Fixture/assertion audit | -- |
+| security-minion | review | Post-settle limitExceeded gap | ADVISE |
+| test-minion | review | Test coverage verification | APPROVE |
+| ux-strategy-minion | review | API consumer experience | APPROVE |
+| lucy | review | Convention compliance | APPROVE (2 advisories) |
+| margo | review | Complexity check | APPROVE |
+| debugger-minion | execution | Implementation | -- |
+| code-review-minion | post-exec | Code quality | APPROVE (4 NITs) |
+
+## Verification
+
+Verification: code review passed (4 NITs, 1 fixed), all 497 tests pass.
+
+## Execution
+
+### Task 1: Switch navigation from networkidle to load + settle delay
+- **Agent**: debugger-minion (sonnet)
+- **Files**: `src/capture.js` (+17/-8), `test/fixtures.js` (+3/-3),
+  `test/capture.test.js` (+2/-2), `openapi.yaml` (+16/-13)
+- **Outcome**: All changes applied, tests pass
+
+## Decisions
+
+### NAV_TIMEOUT_MS: 20s (not 25s)
+Both specialists flagged budget overrun at 25s. With `waitUntil: 'load'`,
+20s is generous (load fires in 1-5s typical). 25s creates overrun window.
+Issue explicitly allowed "justified if kept at 20s."
+
+### Settle mechanism: plain timer
+`setTimeout(3000)` over `waitForLoadState('networkidle')` with timeout
+(TimeoutError confusion) and custom idle detection (over-engineered).
+
+## Session Resources
+
+<details>
+<summary>Skills Invoked</summary>
+
+- `/nefario` (this orchestration)
+
+</details>
+
+<details>
+<summary>Working Files</summary>
+
+Companion directory: `docs/history/nefario-reports/2026-03-16-183802-load-settle-strategy/`
+
+Files:
+- `prompt.md` -- original prompt
+- `phase1-metaplan-prompt.md`, `phase1-metaplan.md` -- meta-plan
+- `phase2-debugger-minion-prompt.md`, `phase2-debugger-minion.md` -- debugger planning
+- `phase2-test-minion-prompt.md`, `phase2-test-minion.md` -- test planning
+- `phase3-synthesis-prompt.md`, `phase3-synthesis.md` -- synthesis
+- `phase3.5-security-minion.md` -- security review (ADVISE)
+- `phase3.5-test-minion.md` -- test review (APPROVE)
+- `phase3.5-ux-strategy-minion.md` -- UX review (APPROVE)
+- `phase3.5-lucy.md` -- lucy review (APPROVE)
+- `phase3.5-margo.md` -- margo review (APPROVE)
+- `phase4-debugger-minion-prompt.md` -- execution prompt
+- `phase5-code-review-minion.md` -- code review (APPROVE)
+
+</details>
+
+Compaction events: 0

--- a/docs/history/nefario-reports/2026-03-16-183802-load-settle-strategy/phase1-metaplan-prompt.md
+++ b/docs/history/nefario-reports/2026-03-16-183802-load-settle-strategy/phase1-metaplan-prompt.md
@@ -1,0 +1,58 @@
+MODE: META-PLAN
+
+You are creating a meta-plan -- a plan for who should help plan.
+
+## Task
+
+Switch navigation wait strategy from networkidle to load + settle delay.
+
+Captures complete reliably for ad-heavy sites (tagesschau.de, adobe.com) that visually load in 2-3s but whose tracking scripts keep network connections alive indefinitely. Currently `page.goto()` uses `waitUntil: 'networkidle'` which burns 20s of the 30s `ctx.waitUntil` budget waiting for network silence that never comes, leaving the partial capture fallback too little time to succeed (tall page screenshots exceed the 2s deadline, cold browser sessions push total time past 30s).
+
+### Success criteria
+- tagesschau.de and adobe.com captures complete successfully (not timeout/pending)
+- Navigation phase completes in under 10s for typical sites (currently 20s+)
+- Sufficient time budget remains for consent dismissal (8s), screenshots, WACZ building, and R2/KV writes
+- All existing tests pass
+- Staged fallback from #53 remains functional as safety net for pages that don't reach the load event
+- NAV_TIMEOUT_MS restored to 25s (or justified if kept at 20s)
+
+### Scope
+**In:** `page.goto()` wait strategy in `defaultRenderer()`, settle delay after load event, NAV_TIMEOUT_MS value, related test assertions
+
+**Out:** Consent dismissal logic, WACZ/signing pipeline, partial capture fallback rewrite, general capture parameterization
+
+### Constraints
+- Use `waitUntil: 'load'` with a post-load settle delay (~3s) to allow late-rendering JS to complete
+- Must fit within the 30s `ctx.waitUntil` hard limit including all downstream work
+
+## Working Directory
+/Users/ben/github/benpeter/web-resource-ledger/.claude/worktrees/nefario/load-settle-strategy
+
+## External Skill Discovery
+Before analyzing the task, scan for project-local skills. If skills are discovered, include an "External Skill Integration" section in your meta-plan.
+
+## Instructions
+1. Read relevant files to understand the codebase context
+2. Discover external skills:
+   a. Scan .claude/skills/ and .skills/ in the working directory for SKILL.md files
+   b. Read frontmatter (name, description) for each discovered skill
+   c. For skills whose description matches the task domain, classify as ORCHESTRATION or LEAF
+   d. Check the project's CLAUDE.md for explicit skill preferences
+   e. Include discovered skills in your meta-plan output
+3. Analyze the task against your delegation table
+4. Identify which specialists should be CONSULTED FOR PLANNING (not execution -- planning). These are agents whose domain expertise is needed to create a good plan.
+5. For each specialist, write a specific planning question that draws on their unique expertise.
+6. Return the meta-plan in the structured format.
+7. Write your complete meta-plan to /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-SJRIzw/load-settle-strategy/phase1-metaplan.md
+
+## Key Codebase Context
+
+The main file to change is `src/capture.js`, specifically:
+- Line 84: `const NAV_TIMEOUT_MS = 20000;` (needs to be 25000 per issue)
+- Line 403: `await page.goto(url, { timeout: NAV_TIMEOUT_MS, waitUntil: 'networkidle' });` (change to 'load' + settle delay)
+- Line 482: `waitUntilReached: 'networkidle'` in render metadata (update to 'load')
+- The partial capture fallback (lines 404-452) catches TimeoutError and must continue working
+
+Test file: `test/capture.test.js` and `test/fixtures.js` have several renderers that reference 'networkidle' in waitUntilReached field.
+
+This is a focused change -- about 3 constants and the goto call, plus test assertions.

--- a/docs/history/nefario-reports/2026-03-16-183802-load-settle-strategy/phase1-metaplan.md
+++ b/docs/history/nefario-reports/2026-03-16-183802-load-settle-strategy/phase1-metaplan.md
@@ -1,0 +1,107 @@
+# Meta-Plan: Switch navigation wait strategy from networkidle to load + settle delay
+
+## Task Analysis
+
+This is a focused, surgical change to the browser navigation strategy in `src/capture.js`. The core problem: `waitUntil: 'networkidle'` wastes 20s waiting for tracking scripts that never go quiet, leaving insufficient time budget for the rest of the capture pipeline. The fix: switch to `waitUntil: 'load'` with a ~3s post-load settle delay.
+
+### Change surface
+
+- **`src/capture.js`**: 3 touch points
+  - Line 84: `NAV_TIMEOUT_MS` from 20000 to 25000
+  - Line 403: `page.goto()` waitUntil from `'networkidle'` to `'load'`, plus a post-load `setTimeout` or `page.waitForTimeout` settle delay (~3s)
+  - Line 482: `waitUntilReached: 'networkidle'` metadata updated to `'load'`
+  - Line 400: Comment about timing budget needs updating
+  - Line 508: `categorizeError` timeout message references "20 seconds", needs updating to match new timeout
+- **`test/capture.test.js`**: Several test renderers and assertions reference `'networkidle'`
+  - Line 601-605: `enrichedStubRenderer` returns `waitUntilReached: 'networkidle'`
+  - Line 751: assertion `expect(record.render.waitUntilReached).toBe('networkidle')`
+  - Lines 141, 290, 713: error message assertions reference "20 seconds"
+- **`test/fixtures.js`**: Multiple renderer stubs return `waitUntilReached: 'networkidle'`
+  - Lines 42, 55, 67: three renderer fixtures
+
+### Constraints
+
+- Must fit within 30s `ctx.waitUntil` hard limit: NAV_TIMEOUT_MS (25s) + settle (~3s) cuts into the consent (8s) + screenshot + WACZ budget. The settle delay must be inside the NAV_TIMEOUT_MS budget, not additive.
+- Partial capture fallback (lines 404-452) must remain functional -- it catches `TimeoutError` when navigation exceeds the timeout.
+- The settle delay occurs after the `load` event fires but before taking screenshots -- it gives late-rendering JS time to paint.
+
+---
+
+## Planning Consultations
+
+### Consultation 1: Timing budget and settle delay implementation
+
+- **Agent**: debugger-minion
+- **Planning question**: Given the 30s `ctx.waitUntil` hard limit and the pipeline stages (navigation + settle, consent dismissal at 8s, screenshots, WACZ build, R2/KV writes), what is the optimal settle delay duration and where exactly should it be placed in `defaultRenderer()`? Should the settle delay use `page.waitForTimeout()`, `page.waitForLoadState('networkidle')` with a short timeout as a "best effort" settle, or a custom idle detection approach? What are the tradeoffs of each approach for ad-heavy sites like tagesschau.de and adobe.com?
+- **Context to provide**: Full `defaultRenderer()` function (lines 343-495 of `src/capture.js`), the 30s budget breakdown (NAV + consent 8s + post-processing), the specific failure mode (tracking scripts keep connections alive indefinitely).
+- **Why this agent**: debugger-minion has expertise in root cause analysis and performance profiling. The core question here is a runtime behavior problem -- understanding when "visually loaded" actually occurs for ad-heavy pages and choosing the right mechanism to detect it.
+
+### Consultation 2: Test fixture and assertion updates
+
+- **Agent**: test-minion
+- **Planning question**: The change from `networkidle` to `load` affects render metadata values in test fixtures (`test/fixtures.js`) and several assertions in `test/capture.test.js`. Should the `enrichedStubRenderer` and consent renderers in fixtures.js simply change `waitUntilReached` from `'networkidle'` to `'load'`, or should we add a new renderer variant that reflects the settle-delay behavior? Are there any test gaps -- specifically, should we add a test that verifies the settle delay is applied (e.g., a renderer that simulates post-load settling)?
+- **Context to provide**: `test/fixtures.js` (all renderers), `test/capture.test.js` (partial capture tests, full capture render metadata tests, error message assertions referencing "20 seconds").
+- **Why this agent**: test-minion ensures the test changes are complete and don't introduce coverage gaps, and can identify whether the settle delay itself needs test coverage.
+
+---
+
+## Cross-Cutting Checklist
+
+- **Testing**: Include test-minion for planning (Consultation 2 above). The change modifies test fixtures and assertions, and the settle delay mechanism may need its own test coverage.
+- **Security**: Exclude security-minion from planning. This change does not alter attack surface, authentication, user input handling, or dependency chain. The cross-domain navigation block, scheme guard, and all security constraints remain untouched. Security review can be deferred to Phase 3.5 mandatory review.
+- **Usability -- Strategy**: Exclude ux-strategy-minion from planning. This is a backend timing optimization with no user-facing interface change. The end result (faster, more reliable captures) is universally positive. UX review is better served at Phase 3.5 where it can confirm no user-visible behavior regression.
+- **Usability -- Design**: Exclude. No UI components involved.
+- **Documentation**: Exclude software-docs-minion and user-docs-minion from planning. The change is internal to one function. The file-level comment at the top of `capture.js` mentions the timing budget and will need a minor update, but that's execution work, not a planning question. Phase 8 post-execution can handle any doc needs.
+- **Observability**: Exclude observability-minion from planning. The existing structured logging (`capture.success`, `capture.partial`, `capture.stage.fail`) already captures `durationMs` and `render` metadata. The `waitUntilReached` field in render metadata will naturally reflect the change. No new log fields or metrics are needed.
+
+---
+
+## Anticipated Approval Gates
+
+**None.** This change has:
+
+- **Low blast radius**: Only `defaultRenderer()` in `src/capture.js` is modified, plus test fixture alignment.
+- **Easy to reverse**: Changing a constant and a `waitUntil` parameter back is trivial.
+- **Clear best practice**: The `load` + settle pattern is well-established for ad-heavy sites; `networkidle` being unsuitable for pages with tracking scripts is a known Playwright limitation.
+- **No downstream dependents**: No other tasks are gated on this decision.
+
+The plan should proceed without blocking gates. Phase 3.5 architecture review (mandatory reviewers: security, test, ux-strategy, lucy, margo) provides the safety net.
+
+---
+
+## Rationale
+
+This is a focused, well-scoped change with a clear root cause and a known solution pattern. Only two specialists are needed for planning:
+
+1. **debugger-minion** brings the performance/runtime expertise to recommend the specific settle delay implementation -- the core technical question. There are multiple valid approaches (fixed timeout, best-effort networkidle with short timeout, requestAnimationFrame-based idle detection) and the right choice depends on understanding the actual behavior of ad-heavy pages on Cloudflare Workers.
+
+2. **test-minion** ensures the test fixture changes are complete and identifies whether the settle mechanism itself warrants test coverage.
+
+Other specialists (security, ux-strategy, docs, observability) will participate in Phase 3.5 review or Phase 5-8 post-execution. Including them in planning would not materially improve the plan for this narrowly-scoped change.
+
+---
+
+## Scope
+
+**In scope:**
+- `page.goto()` `waitUntil` parameter change from `'networkidle'` to `'load'`
+- Post-load settle delay implementation (~3s, mechanism TBD based on debugger-minion input)
+- `NAV_TIMEOUT_MS` value change (20000 -> 25000, or justified alternative)
+- Timing budget comment updates in `defaultRenderer()`
+- `categorizeError()` timeout message update if NAV_TIMEOUT_MS changes
+- `waitUntilReached` metadata update in render result object
+- All test fixture and assertion updates to reflect the new strategy
+- File-level comment update for timing budget
+
+**Out of scope:**
+- Consent dismissal logic (`consent.js`)
+- WACZ/signing pipeline
+- Partial capture fallback rewrite (the existing fallback remains as safety net)
+- General capture parameterization
+- New logging fields or observability changes
+
+---
+
+## External Skill Integration
+
+No external skills detected in project. The global `juli` skill is unrelated (personal conversations).

--- a/docs/history/nefario-reports/2026-03-16-183802-load-settle-strategy/phase2-debugger-minion-prompt.md
+++ b/docs/history/nefario-reports/2026-03-16-183802-load-settle-strategy/phase2-debugger-minion-prompt.md
@@ -1,0 +1,55 @@
+You are contributing to the PLANNING phase of a multi-agent project.
+You are NOT executing yet -- you are providing your domain expertise to help build a comprehensive plan.
+
+## Project Task
+
+Switch navigation wait strategy from networkidle to load + settle delay in src/capture.js.
+
+Currently `page.goto()` uses `waitUntil: 'networkidle'` which burns 20s of the 30s `ctx.waitUntil` budget waiting for network silence that never comes on ad-heavy sites. The fix: switch to `waitUntil: 'load'` with a post-load settle delay (~3s).
+
+### Constraints
+- Use `waitUntil: 'load'` with a post-load settle delay (~3s)
+- Must fit within 30s `ctx.waitUntil` hard limit
+- NAV_TIMEOUT_MS should be restored to 25s (or justified if kept at 20s)
+- Staged fallback from #53 must remain functional
+
+## Your Planning Question
+
+Given the 30s `ctx.waitUntil` hard limit and the pipeline stages (navigation + settle, consent dismissal at 8s, screenshots, WACZ build, R2/KV writes), what is the optimal settle delay duration and where exactly should it be placed in `defaultRenderer()`? Should the settle delay use `page.waitForTimeout()`, `page.waitForLoadState('networkidle')` with a short timeout as a "best effort" settle, or a custom idle detection approach? What are the tradeoffs of each for ad-heavy sites like tagesschau.de and adobe.com?
+
+## Context
+
+Read the full source at:
+- /Users/ben/github/benpeter/web-resource-ledger/.claude/worktrees/nefario/load-settle-strategy/src/capture.js (focus on defaultRenderer, lines 343-495)
+
+The 30s budget breakdown currently:
+- NAV_TIMEOUT_MS = 20s (networkidle timeout)
+- Consent dismissal: 8s hard timeout
+- Post work: ~2s (screenshots, WACZ, R2/KV)
+
+With the new strategy (load + settle):
+- page.goto('load') should fire in 2-5s for typical sites
+- Settle delay: ~3s target
+- This frees up significant budget for downstream work
+
+## Instructions
+1. Read src/capture.js to understand the current flow
+2. Apply your domain expertise to the planning question
+3. Identify risks, dependencies, and requirements from your perspective
+4. Return your contribution in this format:
+
+## Domain Plan Contribution: debugger-minion
+
+### Recommendations
+<your expert recommendations for the settle delay implementation>
+
+### Proposed Tasks
+<specific tasks for the execution plan>
+
+### Risks and Concerns
+<things that could go wrong>
+
+### Additional Agents Needed
+<any specialists not yet involved who should be, and why, or "None">
+
+5. Write your complete contribution to /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-SJRIzw/load-settle-strategy/phase2-debugger-minion.md

--- a/docs/history/nefario-reports/2026-03-16-183802-load-settle-strategy/phase2-debugger-minion.md
+++ b/docs/history/nefario-reports/2026-03-16-183802-load-settle-strategy/phase2-debugger-minion.md
@@ -1,0 +1,164 @@
+# Domain Plan Contribution: debugger-minion
+
+## Recommendations
+
+### 1. Use `page.waitForTimeout(3000)` as the settle delay -- not `networkidle` with a short timeout
+
+Three approaches were asked about. Here is the analysis:
+
+**Option A: `page.waitForTimeout(3000)` (plain timer)**
+
+- Deterministic. Exactly 3000ms added to every successful `load` event.
+- No risk of hanging on ad-heavy sites -- the timer fires regardless of network state.
+- On fast pages (e.g., example.com where load fires in <1s), this "wastes" 3s. But the total navigation phase (load + settle) will be ~4s, far below the current 20s networkidle timeout.
+- Simple to reason about in budget analysis. No Playwright API quirks.
+
+**Option B: `page.waitForLoadState('networkidle')` with a short timeout (~3s) as "best effort"**
+
+- This is the approach that was explicitly rejected in Phase 0014 as adding complexity.
+- On ad-heavy sites (tagesschau.de, adobe.com), `networkidle` will never fire. The 3s timeout will always be hit, turning this into Option A with extra error-handling noise.
+- On clean sites, `networkidle` fires in <500ms, saving ~2.5s vs the timer. But the 30s budget is not tight enough to justify this optimization.
+- Risk: Playwright's `waitForLoadState` timeout throws a `TimeoutError`. This must be caught and swallowed, which introduces confusion with the *navigation* TimeoutError from `page.goto()`. The partial capture fallback catches `navError.name === 'TimeoutError'` (line 405) -- a settle-phase TimeoutError must not leak into that catch block.
+- Verdict: complexity for marginal gain. The error-confusion risk is real and the debugging tax is high.
+
+**Option C: Custom idle detection (e.g., MutationObserver + network quiescence)**
+
+- Most adaptive -- could detect when JS rendering actually completes.
+- Requires injecting a script via `page.evaluate()`, setting up MutationObserver, monitoring network activity, and racing with a timeout.
+- Substantial new code surface for a marginal improvement over a fixed timer.
+- Creates a new failure mode: the injected script could be blocked by CSP, or interact badly with page JS.
+- Verdict: violates KISS and YAGNI. Not warranted.
+
+**Recommendation: Option A (`page.waitForTimeout(3000)`).**
+
+It is the simplest approach that solves the stated problem. The ~3s "waste" on fast pages is a non-issue because the total pipeline time drops from 20-28s to 6-14s -- a massive improvement.
+
+### 2. Settle delay placement: immediately after `page.goto()` succeeds, before screenshots
+
+The settle delay should go at line 453 (immediately after the current `if (limitExceeded)` check), before the viewport height check and before-screenshot. The flow becomes:
+
+```
+page.goto(url, { timeout: NAV_TIMEOUT_MS, waitUntil: 'load' })
+  --> [on timeout: staged fallback path, unchanged from #53]
+  --> [on success: continue]
+if (limitExceeded) throw
+await page.waitForTimeout(SETTLE_DELAY_MS)  // <-- new
+// ... existing: viewport cap, before-screenshot, consent, after-screenshot, html
+```
+
+**Why before screenshots, not after**: The settle delay exists to let late-rendering JS (analytics callbacks, lazy-loaded images, font swaps, hydration) complete before the first screenshot. Placing it after the screenshot defeats the purpose.
+
+**Why not between the two screenshots**: The before-screenshot must capture the page as-loaded (with consent banner). The settle delay should ensure that the page has visually stabilized including any consent banner rendering. Consent dismissal happens after, and the after-screenshot is taken immediately because autoconsent's DOM manipulation is synchronous enough not to need another settle.
+
+### 3. NAV_TIMEOUT_MS should be raised to 25s
+
+Current value: 20s (set in Phase 0014 when `networkidle` was the wait strategy).
+
+With `waitUntil: 'load'`, the timeout covers a much narrower window: DNS + TLS + HTTP response + HTML parsing + subresource loading up to the `load` event. The `load` event fires when the DOM is complete and all synchronous subresources (images, CSS, iframes) are loaded. For healthy sites, this is 1-5s. For pathological sites, 10-15s.
+
+Budget breakdown with 25s NAV_TIMEOUT_MS + 3s settle:
+
+| Phase | Max duration | Cumulative |
+|-------|-------------|------------|
+| Session acquisition | ~0.5s (hot session) | 0.5s |
+| Navigation (load event) | 25s (timeout) | 25.5s |
+| Settle delay | 3s | 28.5s |
+| -- Remaining for consent + screenshots + WACZ + R2/KV | -- | 1.5s |
+
+That budget is too tight if navigation actually takes 25s. However:
+
+- If the `load` event takes 25s, the page is pathological and the staged fallback should handle it.
+- The NAV_TIMEOUT_MS acts as a safety net, not an expected duration. Typical `load` fires in 2-5s.
+- Realistic worst-case budget (5s load + 3s settle + 8s consent + 2s post): 18s, well within 30s.
+
+**Recommendation**: Set NAV_TIMEOUT_MS to 25s. But the staged fallback catch block must account for the settle delay having NOT yet run. See Risk #2 below.
+
+### 4. The settle delay must NOT run on the partial capture path
+
+The staged fallback (lines 402-451) catches `TimeoutError` from `page.goto()` and gives itself a 2s deadline for screenshot + HTML extraction. If the settle delay is inside the `try` block before the catch, it does not execute on timeout (correct). But this must be verified in the implementation -- the settle delay placement must be strictly after the `page.goto()` try/catch block's successful path.
+
+### 5. The `render.waitUntilReached` field should change from `'networkidle'` to `'load'`
+
+Line 482 currently reports `waitUntilReached: 'networkidle'`. This must change to `'load'` for the happy path. The partial path already correctly reports the `readyState`-derived value (line 440). The `openapi.yaml` enum already includes `'load'` as a valid value.
+
+### 6. Introduce a named constant `SETTLE_DELAY_MS = 3000`
+
+Consistent with the project's pattern of naming timeouts (NAV_TIMEOUT_MS, HEADER_FETCH_TIMEOUT_MS, PARTIAL_SCREENSHOT_TIMEOUT_MS, PARTIAL_CONTENT_TIMEOUT_MS, CONSENT_TIMEOUT_MS). The delay value should be tunable in one place.
+
+### 7. The `categorizeError()` user-facing message should be updated
+
+Line 508: `'Page did not finish loading within 20 seconds'` -- this should reflect the new NAV_TIMEOUT_MS value. If NAV_TIMEOUT_MS changes to 25s, the message should say 25. Better: derive the message from the constant so it stays in sync.
+
+---
+
+## Proposed Tasks
+
+1. **Add `SETTLE_DELAY_MS = 3000` constant** alongside existing timeout constants (line ~88).
+
+2. **Change `page.goto()` from `waitUntil: 'networkidle'` to `waitUntil: 'load'`** at line 403.
+
+3. **Insert `await page.waitForTimeout(SETTLE_DELAY_MS)` on the happy path** -- after `if (limitExceeded) throw` (line 454), before viewport height check (line 457).
+
+4. **Restore `NAV_TIMEOUT_MS` to 25000** (line 84).
+
+5. **Update `render.waitUntilReached`** from `'networkidle'` to `'load'` on the happy-path return (line 482).
+
+6. **Update `categorizeError()` message** to reflect the new timeout value (or derive from constant).
+
+7. **Update the file-header comment** (line 15) which describes the budget as "NAV_TIMEOUT_MS=20s + 8s consent + 2s post" -- should reflect new budget breakdown.
+
+8. **Update the inline comment** at line 400 ("Navigate with 20s timeout; 8s consent window + 2s post-processing fits the 30s ctx.waitUntil budget") to describe the new strategy.
+
+9. **Update test assertions**: `enrichedStubRenderer` (fixtures.js line 601) reports `waitUntilReached: 'networkidle'` -- must change to `'load'`. The test at capture.test.js line 751 asserts `networkidle` -- must change. The error message assertion at line 141 ("within 20 seconds") needs updating if the message changes.
+
+10. **Verify staged fallback is unaffected**: The partial capture path (lines 402-451) should not be structurally modified. The `readyState` check and 2s deadline remain. Verify that changing `waitUntil` from `'networkidle'` to `'load'` does not alter when `TimeoutError` fires or what `document.readyState` returns at that point. (Answer: it does not -- `TimeoutError` fires when the timeout expires regardless of `waitUntil`, and `readyState` reflects DOM state independent of the Playwright wait strategy.)
+
+---
+
+## Risks and Concerns
+
+### Risk 1: Visual completeness regression on "clean" sites
+
+**What**: Pages that previously loaded with full visual fidelity under `networkidle` (which waits for 0 connections for 500ms) might now be screenshotted 3s after the `load` event, which for some sites could be before all async-rendered content appears.
+
+**Why it matters**: A JS-heavy SPA might fire `load` before React hydration completes. The 3s settle covers most hydration, but not all.
+
+**Mitigation**: The 3s settle is deliberately generous. React hydration on a typical page completes in <1s. Heavy SPAs (dashboards, apps) are not the target capture population for WRL -- the target is news articles, landing pages, and public content pages. Monitor `render.durationMs` in Coralogix after deployment; if captures consistently complete in <5s total, the settle delay is sufficient.
+
+**Detection**: Compare before/after screenshots for a set of known URLs. This is a manual verification step during the PR review, not an automated test.
+
+### Risk 2: Budget overrun if load event is slow AND settle runs
+
+If a site's `load` event fires at, say, 22s (just under a 25s timeout), the settle delay adds 3s, pushing total to 25s. Then consent (8s max) would push past 30s.
+
+**Mitigation**: This is the same class of site that currently times out at 20s under `networkidle`. The staged fallback handles this today. With the new strategy, these sites are more likely to succeed (load fires faster than networkidle on ad-heavy sites), but if they do time out, the fallback is unchanged.
+
+**However**: There is a subtler scenario. A page where `load` fires at 22s will NOT trigger the staged fallback (no TimeoutError). The settle delay then runs for 3s (total 25s), and the consent phase starts. If consent takes the full 8s, total is 33s -- past the 30s hard limit. The `ctx.waitUntil` will cut execution.
+
+**Proposed mitigation**: After the settle delay, check remaining time budget before entering the consent phase. If less than ~10s remains (not enough for consent + screenshots + post-work), either skip consent entirely or reduce the consent timeout dynamically. This is a new defensive check, not currently in the codebase.
+
+Alternatively (simpler): reduce NAV_TIMEOUT_MS to 20s to guarantee that load + settle (23s max) leaves 7s for downstream work. But this conflicts with the requirement to "restore to 25s or justify if kept at 20s."
+
+**Justification for 20s**: With the new strategy, `waitUntil: 'load'` fires much faster than `networkidle` on real sites. The 20s timeout is generous for the `load` event and leaves a safe margin (20 + 3 = 23s, leaving 7s for consent + post-work). Setting it to 25s saves zero real-world captures (any site that needs >20s to reach `load` is broken) but creates the budget overrun risk above.
+
+### Risk 3: `page.waitForTimeout()` availability on `@cloudflare/playwright`
+
+`page.waitForTimeout()` is a standard Playwright API. However, `@cloudflare/playwright` is a subset of the full Playwright API. Verify that `waitForTimeout` is available in the Cloudflare binding. If not, use `await new Promise(r => setTimeout(r, SETTLE_DELAY_MS))` as a fallback (functionally identical, just less idiomatic).
+
+### Risk 4: Test fixture assumptions
+
+Multiple test fixtures in `test/fixtures.js` hardcode `waitUntilReached: 'networkidle'` (lines 42, 55, 67). These must all be updated to `'load'`. The `openapi.yaml` examples also reference `networkidle` as the happy-path value. Missing any of these creates inconsistency between code and fixtures/spec.
+
+### Risk 5: Error message string matching in tests
+
+`categorizeError()` produces messages matched by tests via string equality (line 141: `'Page did not finish loading within 20 seconds'`). If the message changes, all tests matching it must be found and updated. There are also references in `openapi.yaml` descriptions. A search for "20 seconds" across the codebase should be part of the implementation checklist.
+
+---
+
+## Additional Agents Needed
+
+- **test-minion**: Update test fixtures (`waitUntilReached: 'networkidle'` -> `'load'`), error message assertions, and add a test verifying that the settle delay is documented in the `render.durationMs` field (i.e., durationMs includes settle time). Verify no other tests implicitly depend on `networkidle` semantics.
+
+- **api-spec-minion** (or whoever owns openapi.yaml): Update the `RenderInfo` schema description which says `"networkidle" means fewer than two open network connections for 500ms` and the examples that show `waitUntilReached: networkidle` as the happy-path value. The spec should note that `'load'` is now the expected value for full captures.
+
+- **No security review needed**: This change does not alter the security posture. Cross-domain blocking, subresource limits, page size limits, context isolation, and header redaction are all unaffected. The settle delay is passive (timer, no new code execution on the page).

--- a/docs/history/nefario-reports/2026-03-16-183802-load-settle-strategy/phase2-test-minion-prompt.md
+++ b/docs/history/nefario-reports/2026-03-16-183802-load-settle-strategy/phase2-test-minion-prompt.md
@@ -1,0 +1,48 @@
+You are contributing to the PLANNING phase of a multi-agent project.
+You are NOT executing yet -- you are providing your domain expertise to help build a comprehensive plan.
+
+## Project Task
+
+Switch navigation wait strategy from networkidle to load + settle delay in src/capture.js.
+
+Currently `page.goto()` uses `waitUntil: 'networkidle'` which burns 20s of the 30s `ctx.waitUntil` budget. The fix: switch to `waitUntil: 'load'` with a post-load settle delay (~3s). NAV_TIMEOUT_MS will be restored to 25s.
+
+## Your Planning Question
+
+The change from `networkidle` to `load` affects render metadata values in test fixtures (`test/fixtures.js`) and several assertions in `test/capture.test.js`. Should the consent renderers in fixtures.js simply change `waitUntilReached` from `'networkidle'` to `'load'`, or should we add a new renderer variant for the settle-delay behavior? Are there test gaps -- should we add coverage for verifying the settle delay is applied? The error messages referencing "20 seconds" also need updating if NAV_TIMEOUT_MS changes.
+
+## Context
+
+Read the full test files at:
+- /Users/ben/github/benpeter/web-resource-ledger/.claude/worktrees/nefario/load-settle-strategy/test/capture.test.js
+- /Users/ben/github/benpeter/web-resource-ledger/.claude/worktrees/nefario/load-settle-strategy/test/fixtures.js
+- /Users/ben/github/benpeter/web-resource-ledger/.claude/worktrees/nefario/load-settle-strategy/src/capture.js
+
+Key observations:
+- fixtures.js has renderers with `waitUntilReached: 'networkidle'` (lines 42, 55)
+- capture.test.js line 751: `expect(record.render.waitUntilReached).toBe('networkidle');`
+- capture.test.js line 600-605: `enrichedStubRenderer` has `waitUntilReached: 'networkidle'`
+- Error messages reference "20 seconds" (lines 141, 290, 508, 713)
+- NAV_TIMEOUT_MS is changing from 20000 to 25000
+
+## Instructions
+1. Read the test files to understand the current test structure
+2. Apply your domain expertise to the planning question
+3. Identify all assertions and fixtures that need updating
+4. Return your contribution in this format:
+
+## Domain Plan Contribution: test-minion
+
+### Recommendations
+<your expert recommendations for test changes>
+
+### Proposed Tasks
+<specific tasks for the execution plan>
+
+### Risks and Concerns
+<things that could go wrong>
+
+### Additional Agents Needed
+<any specialists not yet involved who should be, and why, or "None">
+
+5. Write your complete contribution to /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-SJRIzw/load-settle-strategy/phase2-test-minion.md

--- a/docs/history/nefario-reports/2026-03-16-183802-load-settle-strategy/phase2-test-minion.md
+++ b/docs/history/nefario-reports/2026-03-16-183802-load-settle-strategy/phase2-test-minion.md
@@ -1,0 +1,127 @@
+## Domain Plan Contribution: test-minion
+
+### Recommendations
+
+**1. Fixtures: change `waitUntilReached` from `'networkidle'` to `'load'` -- do NOT add a new renderer variant.**
+
+The change in `defaultRenderer` means successful full captures will report `waitUntilReached: 'load'` instead of `'networkidle'`. The existing fixtures that model full captures should simply update their value. There is no semantic distinction between "load strategy" and "load+settle" that warrants a separate renderer -- the settle delay is an implementation detail of the renderer, not a metadata field. The renderer still returns `waitUntilReached: 'load'`, `timedOut: false`, and a `durationMs` reflecting the total time including settle. A new variant would add testing surface without catching any new bug category.
+
+Specifically, update these three fixture renderers in `test/fixtures.js`:
+- `consentNotDetectedRenderer` (line 42): `'networkidle'` -> `'load'`
+- `dualScreenshotRenderer` (line 55): `'networkidle'` -> `'load'`
+- `consentFailedRenderer` (line 67): `'networkidle'` -> `'load'`
+
+**2. Update `enrichedStubRenderer` in `capture.test.js`.**
+
+The inline `enrichedStubRenderer` at line 601 also has `waitUntilReached: 'networkidle'`. This must change to `'load'` and the corresponding assertion at line 751 must match.
+
+**3. Update error messages from "20 seconds" to "25 seconds".**
+
+Since NAV_TIMEOUT_MS changes from 20000 to 25000, the user-facing message in `categorizeError()` changes. All test assertions must track. Better yet: the implementation should derive the message from the constant (`Page did not finish loading within ${NAV_TIMEOUT_MS / 1000} seconds`) so future changes are a single-point edit. Either way, the test assertions must match the new string.
+
+Affected test assertions in `capture.test.js`:
+- Line 141: `'Page did not finish loading within 20 seconds'`
+- Line 290: `'Page did not finish loading within 20 seconds'`
+- Line 713: `'Page did not finish loading within 20 seconds'`
+- Line 727: `'Page did not finish loading within 20 seconds'`
+
+Also update `openapi.yaml` examples:
+- Line 896: `error: Page did not finish loading within 20 seconds`
+- Line 1273: `error: Page did not finish loading within 20 seconds`
+
+**4. Do NOT add a test for "the settle delay is applied".**
+
+Testing that a specific delay duration occurs would require either:
+- A real browser integration test with timing measurements (flaky, expensive)
+- Mocking `setTimeout`/`page.waitForTimeout` (tests the mock, not the behavior)
+
+Neither approach provides value proportional to its cost. The settle delay is a simple constant applied inside `defaultRenderer`. The real validation comes from:
+- The existing stub renderer pattern (tests verify that `performCapture` correctly stores whatever the renderer returns)
+- Integration/staging tests against real sites (already covered by the smoke test infrastructure)
+
+What IS worth verifying: that the renderer's *output contract* is correct for the new strategy. The existing tests already cover this -- `enrichedStubRenderer` (now returning `'load'`) validates that `performCapture` stores the render metadata correctly. This is sufficient.
+
+**5. Update the `openapi.yaml` `RenderInfo` description.**
+
+Lines 260-286 describe `waitUntilReached` with `networkidle` as the target milestone. After this change, `'load'` is the target milestone for full captures. The description and `timedOut` explanation must be updated. The enum already includes `load` -- no schema change needed, only narrative updates.
+
+**6. The `partialRenderer` in `fixtures.js` stays as-is.**
+
+`partialRenderer` uses `waitUntilReached: 'domcontentloaded'` (line 80) which is correct -- partial captures happen when the page times out before reaching `load`. This value represents the actual DOM readyState, not the `waitUntil` target, so it does not change.
+
+Similarly, `partialLoadRenderer` in `capture.test.js` (line 586-594) correctly uses `'load'` for a partial capture where `readyState === 'complete'`. No change needed.
+
+**7. Update the comment in `capture.js` defaultRenderer.**
+
+Line 400-401: The comment `// Playwright uses 'networkidle' (not 'networkidle2')` should be updated to reflect the new `'load'` strategy. The surrounding budget calculation comment (line 15) also needs updating to reflect the new timing model.
+
+### Proposed Tasks
+
+Listed in dependency order. Tasks within the same group can be done in parallel.
+
+**Group A -- Source changes (do these first, tests follow)**
+
+- **T1: Update `NAV_TIMEOUT_MS` from 20000 to 25000** in `src/capture.js` line 84.
+- **T2: Change `page.goto()` from `waitUntil: 'networkidle'` to `waitUntil: 'load'`** in `src/capture.js` line 403.
+- **T3: Add post-load settle delay** (~3s) after `page.goto()` returns in the `defaultRenderer` function. Something like `await page.waitForTimeout(3000)` or similar. The `render.waitUntilReached` return value at line 482 should change from `'networkidle'` to `'load'`.
+- **T4: Update `categorizeError()` timeout messages** from `'Page did not finish loading within 20 seconds'` to `'Page did not finish loading within 25 seconds'` (lines 508, 512). Strongly recommend deriving from constant: `` `Page did not finish loading within ${NAV_TIMEOUT_MS / 1000} seconds` ``.
+- **T5: Update budget comments** in `src/capture.js` -- lines 15 (header comment), 400-401 (goto comment), 412 (budget comment referencing `~20.5s`).
+
+**Group B -- Test fixture and assertion updates**
+
+- **T6: Update `test/fixtures.js`** -- change `waitUntilReached: 'networkidle'` to `'load'` on lines 42, 55, 67.
+- **T7: Update `test/capture.test.js` inline renderers and assertions:**
+  - `enrichedStubRenderer` line 601: `'networkidle'` -> `'load'`
+  - Assertion line 751: `'networkidle'` -> `'load'`
+  - Error message assertions lines 141, 290, 713, 727: `'20 seconds'` -> `'25 seconds'`
+- **T8: Update `timeoutRenderer` error message** in `capture.test.js` line 114: `'Navigation timeout of 25000 ms exceeded'` -- this already says 25000, confirm it still matches the new `NAV_TIMEOUT_MS`. (It does, since NAV_TIMEOUT_MS is becoming 25000. No change needed here.)
+- **T9: Update `playwrightTimeout` error message** in `capture.test.js` line 280: `'page.goto: Timeout 25000ms exceeded'` -- same as T8, already matches. Confirm no change needed.
+
+**Group C -- API documentation**
+
+- **T10: Update `openapi.yaml`**:
+  - Error examples at lines 896, 1273: `'20 seconds'` -> `'25 seconds'`
+  - `RenderInfo` description (lines 260-286): change target milestone from `networkidle` to `load`, update `timedOut` description
+  - `CaptureRecord.renderQuality` description (line 332): `networkidle` -> `load`
+  - Other `networkidle` narrative references in the schema
+
+**Group D -- Verify no collateral damage**
+
+- **T11: Run full test suite** and verify all assertions pass. The following files have `networkidle` or `20 seconds` references but should NOT change:
+  - `test/kv.test.js`: uses `domcontentloaded` only -- no change needed
+  - `test/capture-retrieval.test.js`: uses `domcontentloaded` only -- no change needed
+  - `test/list-captures.test.js`: uses `domcontentloaded` only -- no change needed
+  - `test/verify-integration.test.js`: uses `domcontentloaded` only -- no change needed
+  - None of these files import consent-related renderers from fixtures.js
+
+### Risks and Concerns
+
+**Risk 1: Partial capture readyState mapping may need adjustment.**
+
+In `defaultRenderer`, the partial capture path (lines 438-446) sets `waitUntilReached` based on `document.readyState`. When `readyState === 'complete'`, it reports `'load'`. When `'interactive'`, it reports `'domcontentloaded'`. With the switch from `networkidle` to `load`, a page that fires `load` quickly but has lingering network activity will now succeed (not time out), so the partial capture path is entered less often. This is the desired behavior -- but verify that the partial capture tests still exercise realistic scenarios. The existing test coverage is adequate since partial renderers are stubs that inject the specific metadata values.
+
+**Risk 2: The settle delay constant should be a named constant, not a magic number.**
+
+If `3000` is used inline, it becomes hard to adjust and test. Recommend defining `SETTLE_DELAY_MS = 3000` alongside `NAV_TIMEOUT_MS`. This doesn't require a test but makes the code maintainable and the budget math auditable.
+
+**Risk 3: Budget math must be validated.**
+
+The new budget breakdown should be documented:
+- NAV_TIMEOUT_MS (25s) covers `page.goto(waitUntil: 'load')` + settle delay (3s)
+- Actually, clarify: is NAV_TIMEOUT_MS the `page.goto()` timeout (which would NOT include the settle delay)? Or does it include settle? The settle delay happens AFTER `page.goto()` returns, so the total renderer time is `goto_time + settle + screenshot + consent`. With a 30s `ctx.waitUntil` budget:
+  - goto timeout: 25s max (but load fires much faster than networkidle)
+  - settle: 3s
+  - consent: 8s
+  - post: 2s
+  - Total worst case: 25 + 3 + 8 + 2 = 38s -- exceeds 30s budget
+
+This needs careful review. If `page.goto()` uses a 25s timeout and settle is 3s, the consent window (8s) may not fit. The implementation should ensure the settle delay is accounted for in the budget. This is a **design concern more than a test concern**, but tests should validate that the partial capture deadline logic still fires correctly.
+
+**Risk 4: The `openapi.yaml` enum stays unchanged but semantics shift.**
+
+The enum `[domcontentloaded, load, networkidle]` keeps `networkidle` as a valid value for backward compatibility (old records may have it). But new full captures will report `'load'`. API consumers should not break, but the documentation must clearly state that `networkidle` is a legacy value. This is not a test risk but an API contract consideration.
+
+### Additional Agents Needed
+
+- **api-design-minion**: Review the `openapi.yaml` changes, particularly the `RenderInfo` description updates and any backward-compatibility implications for API consumers who might be matching on `waitUntilReached === 'networkidle'`.
+- **edge-minion**: Validate the budget math. The interaction between NAV_TIMEOUT_MS, settle delay, consent window, and `ctx.waitUntil` budget is the critical correctness concern. Tests can verify the renderer output contract but cannot validate real-world timing behavior.

--- a/docs/history/nefario-reports/2026-03-16-183802-load-settle-strategy/phase3-synthesis-prompt.md
+++ b/docs/history/nefario-reports/2026-03-16-183802-load-settle-strategy/phase3-synthesis-prompt.md
@@ -1,0 +1,55 @@
+MODE: SYNTHESIS
+
+You are synthesizing specialist planning contributions into a final execution plan.
+
+## Original Task
+
+Switch navigation wait strategy from networkidle to load + settle delay (GitHub issue #67).
+
+Captures complete reliably for ad-heavy sites (tagesschau.de, adobe.com) that visually load in 2-3s but whose tracking scripts keep network connections alive indefinitely. Currently page.goto() uses waitUntil: 'networkidle' which burns 20s of the 30s ctx.waitUntil budget waiting for network silence that never comes.
+
+### Success criteria
+- tagesschau.de and adobe.com captures complete successfully
+- Navigation phase completes in under 10s for typical sites
+- Sufficient time budget remains for consent dismissal (8s), screenshots, WACZ building, and R2/KV writes
+- All existing tests pass
+- Staged fallback from #53 remains functional
+- NAV_TIMEOUT_MS restored to 25s (or justified if kept at 20s)
+
+### Constraints
+- Use waitUntil: 'load' with a post-load settle delay (~3s)
+- Must fit within 30s ctx.waitUntil hard limit
+
+## Specialist Contributions
+
+Read the following scratch files for full specialist contributions:
+- /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-SJRIzw/load-settle-strategy/phase2-debugger-minion.md
+- /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-SJRIzw/load-settle-strategy/phase2-test-minion.md
+
+## Key consensus across specialists:
+
+### debugger-minion
+- Recommends page.waitForTimeout(3000) for settle delay (deterministic, no hang risk)
+- Place after goto succeeds and limitExceeded check, before screenshot
+- CRITICAL: Budget overrun risk if NAV_TIMEOUT_MS=25s (25+3+8=36s > 30s)
+- Argues for keeping NAV_TIMEOUT_MS at 20s or adding budget check before consent
+- Staged fallback structurally unaffected
+
+### test-minion
+- Simple value updates: 'networkidle' -> 'load' in 3 fixtures + 2 inline references
+- '20 seconds' -> '25 seconds' in 4 error assertions (if NAV_TIMEOUT_MS changes)
+- openapi.yaml has references to networkidle and 20 seconds that need updating
+- No new renderer variants needed (settle delay is internal detail)
+- Same budget concern: worst case 38s > 30s
+
+## External Skills Context
+No external skills detected
+
+## Instructions
+1. Review all specialist contributions
+2. Resolve the NAV_TIMEOUT_MS conflict: issue says 25s, both specialists warn about budget overrun
+3. Create the final execution plan in structured format
+4. Ensure every task has a complete, self-contained prompt
+5. This is a narrow, focused change. Prefer a single execution task (or at most two if there's a natural boundary).
+6. The project follows the Helix Manifesto: YAGNI, KISS, lean and mean.
+7. Write your complete delegation plan to /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-SJRIzw/load-settle-strategy/phase3-synthesis.md

--- a/docs/history/nefario-reports/2026-03-16-183802-load-settle-strategy/phase3-synthesis.md
+++ b/docs/history/nefario-reports/2026-03-16-183802-load-settle-strategy/phase3-synthesis.md
@@ -1,0 +1,246 @@
+# Phase 3: Synthesis -- Load + Settle Strategy
+
+## Delegation Plan
+
+**Team name**: load-settle-strategy
+**Description**: Switch navigation wait strategy from networkidle to load + settle delay for reliable captures on ad-heavy sites.
+
+### Conflict Resolution: NAV_TIMEOUT_MS
+
+Both specialists flagged budget overrun risk if NAV_TIMEOUT_MS is raised to 25s. The worst-case arithmetic (25 + 3 + 8 + 2 = 38s) exceeds the 30s ctx.waitUntil hard limit.
+
+**Resolution: Keep NAV_TIMEOUT_MS at 20s.**
+
+Rationale:
+- With `waitUntil: 'load'`, the timeout covers a much narrower event than `networkidle`. The `load` event fires when the DOM and synchronous subresources (images, CSS, iframes) are loaded. For healthy sites: 1-5s. For pathological sites: 10-15s. A 20s timeout for just the `load` event is generous.
+- 20s timeout means worst-case budget: 20 + 3 + 8 + 2 = 33s. Still tight, but the pathological case (load at 20s) already triggers the staged fallback (TimeoutError), so the settle delay never runs. Realistic worst: 10 + 3 + 8 + 2 = 23s, well within 30s.
+- The issue says "NAV_TIMEOUT_MS restored to 25s (or justified if kept at 20s)." This is the justification: raising to 25s creates a real budget overrun window (pages where load fires at 22-24s succeed but then push past 30s with settle + consent), while keeping at 20s saves zero real-world captures (any site needing >20s to fire `load` is broken).
+- debugger-minion independently recommends 20s for the same reasons.
+- A comment in `categorizeError()` will document the justification.
+
+### Task 1: Switch navigation from networkidle to load + settle delay
+- **Agent**: debugger-minion
+- **Delegation type**: standard
+- **Model**: sonnet
+- **Mode**: bypassPermissions
+- **Blocked by**: none
+- **Approval gate**: no
+- **Gate reason**: n/a -- single-file source change + mechanical test/spec updates, easy to reverse, low blast radius.
+- **Prompt**: |
+    ## Task: Switch navigation from networkidle to load + settle delay
+
+    GitHub issue #67. Change `defaultRenderer()` in `src/capture.js` to use
+    `waitUntil: 'load'` with a 3-second post-load settle delay instead of
+    `waitUntil: 'networkidle'`. Update tests and OpenAPI spec to match.
+
+    ### Why
+
+    Ad-heavy sites (tagesschau.de, adobe.com) visually load in 2-3s but their
+    tracking scripts keep network connections alive indefinitely. `networkidle`
+    burns 20s waiting for silence that never comes, leaving too little budget
+    for consent dismissal, screenshots, and WACZ packaging.
+
+    ### What to change
+
+    All changes are in the worktree at:
+    `/Users/ben/github/benpeter/web-resource-ledger/.claude/worktrees/nefario/load-settle-strategy/`
+
+    #### A. Source changes (`src/capture.js`)
+
+    1. **Add constant** `SETTLE_DELAY_MS = 3000` alongside existing timeout
+       constants (after line 88, alongside PARTIAL_CONTENT_TIMEOUT_MS).
+
+    2. **Keep `NAV_TIMEOUT_MS` at 20000** (line 84). Do NOT change it. The
+       issue suggested 25s but budget analysis shows 20s is correct:
+       - With `waitUntil: 'load'`, the timeout covers only the load event
+         (1-5s typical, 10-15s pathological). 20s is generous for this.
+       - Budget: 20 + 3 + 8 + 2 = 33s worst-case. But if goto takes 20s,
+         TimeoutError fires and staged fallback runs (settle delay never
+         executes). Realistic worst: 10 + 3 + 8 + 2 = 23s.
+       - 25s would create a real overrun window: pages where load fires at
+         22-24s succeed but settle + consent push past 30s.
+
+    3. **Change `page.goto()` call** (line 403) from
+       `waitUntil: 'networkidle'` to `waitUntil: 'load'`.
+
+    4. **Add settle delay on happy path** -- insert
+       `await page.waitForTimeout(SETTLE_DELAY_MS)` immediately after the
+       `if (limitExceeded) throw` check (after line 454), BEFORE the viewport
+       height check and screenshots. This is the happy path only -- the settle
+       delay must NOT run on the partial capture (timeout) path.
+
+       NOTE: `page.waitForTimeout()` is standard Playwright API. If it's not
+       available in `@cloudflare/playwright`, use
+       `await new Promise(r => setTimeout(r, SETTLE_DELAY_MS))` instead.
+
+    5. **Update `render.waitUntilReached`** on the happy-path return (line 482)
+       from `'networkidle'` to `'load'`.
+
+    6. **Update `categorizeError()` messages** (lines 508, 512). Since
+       NAV_TIMEOUT_MS stays at 20s, the message text stays the same ("within
+       20 seconds"). But improve it to derive from the constant so future
+       changes are single-point:
+       ```js
+       return { message: `Page did not finish loading within ${NAV_TIMEOUT_MS / 1000} seconds`, retryable: true };
+       ```
+       Do this for both the "Deadline exceeded" case (line 508) and the
+       TimeoutError case (line 512).
+
+    7. **Update the file-header comment** (line 15) which says
+       `NAV_TIMEOUT_MS=20s + 8s consent + 2s post`. Change to:
+       `NAV_TIMEOUT_MS=20s load + 3s settle + 8s consent + 2s post ≈ 33s worst-case; in practice load fires in 2-5s`.
+
+    8. **Update the inline comment** at line 400-401. Currently says:
+       ```
+       // Navigate with 20s timeout; 8s consent window + 2s post-processing fits the 30s ctx.waitUntil budget
+       // Playwright uses 'networkidle' (not 'networkidle2')
+       ```
+       Change to:
+       ```
+       // Navigate with 20s timeout using 'load' (not 'networkidle' -- ad trackers keep connections alive indefinitely)
+       // Post-load: 3s settle + 8s consent + 2s post-processing fits the 30s ctx.waitUntil budget
+       ```
+
+    9. **Update the partial-capture budget comment** at line 412. Currently says:
+       `// 2000ms budget: renderer has been running ~20.5s; leaves margin for KV/R2 post-work`
+       Change to:
+       `// 2000ms budget: renderer has been running ~20.5s (load timed out); leaves margin for KV/R2 post-work`
+       (The "~20.5s" is still correct -- this path runs when goto times out at 20s.)
+
+    #### B. Test changes
+
+    10. **`test/fixtures.js`** -- change `waitUntilReached: 'networkidle'` to
+        `'load'` on these three fixture renderers:
+        - `consentNotDetectedRenderer` (line 42)
+        - `dualScreenshotRenderer` (line 55)
+        - `consentFailedRenderer` (line 67)
+
+    11. **`test/capture.test.js`** -- update inline renderer and assertions:
+        - `enrichedStubRenderer` (line 601): `'networkidle'` -> `'load'`
+        - Assertion (line 751): `'networkidle'` -> `'load'`
+        - Error message assertions: since NAV_TIMEOUT_MS stays at 20s, these
+          four assertions remain "20 seconds" and do NOT change:
+          - Line 141, 290, 713, 727
+          Verify they still pass after the template literal change in
+          `categorizeError()`.
+
+    #### C. OpenAPI spec changes (`openapi.yaml`)
+
+    12. **RenderInfo description** (lines 260-286): Update narrative to reflect
+        that the target milestone is now `load` (not `networkidle`). The enum
+        keeps `networkidle` for backward compatibility (old records may have it).
+        Specifically:
+        - Line 262: change "reached the target (networkidle)" to "reached the
+          target milestone (load). Older captures may report networkidle."
+        - Line 263: change "When absent, the page reached networkidle" to
+          "When absent, the page loaded successfully"
+        - Line 272: keep the description of what "networkidle" means (it's
+          still a valid enum value for old records), but add that "load" is
+          the current target for full captures.
+        - Lines 278-280: change "did not reach the target milestone
+          (networkidle)" to "did not reach the target milestone (load)"
+        - Line 286: change "at networkidle or at timeout" to "at load
+          completion or at timeout"
+
+    13. **CaptureRecord.renderQuality description** (line 332): change
+        "reached networkidle" to "reached the load milestone"
+
+    14. **CaptureRecord.render description** (line 340): change "reached
+        networkidle" to "loaded successfully"
+
+    15. **Error examples** -- since NAV_TIMEOUT_MS stays at 20s, these
+        stay the same. No change needed:
+        - Line 896: `error: Page did not finish loading within 20 seconds`
+        - Line 1273: `error: Page did not finish loading within 20 seconds`
+
+    #### D. Do NOT change
+
+    - `partialRenderer` in `test/fixtures.js` (line 80) -- uses
+      `domcontentloaded`, which is correct for partial captures.
+    - `partialLoadRenderer` in `test/capture.test.js` (line 590) -- uses
+      `'load'` for partial capture where readyState is complete. Correct.
+    - `timeoutRenderer` error message (line 114) -- already says 25000ms,
+      which is the Playwright timeout value. This is fine.
+    - `playwrightTimeout` error message (line 280) -- already says 25000ms.
+    - The staged fallback path (lines 402-451) -- structurally unchanged.
+      The readyState check, 2s deadline, partial screenshot/content
+      extraction all remain as-is.
+    - Other test files (`kv.test.js`, `capture-retrieval.test.js`,
+      `list-captures.test.js`, `verify-integration.test.js`) -- none
+      reference `networkidle` or `20 seconds`.
+
+    #### E. After all changes
+
+    Run `npm test` and verify all tests pass. The test suite has ~474 tests.
+
+    ### Success criteria
+    - `waitUntil: 'load'` in `page.goto()` call
+    - `SETTLE_DELAY_MS = 3000` constant defined
+    - `page.waitForTimeout(SETTLE_DELAY_MS)` on happy path after limitExceeded check, before screenshots
+    - `render.waitUntilReached` returns `'load'` on happy path
+    - `categorizeError()` derives message from `NAV_TIMEOUT_MS` constant
+    - All 3 fixture renderers updated to `'load'`
+    - `enrichedStubRenderer` and assertion updated to `'load'`
+    - OpenAPI spec descriptions updated (enum unchanged)
+    - All existing tests pass
+    - No changes to the staged fallback path structure
+
+- **Deliverables**:
+    - Modified `src/capture.js` (new constant, changed wait strategy, settle delay, updated comments and error messages)
+    - Modified `test/fixtures.js` (3 renderer values)
+    - Modified `test/capture.test.js` (inline renderer + assertion)
+    - Modified `openapi.yaml` (narrative descriptions)
+- **Success criteria**: `npm test` passes. Manual code review confirms settle delay placement is on happy path only, between limitExceeded check and first screenshot.
+
+### Cross-Cutting Coverage
+
+- **Testing** (test-minion): Covered within Task 1 -- test fixture and assertion updates are part of the implementation task. Phase 6 post-execution will run the full test suite.
+- **Security** (security-minion): Not needed. debugger-minion explicitly confirmed: no security posture change. The settle delay is a passive timer with no new code execution on the page. Cross-domain blocking, subresource limits, context isolation, header redaction all unaffected.
+- **Usability -- Strategy** (ux-strategy-minion): Not needed for execution. This is a backend timing change invisible to API consumers. The `waitUntilReached` field value changes from `networkidle` to `load` for new captures, but the enum and contract are unchanged. Phase 3.5 review will cover this.
+- **Usability -- Design** (ux-design-minion, accessibility-minion): Not needed. No user-facing interface changes.
+- **Documentation** (software-docs-minion / user-docs-minion): OpenAPI spec updates are included in Task 1. The spec narrative changes are straightforward (networkidle -> load in descriptions). Phase 8 post-execution will handle any remaining documentation. No user-facing documentation changes needed.
+- **Observability** (observability-minion, sitespeed-minion): Not needed. No new logging, metrics, or tracing. The existing `render.durationMs` field will naturally include settle time (it measures wall-clock from navigation start to capture). Coralogix monitoring should be checked post-deploy for `render.durationMs` distribution changes, but that's operational, not a code change.
+
+### Architecture Review Agents
+
+- **Mandatory** (5): security-minion, test-minion, ux-strategy-minion, lucy, margo
+- **Discretionary picks**:
+  - None. This is a narrow timing change within a single source file plus mechanical updates to tests and spec. No UI, no new runtime components, no user-facing documentation impact, no multi-service coordination.
+- **Not selected**: ux-design-minion, accessibility-minion, sitespeed-minion, observability-minion, user-docs-minion
+
+### Conflict Resolutions
+
+1. **NAV_TIMEOUT_MS: 25s vs 20s** -- Issue #67 says "restored to 25s (or justified if kept at 20s)." Both specialists warn about budget overrun with 25s. Resolution: keep at 20s with justification documented in code comments. See detailed rationale at top of this document.
+
+2. **api-spec-minion / api-design-minion involvement** -- Both specialists recommended an API spec agent review the openapi.yaml changes. Resolution: the changes are narrative-only (updating descriptions from "networkidle" to "load"). The enum is unchanged, no schema changes, no backward compatibility issues. Including these in the single implementation task is proportionate. Phase 3.5 review by ux-strategy-minion covers the API consumer perspective.
+
+### Risks and Mitigations
+
+1. **Visual completeness regression on clean sites** (LOW): Pages that loaded fully under `networkidle` (0 connections for 500ms) now get a 3s timer instead. Risk: async-rendered content might not be complete in 3s. Mitigation: 3s is generous for typical hydration (<1s). Target capture population is news articles and landing pages, not heavy SPAs. Monitor `render.durationMs` in Coralogix post-deploy.
+
+2. **`page.waitForTimeout()` unavailable in @cloudflare/playwright** (LOW): If the API subset doesn't include this method, the fallback is `await new Promise(r => setTimeout(r, SETTLE_DELAY_MS))` -- functionally identical. The prompt includes this fallback instruction.
+
+3. **Budget math edge case** (MEDIUM): If load fires at exactly 20s, TimeoutError triggers and the staged fallback runs (settle delay skipped -- correct). If load fires at 19.9s, the happy path runs: 19.9 + 3 + 8 + 2 = 32.9s, past 30s. Mitigation: a page needing 19.9s to fire `load` is deeply pathological. The consent phase has its own 8s timeout and most consent completes in <3s. Realistic worst case for this edge: 19.9 + 3 + 3 + 1 = 26.9s. Acceptable.
+
+4. **Test assertion string matching** (LOW): `categorizeError()` switching to template literal must produce the exact same string. Since NAV_TIMEOUT_MS stays at 20000, the output is `"Page did not finish loading within 20 seconds"` -- unchanged. Tests catch any mismatch.
+
+### Execution Order
+
+```
+Batch 1: Task 1 (all source, test, and spec changes)
+Phase 3.5: Architecture review (5 mandatory reviewers)
+Phase 5: Code review (code-review-minion, lucy, margo)
+Phase 6: Test execution (npm test)
+Phase 8: Documentation (evolution log)
+```
+
+No approval gates. Single task, easy to reverse, no downstream dependents.
+
+### Verification Steps
+
+1. `npm test` passes all ~474 tests
+2. `grep -rn 'networkidle' src/` returns zero matches (only docs/history should have it)
+3. `grep -rn "waitUntilReached: 'networkidle'" test/` returns zero matches
+4. Code review confirms settle delay is placed after limitExceeded check, before viewport height check and screenshots
+5. Code review confirms staged fallback path (lines 402-451) is structurally unchanged
+6. OpenAPI spec `waitUntilReached` enum still includes all three values (backward compat)

--- a/docs/history/nefario-reports/2026-03-16-183802-load-settle-strategy/phase3.5-lucy.md
+++ b/docs/history/nefario-reports/2026-03-16-183802-load-settle-strategy/phase3.5-lucy.md
@@ -1,0 +1,74 @@
+# Phase 3.5: Lucy -- Alignment and Convention Review
+
+## Verdict: APPROVE
+
+The plan is well-aligned with the original request, proportionate to the problem, and compliant with project conventions. Two advisory findings below; neither blocks execution.
+
+---
+
+## Requirement Traceability
+
+| Requirement (from prompt.md) | Plan element | Status |
+|------------------------------|-------------|--------|
+| Switch from `networkidle` to `load` wait strategy | Task 1, step 3 (`page.goto` change) | COVERED |
+| Post-load settle delay (~3s) | Task 1, steps 1+4 (`SETTLE_DELAY_MS` constant + `waitForTimeout`) | COVERED |
+| NAV_TIMEOUT_MS restored to 25s or justified at 20s | Conflict Resolution section: kept at 20s with explicit justification | COVERED |
+| All existing tests pass | Task 1 section E, Verification Step 1 | COVERED |
+| Staged fallback from #53 remains functional | Task 1 section D (explicit "do NOT change" list) + Verification Step 5 | COVERED |
+| Sufficient time budget for consent + screenshots + WACZ + R2/KV | Budget analysis (realistic worst 23s), Risk 3 analysis | COVERED |
+| tagesschau.de / adobe.com captures succeed | Motivation in "Why" section; no automated validation in plan (operational) | COVERED (intent) |
+| Update related test assertions | Task 1 steps 10-11, Verification Steps 2-3 | COVERED |
+
+No orphaned tasks. No unaddressed requirements.
+
+---
+
+## Drift Analysis
+
+**Scope creep**: None. The plan is a single-task delegation touching four files (`src/capture.js`, `test/fixtures.js`, `test/capture.test.js`, `openapi.yaml`). All changes trace directly to the stated scope ("page.goto() wait strategy in defaultRenderer(), settle delay after load event, NAV_TIMEOUT_MS value, related test assertions").
+
+**Over-engineering**: None. The plan explicitly rejects Options B (networkidle-with-short-timeout) and C (custom idle detection) from the debugger-minion analysis, choosing the simplest option (fixed timer). This is consistent with KISS and YAGNI.
+
+**Feature substitution**: None. The plan delivers exactly what was asked.
+
+**Gold-plating**: None. The categorizeError template literal change (step 6) is a minor improvement but directly serves the NAV_TIMEOUT_MS justification requirement and prevents future string-value drift. Proportionate.
+
+---
+
+## CLAUDE.md Compliance
+
+| Directive | Status |
+|-----------|--------|
+| Evolution log required (CLAUDE.md "Evolution Log") | Plan references Phase 8 for documentation. The slug `load-settle-strategy` and next sequence number (0029) are implied by the prompt. process.md is mentioned in the original prompt's instructions. | COMPLIANT |
+| YAGNI / KISS / Lean and Mean (Engineering Philosophy) | Single constant, single timer, no new abstractions, no new dependencies. | COMPLIANT |
+| Helix Manifesto latency principle | The change reduces navigation phase from 20s+ to ~5s typical. | COMPLIANT |
+| Prefer lightweight vanilla solutions | No new dependencies introduced. | COMPLIANT |
+| Backlog update after every phase (Evolution Log Rule 4) | Not explicitly mentioned in the synthesis plan's Phase 8 description, but is a CLAUDE.md mandate that applies regardless. | SEE ADVISE #1 |
+
+---
+
+## Findings
+
+### ADVISE #1 -- COMPLIANCE: Backlog update not explicitly called out in execution plan
+
+**WHAT**: CLAUDE.md Evolution Log Rule 4 requires reviewing `docs/backlog.md` after every phase and recording backlog changes (or their absence) in `outcome.md`. The synthesis plan's Phase 8 description says "Documentation (evolution log)" but does not explicitly mention the backlog update step.
+
+**WHY**: This is a known failure mode in prior orchestrations (see project memory `feedback_evolution_log.md`). The requirement applies regardless of whether the skill's wrap-up mentions it (CLAUDE.md Precedence section).
+
+**FIX**: No plan change needed -- this is a reminder for the orchestrator to include the backlog review in Phase 8's evolution log work. Issue #67 should be closed or marked done in the backlog if it existed there.
+
+---
+
+### ADVISE #2 -- TRACE: NAV_TIMEOUT_MS justification should be captured in evolution log decisions.md
+
+**WHAT**: The conflict resolution on NAV_TIMEOUT_MS (20s vs 25s) is well-reasoned in the synthesis document but this is a scratch file that will not persist. The issue (#67) explicitly requested "restored to 25s (or justified if kept at 20s)" -- the justification is a first-class deliverable.
+
+**WHY**: The synthesis scratch file lives in a temp directory. If the justification is only recorded as a code comment (step 8), a future reader needs to find the right line in `src/capture.js` to understand why the project deviated from the issue's default expectation. The evolution log `decisions.md` is the canonical location for this kind of design rationale.
+
+**FIX**: Ensure Phase 8 (evolution log) captures the NAV_TIMEOUT_MS decision in `docs/evolution/0029-load-settle-strategy/decisions.md` with the full rationale: both specialists flagged budget overrun, 20s is generous for `load` event, 25s creates a real overrun window with settle + consent, and any site needing >20s to fire `load` is broken.
+
+---
+
+## Summary
+
+The plan is tight, well-scoped, and directly aligned with the user's request. It resolves the NAV_TIMEOUT_MS ambiguity from the issue with clear reasoning. The single-task structure is appropriate for the scope -- four files, mechanical changes, no architectural decisions. The two advisory items are procedural (evolution log completeness) and do not affect the implementation itself.

--- a/docs/history/nefario-reports/2026-03-16-183802-load-settle-strategy/phase3.5-margo.md
+++ b/docs/history/nefario-reports/2026-03-16-183802-load-settle-strategy/phase3.5-margo.md
@@ -1,0 +1,25 @@
+# Margo Review: Load + Settle Strategy
+
+## Verdict: APPROVE
+
+This plan is proportionate to the problem. One constant added, one argument changed, one `waitForTimeout` inserted, and mechanical updates to tests and spec descriptions. No new dependencies, no new abstractions, no new services, no speculative features.
+
+### What I checked
+
+1. **Scope alignment**: The request is "switch from networkidle to load + settle delay." The plan does exactly that -- nothing more. Single task, four files touched, all changes mechanical. No scope creep.
+
+2. **YAGNI**: No speculative features detected. The plan explicitly lists what NOT to change (staged fallback structure, partial capture logic, consent pipeline). Good discipline.
+
+3. **Complexity budget**: Zero new technologies, zero new dependencies, zero new abstraction layers. One new constant (`SETTLE_DELAY_MS`). Total complexity cost: effectively zero.
+
+4. **NAV_TIMEOUT_MS justification**: The decision to keep 20s rather than raise to 25s is well-reasoned and reduces budget risk. The arithmetic is sound. Both specialists independently arrived at the same conclusion. This is the simpler, safer choice.
+
+5. **No over-engineering**: The settle delay is a plain `waitForTimeout` / `setTimeout` -- not a polling loop, not an event listener, not a "smart" settle detector. This is the simplest possible implementation. Good.
+
+6. **Single task, no approval gate**: Correct for the scope. This is a four-file change that's easy to review and easy to revert.
+
+### One observation (non-blocking)
+
+The plan notes risk #3: if `load` fires at 19.9s, total budget could reach 32.9s (past 30s). The mitigation ("deeply pathological") is reasonable but worth watching in production logs. This is an operational concern, not a plan concern -- no code change needed.
+
+No issues found. Proceed.

--- a/docs/history/nefario-reports/2026-03-16-183802-load-settle-strategy/phase3.5-security-minion.md
+++ b/docs/history/nefario-reports/2026-03-16-183802-load-settle-strategy/phase3.5-security-minion.md
@@ -1,0 +1,28 @@
+# Security Review: load-settle-strategy
+
+## Verdict: ADVISE
+
+---
+
+[security]: The 3-second settle delay adds a fixed, unconditional window where the page's JavaScript continues executing with full access to the capture context (DOM, cookies, storage). This is not new attack surface the capture service introduces, but it is an intentional extension of attacker-controlled code execution time. The existing security posture (cross-domain blocking, subresource limits, context isolation) remains intact. The risk is marginal and already accepted by the current design (network connections already lived for 20s under networkidle). However, one implementation detail warrants a flag.
+
+**SCOPE**: `src/capture.js` -- settle delay placement and `limitExceeded` check interaction
+**CHANGE**: Adding `await page.waitForTimeout(SETTLE_DELAY_MS)` after the `limitExceeded` throw check on the happy path
+**WHY**: The `limitExceeded` flag is set by a response event listener that fires asynchronously. The plan correctly places the check at line 454 (`if (limitExceeded) throw`), then runs the settle delay. However, during the settle delay itself, the response listener continues running -- additional responses can arrive and push `totalBytes` past `MAX_PAGE_BYTES`. These post-settle responses are never re-checked: the code proceeds directly to screenshot, `page.content()`, and R2 upload without a second `limitExceeded` guard. An adversarial page could intentionally delay large responses (e.g., chunked streaming responses, lazy-loaded media) to fire during the settle window, bypassing the size cap.
+**TASK**: After the settle delay completes, add a second `limitExceeded` check before proceeding to the screenshot phase:
+```js
+await page.waitForTimeout(SETTLE_DELAY_MS); // or Promise-based fallback
+if (limitExceeded) throw new Error(limitExceeded);
+// then: viewport height check, screenshots, etc.
+```
+This is a two-line addition that closes the window entirely. The existing pattern at line 454 is the model.
+
+---
+
+All other security properties are unchanged:
+- The settle delay uses no user-controlled duration (constant only).
+- `categorizeError()` message derivation from the constant is safe and improves consistency.
+- No new I/O, no new network requests, no new external data flows.
+- Context isolation (`context.close()` in finally) is unaffected.
+- No secrets, credentials, or internal details enter new code paths.
+- The OpenAPI enum change is backward-compatible and introduces no schema injection surface.

--- a/docs/history/nefario-reports/2026-03-16-183802-load-settle-strategy/phase3.5-test-minion.md
+++ b/docs/history/nefario-reports/2026-03-16-183802-load-settle-strategy/phase3.5-test-minion.md
@@ -1,0 +1,15 @@
+APPROVE
+
+All test fixture and assertion updates are correctly accounted for in the plan.
+
+Verification against actual files:
+
+- `test/fixtures.js`: Three fixtures (`consentNotDetectedRenderer` line 42, `dualScreenshotRenderer` line 55, `consentFailedRenderer` line 67) all currently carry `'networkidle'`. All three are listed for update. `partialRenderer` (line 75) correctly uses `'domcontentloaded'` and is explicitly excluded from changes.
+- `test/capture.test.js`: `enrichedStubRenderer` (line 601) has `'networkidle'` and is listed for update. Line 751 assertion (`expect(record.render.waitUntilReached).toBe('networkidle')`) is listed for update.
+- Error message assertions at lines 141, 290, 713, 727 all assert `'Page did not finish loading within 20 seconds'`. The plan correctly identifies these as unchanged -- the template literal refactor in `categorizeError()` produces the same string since `NAV_TIMEOUT_MS / 1000 = 20`.
+- `partialLoadRenderer` (line 590) already uses `'load'` -- the plan correctly excludes it.
+- No other test files reference `networkidle` or the 20-second message, per the plan's explicit verification step.
+
+Settle delay test coverage: the plan does not add a dedicated test for the settle delay itself, but this is acceptable. The settle delay is a `waitForTimeout` call -- a passive timer with no branching logic. It is not the right layer to unit test (it would require mocking timers or real Playwright). The placement constraint (after `limitExceeded` check, before screenshots) is verified structurally by code review in Phase 5, not by a test assertion. This is proportionate.
+
+No gaps or risks from the testing perspective.

--- a/docs/history/nefario-reports/2026-03-16-183802-load-settle-strategy/phase3.5-ux-strategy-minion.md
+++ b/docs/history/nefario-reports/2026-03-16-183802-load-settle-strategy/phase3.5-ux-strategy-minion.md
@@ -1,0 +1,19 @@
+## UX Strategy Review -- load-settle-strategy
+
+**Verdict: APPROVE**
+
+This is a backend timing change with no user-facing interface impact. UX strategy has no blocking concerns.
+
+### Scope assessment
+
+No screens, flows, or interaction patterns are affected. The only API-consumer-visible change is `waitUntilReached` returning `'load'` instead of `'networkidle'` for new captures. The enum is preserved for backward compatibility, so existing integrations continue to work without changes.
+
+### What the plan gets right
+
+**Reduces conceptual leakage.** The OpenAPI description updates replace `networkidle` (an internal Playwright abstraction) with `load` (a standard browser lifecycle concept). API consumers now see terminology they already understand from web development. This is a net simplification of the mental model.
+
+**Serves the user job directly.** The job is "capture a web resource reliably." The change unblocks captures on ad-heavy sites that currently fail. No new concepts or decision points are introduced for API consumers.
+
+**Lean scope.** The plan correctly excludes agent reviews where they add no value (API spec agent for narrative-only changes, security agent for a passive timer). The single-task structure means no partial-deliverable risk.
+
+### No concerns within UX strategy domain.

--- a/docs/history/nefario-reports/2026-03-16-183802-load-settle-strategy/phase4-debugger-minion-prompt.md
+++ b/docs/history/nefario-reports/2026-03-16-183802-load-settle-strategy/phase4-debugger-minion-prompt.md
@@ -1,0 +1,92 @@
+## Task: Switch navigation from networkidle to load + settle delay
+
+GitHub issue #67. Change `defaultRenderer()` in `src/capture.js` to use
+`waitUntil: 'load'` with a 3-second post-load settle delay instead of
+`waitUntil: 'networkidle'`. Update tests and OpenAPI spec to match.
+
+### Why
+
+Ad-heavy sites (tagesschau.de, adobe.com) visually load in 2-3s but their
+tracking scripts keep network connections alive indefinitely. `networkidle`
+burns 20s waiting for silence that never comes, leaving too little budget
+for consent dismissal, screenshots, and WACZ packaging.
+
+### What to change
+
+All changes are in the worktree at:
+/Users/ben/github/benpeter/web-resource-ledger/.claude/worktrees/nefario/load-settle-strategy/
+
+#### A. Source changes (src/capture.js)
+
+1. Add constant SETTLE_DELAY_MS = 3000 alongside existing timeout constants.
+
+2. Keep NAV_TIMEOUT_MS at 20000. Do NOT change it.
+
+3. Change page.goto() call from waitUntil: 'networkidle' to waitUntil: 'load'.
+
+4. Add settle delay on happy path -- insert await page.waitForTimeout(SETTLE_DELAY_MS)
+   immediately after the limitExceeded check, BEFORE the viewport height check and
+   screenshots. If page.waitForTimeout() is not available, use
+   await new Promise(r => setTimeout(r, SETTLE_DELAY_MS)) instead.
+
+5. SECURITY ADVISORY: After the settle delay, add a SECOND limitExceeded check.
+   During the settle delay, async response events can push totalBytes past
+   MAX_PAGE_BYTES. Add: if (limitExceeded) throw new Error(limitExceeded);
+   after the settle delay. This closes the window.
+
+6. Update render.waitUntilReached on the happy-path return from 'networkidle' to 'load'.
+
+7. Update categorizeError() messages to derive from NAV_TIMEOUT_MS constant:
+   return { message: `Page did not finish loading within ${NAV_TIMEOUT_MS / 1000} seconds`, retryable: true };
+   Do this for both the Deadline exceeded case and the TimeoutError case.
+
+8. Update file-header comment (line 15) to reflect new timing budget.
+
+9. Update inline comment at the goto call to explain the strategy change.
+
+10. Update partial-capture budget comment to note this is the load timeout path.
+
+#### B. Test changes
+
+11. test/fixtures.js -- change waitUntilReached: 'networkidle' to 'load' on:
+    - consentNotDetectedRenderer (line 42)
+    - dualScreenshotRenderer (line 55)
+    - consentFailedRenderer (line 67)
+
+12. test/capture.test.js -- update:
+    - enrichedStubRenderer (line 601): 'networkidle' -> 'load'
+    - Assertion (line 751): 'networkidle' -> 'load'
+    - Error message assertions at lines 141, 290, 713, 727 stay as "20 seconds"
+      (NAV_TIMEOUT_MS unchanged). Verify they still pass after template literal change.
+
+#### C. OpenAPI spec changes (openapi.yaml)
+
+13. Update RenderInfo descriptions to reflect load milestone instead of networkidle.
+    Keep networkidle in the enum for backward compatibility.
+
+14. Update CaptureRecord.renderQuality and render descriptions similarly.
+
+15. Error examples stay the same (20 seconds, NAV_TIMEOUT_MS unchanged).
+
+#### D. Do NOT change
+- partialRenderer in test/fixtures.js (uses domcontentloaded -- correct)
+- partialLoadRenderer in test/capture.test.js (uses 'load' for partial -- correct)
+- timeoutRenderer error messages (25000ms -- correct Playwright timeout value)
+- Staged fallback path structure (lines 402-451)
+- Other test files
+
+#### E. After all changes
+Run npm test and verify all tests pass.
+
+### Success criteria
+- waitUntil: 'load' in page.goto() call
+- SETTLE_DELAY_MS = 3000 constant defined
+- Settle delay on happy path after limitExceeded check, before screenshots
+- Second limitExceeded check after settle delay (security advisory)
+- render.waitUntilReached returns 'load' on happy path
+- categorizeError() derives message from NAV_TIMEOUT_MS constant
+- All 3 fixture renderers updated to 'load'
+- enrichedStubRenderer and assertion updated to 'load'
+- OpenAPI spec descriptions updated (enum unchanged)
+- All existing tests pass
+- No changes to the staged fallback path structure

--- a/docs/history/nefario-reports/2026-03-16-183802-load-settle-strategy/phase5-code-review-minion.md
+++ b/docs/history/nefario-reports/2026-03-16-183802-load-settle-strategy/phase5-code-review-minion.md
@@ -1,0 +1,61 @@
+---
+phase: load-settle-strategy
+reviewer: code-review-minion
+files-reviewed:
+  - src/capture.js
+  - test/fixtures.js
+  - test/capture.test.js
+  - openapi.yaml
+---
+
+# Code Review: load-settle-strategy
+
+## Summary
+
+The implementation is correct and well-structured. All five verification
+points from the review brief pass. No blocking issues. Four nits, all
+minor.
+
+---
+
+VERDICT: APPROVE
+
+---
+
+## FINDINGS
+
+### Correctness
+
+- [NIT] src/capture.js:459 -- `await new Promise(r => setTimeout(r, SETTLE_DELAY_MS))` uses a bare arrow parameter name `r`. Style is consistent with Cloudflare Workers idioms, but `resolve` is clearer in a project that documents its intent carefully.
+  FIX: `await new Promise(resolve => setTimeout(resolve, SETTLE_DELAY_MS));`
+
+- [NIT] src/capture.js:15 -- Header comment budget arithmetic reads "20s load + 3s settle + 8s consent ≈ 33s worst-case". 20 + 3 + 8 = 31, not 33. Arithmetic is off by 2.
+  FIX: Either correct the sum to 31s or add the missing margin (e.g., "+2s post-processing → 33s worst-case") to make it precise.
+
+### Verification checks (all pass)
+
+1. **Settle delay on happy path only** -- PASS. The `await new Promise(r => setTimeout(r, SETTLE_DELAY_MS))` at line 459 appears after the `goto` try/catch block. The partial-capture return at lines 436-447 exits before reaching line 459. The settle delay is unreachable from the partial path.
+
+2. **Second limitExceeded check after settle delay** -- PASS. The re-check `if (limitExceeded) throw new Error(limitExceeded)` at line 463 is correctly placed after the `setTimeout` at line 459, catching any bytes that arrived during the settle window.
+
+3. **categorizeError template literals** -- PASS. Both timeout branches at lines 517 and 521 produce `Page did not finish loading within 20 seconds` (NAV_TIMEOUT_MS / 1000 = 20000 / 1000 = 20). The subresource message at line 524 produces `Page exceeded 200 subresource limit` (MAX_SUBRESOURCES = 200). All match their corresponding test assertions in capture.test.js lines 141, 290, 713, 727, 168.
+
+4. **OpenAPI enum preserved for backward compat** -- PASS. `waitUntilReached` enum at openapi.yaml line 269 retains all three values: `[domcontentloaded, load, networkidle]`. The description correctly explains `networkidle` is legacy-retained. No enum values removed.
+
+5. **Staged fallback structure unchanged** -- PASS. The partial-capture return shape at lines 436-447 is intact: `{ screenshot, html, partial: true, render: { waitUntilReached, timedOut, durationMs }, consent: null, screenshotBefore: null }`. No regression to the fallback structure.
+
+### Testing
+
+- [NIT] test/capture.test.js:574-605 -- The three inline renderer stubs (`partialRenderer`, `partialLoadRenderer`, `enrichedStubRenderer`) duplicate shape from test/fixtures.js. `partialLoadRenderer` and `enrichedStubRenderer` are test-local and reasonably sized, but `partialRenderer` is a narrower duplicate of the fixture at fixtures.js:75. Not a correctness issue -- just mild DRY drift that could confuse future editors about the canonical shape.
+  FIX: Import `partialRenderer` from fixtures.js (it already exists there with the same shape) and keep only the test-local variants (`partialLoadRenderer`, `enrichedStubRenderer`) as inline stubs.
+
+### OpenAPI
+
+- [NIT] openapi.yaml:272-274 -- The `networkidle` enum description says "fewer than two open network connections for 500ms". Playwright's actual `networkidle` definition is zero open connections for 500ms (not fewer than two). The two-connection threshold is `networkidle0` (older Puppeteer terminology) vs `networkidle2`. The current prose is imprecise and could mislead API consumers reading the spec.
+  FIX: Update to "no open network connections for 500ms" or add a clarifying note that this value is retained for backward compatibility only and will not be emitted by new captures.
+
+### Security (in scope for this review)
+
+No hardcoded secrets, no injection vectors introduced. The second `limitExceeded` guard at line 463 is the correct place to catch bytes delivered asynchronously during the settle window -- this is a positive security addition. The partial path correctly bypasses the settle delay, keeping the 2s post-timeout budget intact.
+
+No issues to report.

--- a/docs/history/nefario-reports/2026-03-16-183802-load-settle-strategy/prompt.md
+++ b/docs/history/nefario-reports/2026-03-16-183802-load-settle-strategy/prompt.md
@@ -1,0 +1,26 @@
+## Outcome
+
+Captures complete reliably for ad-heavy sites (tagesschau.de, adobe.com) that visually load in 2-3s but whose tracking scripts keep network connections alive indefinitely. Currently `page.goto()` uses `waitUntil: 'networkidle'` which burns 20s of the 30s `ctx.waitUntil` budget waiting for network silence that never comes, leaving the partial capture fallback too little time to succeed (tall page screenshots exceed the 2s deadline, cold browser sessions push total time past 30s).
+
+## Success criteria
+
+- tagesschau.de and adobe.com captures complete successfully (not timeout/pending)
+- Navigation phase completes in under 10s for typical sites (currently 20s+)
+- Sufficient time budget remains for consent dismissal (8s), screenshots, WACZ building, and R2/KV writes
+- All existing tests pass
+- Staged fallback from #53 remains functional as safety net for pages that don't reach the load event
+- NAV_TIMEOUT_MS restored to 25s (or justified if kept at 20s)
+
+## Scope
+
+**In:** `page.goto()` wait strategy in `defaultRenderer()`, settle delay after load event, NAV_TIMEOUT_MS value, related test assertions
+
+**Out:** Consent dismissal logic, WACZ/signing pipeline, partial capture fallback rewrite, general capture parameterization
+
+## Constraints
+
+- Use `waitUntil: 'load'` with a post-load settle delay (~3s) to allow late-rendering JS to complete
+- Must fit within the 30s `ctx.waitUntil` hard limit including all downstream work
+
+---
+Additional context: skip all approval gates -- defer decisions to gru and lucy instead of halting for human input. skip compaction checkpoints. auto-create the PR at wrap-up without halting. IMPORTANT: write process.md in the evolution log directory -- this is a project requirement. IMPORTANT: other worktrees may be running in parallel -- pick the next available evolution sequence number (check docs/evolution/ for existing entries) and use the slug provided below. Evolution slug: load-settle-strategy.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -259,9 +259,9 @@ components:
       description: >
         Rendering process metadata. Reports which browser readiness milestone was
         reached and whether the navigation timed out before reaching the target
-        (networkidle). Present on completed captures created after this feature;
-        absent on earlier captures. When absent, the page reached networkidle
-        (consistent with renderQuality: full).
+        (load). Present on completed captures created after this feature;
+        absent on earlier captures. When absent, the page reached the load
+        milestone (consistent with renderQuality: full).
       required: [waitUntilReached, timedOut, durationMs]
       properties:
         waitUntilReached:
@@ -269,21 +269,23 @@ components:
           enum: [domcontentloaded, load, networkidle]
           description: >
             Highest browser readiness milestone confirmed before the page was
-            captured. "networkidle" means fewer than two open network connections
-            for 500ms. "load" means the load event fired. "domcontentloaded"
-            means the DOM was parsed but some resources may still be loading.
+            captured. "load" means the load event fired (default for new captures).
+            "networkidle" means fewer than two open network connections for 500ms
+            (used by older captures -- retained in enum for backward compatibility).
+            "domcontentloaded" means the DOM was parsed but some resources may
+            still be loading.
         timedOut:
           type: boolean
           description: >
             True when the navigation did not reach the target milestone
-            (networkidle) within the timeout window. When true, renderQuality
+            (load) within the timeout window. When true, renderQuality
             is "partial".
         durationMs:
           type: integer
           minimum: 0
           description: >
             Wall-clock milliseconds from navigation start to the point the page
-            was captured (either at networkidle or at timeout).
+            was captured (either at load + settle delay, or at timeout).
           examples:
             - 25012
 
@@ -329,15 +331,16 @@ components:
           type: string
           enum: [full, partial]
           description: >
-            Render quality of the capture. 'full' when the page reached networkidle
-            before capture. 'partial' when the capture was taken after a navigation
-            timeout but DOMContentLoaded had fired. Defaults to 'full' for captures
-            created before this feature.
+            Render quality of the capture. 'full' when the page reached the load
+            milestone before capture (followed by a 3s settle delay). 'partial'
+            when the capture was taken after a navigation timeout but
+            DOMContentLoaded had fired. Defaults to 'full' for captures created
+            before this feature.
         render:
           $ref: '#/components/schemas/RenderInfo'
           description: >
             Rendering process metadata. Present on captures created after this feature.
-            When absent, the page reached networkidle (consistent with renderQuality: full).
+            When absent, the page reached the load milestone (consistent with renderQuality: full).
         artifacts:
           $ref: '#/components/schemas/CaptureArtifacts'
         wacz:

--- a/src/capture.js
+++ b/src/capture.js
@@ -12,7 +12,7 @@
  *   dismissed, a second screenshot is taken. Both screenshots and consent
  *   metadata (captureSettings) are included in the WACZ bundle and covered
  *   by the Ed25519 signature. Consent has an 8s hard timeout within the
- *   30s ctx.waitUntil budget (NAV_TIMEOUT_MS=20s load + 3s settle + 8s consent ≈ 33s worst-case; in practice load fires in 2-5s).
+ *   30s ctx.waitUntil budget (NAV_TIMEOUT_MS=20s load + 3s settle + 8s consent + 2s post ≈ 33s worst-case; in practice load fires in 2-5s).
  *   Partial captures skip consent entirely.
  *
  * Called from ctx.waitUntil() -- must always update KV (never leave pending).

--- a/src/capture.js
+++ b/src/capture.js
@@ -12,7 +12,7 @@
  *   dismissed, a second screenshot is taken. Both screenshots and consent
  *   metadata (captureSettings) are included in the WACZ bundle and covered
  *   by the Ed25519 signature. Consent has an 8s hard timeout within the
- *   30s ctx.waitUntil budget (NAV_TIMEOUT_MS=20s + 8s consent + 2s post).
+ *   30s ctx.waitUntil budget (NAV_TIMEOUT_MS=20s load + 3s settle + 8s consent ≈ 33s worst-case; in practice load fires in 2-5s).
  *   Partial captures skip consent entirely.
  *
  * Called from ctx.waitUntil() -- must always update KV (never leave pending).
@@ -82,6 +82,7 @@ const MAX_SUBRESOURCES = 200;
 const MAX_PAGE_BYTES = 50 * 1024 * 1024; // 50 MB
 const MAX_PAGE_HEIGHT = 8000;
 const NAV_TIMEOUT_MS = 20000;
+const SETTLE_DELAY_MS = 3000;
 const HEADER_FETCH_TIMEOUT_MS = 10000;
 const KEEP_ALIVE_MS = 120000; // 2 minutes
 const PARTIAL_SCREENSHOT_TIMEOUT_MS = 3000;
@@ -397,10 +398,10 @@ async function defaultRenderer(browserBinding, url) {
       }
     });
 
-    // Navigate with 20s timeout; 8s consent window + 2s post-processing fits the 30s ctx.waitUntil budget
-    // Playwright uses 'networkidle' (not 'networkidle2')
+    // Navigate with 20s timeout using 'load' (not 'networkidle' -- ad trackers keep connections alive indefinitely)
+    // Post-load: 3s settle + 8s consent + 2s post-processing fits the 30s ctx.waitUntil budget
     try {
-      await page.goto(url, { timeout: NAV_TIMEOUT_MS, waitUntil: 'networkidle' });
+      await page.goto(url, { timeout: NAV_TIMEOUT_MS, waitUntil: 'load' });
     } catch (navError) {
       if (navError.name === 'TimeoutError') {
         // Check if DOM has at least loaded before attempting partial capture
@@ -409,7 +410,7 @@ async function defaultRenderer(browserBinding, url) {
           throw navError;
         }
 
-        // 2000ms budget: renderer has been running ~20.5s; leaves margin for KV/R2 post-work
+        // 2000ms budget: renderer has been running ~20.5s (load timed out); leaves margin for KV/R2 post-work
         const deadline = Date.now() + 2000;
         const remainingMs = () => Math.max(0, deadline - Date.now());
 
@@ -453,6 +454,14 @@ async function defaultRenderer(browserBinding, url) {
 
     if (limitExceeded) throw new Error(limitExceeded);
 
+    // Settle delay: allow async resources (analytics, ads) to finish loading
+    // before taking screenshots. 'load' fires before tracking scripts settle.
+    await new Promise(r => setTimeout(r, SETTLE_DELAY_MS));
+
+    // SECURITY: async response events can push totalBytes past MAX_PAGE_BYTES
+    // during the settle delay. Re-check after settling.
+    if (limitExceeded) throw new Error(limitExceeded);
+
     // Cap screenshot height to prevent memory exhaustion
     const pageHeight = await page.evaluate(() => document.body.scrollHeight);
     if (pageHeight > MAX_PAGE_HEIGHT) {
@@ -479,7 +488,7 @@ async function defaultRenderer(browserBinding, url) {
       html,
       partial: false,
       render: {
-        waitUntilReached: 'networkidle',
+        waitUntilReached: 'load',
         timedOut: false,
         durationMs: Date.now() - renderStart,
       },
@@ -505,11 +514,11 @@ function categorizeError(error) {
   const msg = error?.message ?? '';
 
   if (msg.includes('Deadline exceeded')) {
-    return { message: 'Page did not finish loading within 20 seconds', retryable: true };
+    return { message: `Page did not finish loading within ${NAV_TIMEOUT_MS / 1000} seconds`, retryable: true };
   }
   // Playwright throws TimeoutError (by name) for navigation and wait timeouts
   if (error?.name === 'TimeoutError' || msg.includes('timeout') || msg.includes('Timeout')) {
-    return { message: 'Page did not finish loading within 20 seconds', retryable: true };
+    return { message: `Page did not finish loading within ${NAV_TIMEOUT_MS / 1000} seconds`, retryable: true };
   }
   if (msg.includes(`${MAX_SUBRESOURCES} subresource limit`)) {
     return { message: `Page exceeded ${MAX_SUBRESOURCES} subresource limit`, retryable: false };

--- a/test/capture.test.js
+++ b/test/capture.test.js
@@ -598,7 +598,7 @@ const enrichedStubRenderer = async () => ({
   html: TEST_HTML,
   partial: false,
   render: {
-    waitUntilReached: 'networkidle',
+    waitUntilReached: 'load',
     timedOut: false,
     durationMs: 3500,
   },
@@ -748,7 +748,7 @@ describe('performCapture -- full capture with render metadata', () => {
     await performCapture(env, TEST_URL, TEST_IP, TEST_ID, 'default', undefined, enrichedStubRenderer);
 
     const record = await getCapture(env.KV, TEST_ID);
-    expect(record.render.waitUntilReached).toBe('networkidle');
+    expect(record.render.waitUntilReached).toBe('load');
     expect(record.render.timedOut).toBe(false);
   });
 });

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -39,7 +39,7 @@ export const consentNotDetectedRenderer = async () => ({
   screenshotBefore: null,
   html: TEST_HTML,
   partial: false,
-  render: { waitUntilReached: 'networkidle', timedOut: false, durationMs: 2800 },
+  render: { waitUntilReached: 'load', timedOut: false, durationMs: 2800 },
   consent: { status: 'none', cmp: null, durationMs: 2500 },
 });
 
@@ -52,7 +52,7 @@ export const dualScreenshotRenderer = async () => ({
   screenshotBefore: PNG_BYTES,
   html: TEST_HTML,
   partial: false,
-  render: { waitUntilReached: 'networkidle', timedOut: false, durationMs: 3500 },
+  render: { waitUntilReached: 'load', timedOut: false, durationMs: 3500 },
   consent: { status: 'dismissed', cmp: 'cookiebot', durationMs: 850 },
 });
 
@@ -64,7 +64,7 @@ export const consentFailedRenderer = async () => ({
   screenshotBefore: null,
   html: TEST_HTML,
   partial: false,
-  render: { waitUntilReached: 'networkidle', timedOut: false, durationMs: 4200 },
+  render: { waitUntilReached: 'load', timedOut: false, durationMs: 4200 },
   consent: { status: 'timeout', cmp: null, durationMs: 8000 },
 });
 


### PR DESCRIPTION

## Summary

Switched `page.goto()` from `waitUntil: 'networkidle'` to `waitUntil: 'load'`
with a 3s post-load settle delay in `defaultRenderer()`. Ad-heavy sites
(tagesschau.de, adobe.com) that visually load in 2-3s but whose tracking
scripts keep network connections alive indefinitely no longer burn the full
NAV_TIMEOUT_MS budget waiting for network silence. 4 files changed (+38/-26
lines), 497 tests pass.

NAV_TIMEOUT_MS kept at 20s (not raised to 25s per issue suggestion) because
the `load` event is a much narrower target than `networkidle` and 25s creates
a real budget overrun window. Both planning specialists independently flagged
this risk.

## Original Prompt

Switch navigation wait strategy from networkidle to load + settle delay
(GitHub issue #67). Ad-heavy sites burn 20s waiting for network silence that
never comes, leaving insufficient budget for consent dismissal, screenshots,
and WACZ packaging.

## Key Design Decisions

1. **NAV_TIMEOUT_MS stays at 20s** -- 25s creates budget overrun
   (25+3+8+2=38s > 30s limit). 20s is generous for the `load` event.
2. **Plain `setTimeout` for settle delay** -- deterministic, no hang risk,
   avoids TimeoutError confusion with staged fallback catch block.
3. **Post-settle `limitExceeded` re-check** -- security advisory from
   Phase 3.5. Closes async size-limit bypass window during settle.
4. **Template literal in `categorizeError()`** -- derives message from
   constant. Single point of truth.

## Phases

### Phase 1: Meta-Plan
Nefario selected 2 planning specialists: debugger-minion (settle mechanism
tradeoffs) and test-minion (fixture/assertion audit). Excluded security, docs,
UX, and observability from planning -- narrow scope, Phase 3.5 provides
architectural coverage.

### Phase 2: Specialist Planning
Two specialists ran in parallel. Both independently flagged the NAV_TIMEOUT_MS
budget overrun risk. debugger-minion evaluated three settle options (plain
timer, networkidle-with-timeout, custom idle detection) and recommended the
simplest. test-minion identified all 5 test locations needing updates and
determined no new renderer variants were needed.

### Phase 3: Synthesis
Consolidated into 1 task, 0 gates. Resolved NAV_TIMEOUT_MS conflict by
keeping 20s with documented justification (issue explicitly allowed this).
Single-task structure appropriate for 4-file change.

### Phase 3.5: Architecture Review
5 mandatory reviewers. security-minion caught a real gap (post-settle size
limit bypass) and recommended a 2-line fix. All others approved. lucy
reminded about evolution log completeness.

### Phase 4: Execution
Single batch, single agent (debugger-minion on sonnet). All changes applied
cleanly. 497 tests pass. Security advisory incorporated (second
`limitExceeded` check after settle delay).

### Phase 5: Code Review
code-review-minion: APPROVE with 4 NITs. One fixed (comment arithmetic).
Three deferred (variable naming, DRY opportunity, Playwright definition
precision).

### Phase 6: Test Execution
497 tests pass, 0 failures.

### Phase 7: Deployment
Skipped (not requested).

### Phase 8: Documentation
Phase 8a: 0 documentation items identified. OpenAPI spec updated inline
during execution. Evolution log entries written.

## Agent Contributions

| Agent | Phase | Role | Verdict |
|-------|-------|------|---------|
| debugger-minion | planning | Settle mechanism analysis, budget math | -- |
| test-minion | planning | Fixture/assertion audit | -- |
| security-minion | review | Post-settle limitExceeded gap | ADVISE |
| test-minion | review | Test coverage verification | APPROVE |
| ux-strategy-minion | review | API consumer experience | APPROVE |
| lucy | review | Convention compliance | APPROVE (2 advisories) |
| margo | review | Complexity check | APPROVE |
| debugger-minion | execution | Implementation | -- |
| code-review-minion | post-exec | Code quality | APPROVE (4 NITs) |

## Verification

Verification: code review passed (4 NITs, 1 fixed), all 497 tests pass.

## Execution

### Task 1: Switch navigation from networkidle to load + settle delay
- **Agent**: debugger-minion (sonnet)
- **Files**: `src/capture.js` (+17/-8), `test/fixtures.js` (+3/-3),
  `test/capture.test.js` (+2/-2), `openapi.yaml` (+16/-13)
- **Outcome**: All changes applied, tests pass

## Decisions

### NAV_TIMEOUT_MS: 20s (not 25s)
Both specialists flagged budget overrun at 25s. With `waitUntil: 'load'`,
20s is generous (load fires in 1-5s typical). 25s creates overrun window.
Issue explicitly allowed "justified if kept at 20s."

### Settle mechanism: plain timer
`setTimeout(3000)` over `waitForLoadState('networkidle')` with timeout
(TimeoutError confusion) and custom idle detection (over-engineered).

## Session Resources

<details>
<summary>Skills Invoked</summary>

- `/nefario` (this orchestration)

</details>

<details>
<summary>Working Files</summary>

Companion directory: `docs/history/nefario-reports/2026-03-16-183802-load-settle-strategy/`

Files:
- `prompt.md` -- original prompt
- `phase1-metaplan-prompt.md`, `phase1-metaplan.md` -- meta-plan
- `phase2-debugger-minion-prompt.md`, `phase2-debugger-minion.md` -- debugger planning
- `phase2-test-minion-prompt.md`, `phase2-test-minion.md` -- test planning
- `phase3-synthesis-prompt.md`, `phase3-synthesis.md` -- synthesis
- `phase3.5-security-minion.md` -- security review (ADVISE)
- `phase3.5-test-minion.md` -- test review (APPROVE)
- `phase3.5-ux-strategy-minion.md` -- UX review (APPROVE)
- `phase3.5-lucy.md` -- lucy review (APPROVE)
- `phase3.5-margo.md` -- margo review (APPROVE)
- `phase4-debugger-minion-prompt.md` -- execution prompt
- `phase5-code-review-minion.md` -- code review (APPROVE)

</details>

Compaction events: 0

Resolves #67
