### PR TITLE
fix(config): switch TSA from Sectigo to DigiCert HTTP

### DIFF
--- a/vitest.config.js
+++ b/vitest.config.js
@@ -25,7 +25,7 @@ export default defineWorkersConfig({
             TEST_ARCHIVED_KEY: testArchivedKey,
             CORS_ORIGINS: 'https://allowed.example.com,https://other-allowed.example.com',
             IP_HASH_SEED: 'test-ip-hash-seed-for-vitest',
-            TSA_URL: 'https://timestamp.sectigo.com',
+            TSA_URL: 'http://timestamp.digicert.com',
           },
           // R2 isolated storage uses SQLite WAL files that can remain open
           // between tests, causing "failed to pop isolated storage stack frame"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -41,7 +41,7 @@ binding = "BROWSER"
 [vars]
 CORALOGIX_ENDPOINT = "https://ingress.eu2.coralogix.com/logs/v1/singles"
 APPLICATION_NAME = "wrl"
-TSA_URL = "https://timestamp.sectigo.com"
+TSA_URL = "http://timestamp.digicert.com"
 # Comma-separated origins allowed for CORS preflight (browser clients).
 # Omit or leave empty to disable CORS. No wildcards.
 # CORS_ORIGINS = "https://my-extension.example.com"
@@ -86,7 +86,7 @@ binding = "BROWSER"
 [env.staging.vars]
 CORALOGIX_ENDPOINT = "https://ingress.eu2.coralogix.com/logs/v1/singles"
 APPLICATION_NAME = "wrl-staging"
-TSA_URL = "https://timestamp.sectigo.com"
+TSA_URL = "http://timestamp.digicert.com"
 # Comma-separated origins allowed for CORS preflight (browser clients).
 # Omit or leave empty to disable CORS. No wildcards.
 # CORS_ORIGINS = "https://my-extension.example.com"


### PR DESCRIPTION
## Summary

- Switch TSA from `https://timestamp.sectigo.com` to `http://timestamp.digicert.com` (prod, staging, tests)
- Sectigo returns HTTP 404 from CF Workers despite correct request body and headers (confirmed via httpbin mirror)
- DigiCert HTTP verified working: 5/5 staging captures with valid, passing RFC 3161 timestamps
- HTTP transport is fine — RFC 3161 tokens are cryptographically signed; integrity comes from the CMS signature, not TLS

## Test plan

- [x] All 4103 tests pass
- [x] 5 staging captures with `http://timestamp.digicert.com` — all 4 verification checks pass
- [ ] Deploy to production and verify timestamps on live captures

🤖 Generated with [Claude Code](https://claude.com/claude-code)
