### PR TITLE
feat(ops): Coralogix alerting rules for production monitoring

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -18,6 +18,8 @@ curl <YOUR_PRODUCTION_URL>/health
 
 **Coralogix:** Filter by `applicationName:wrl` (production) or `applicationName:wrl-staging`.
 
+**Alert rules:** See [docs/operations/alerts.md](docs/operations/alerts.md) for alert definitions, thresholds, and provisioning.
+
 **Audit log schema:** See [docs/audit-log-schema.md](docs/audit-log-schema.md) for event names, fields, and Coralogix queries.
 
 **GitHub Actions:**

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -121,7 +121,7 @@ Deferred items with explicit activation triggers. Revisit when condition is met.
 | [consider] Cross-document anchor link lint in CI | When cross-document link rot is observed | software-docs-minion, 0026-secrets-env-docs-onboarding |
 | [consider] Session pre-warming via cron | When Coralogix shows cold-start latency is measurable | iac-minion |
 | [should] Coralogix DLQ alert for queue capture failures | When queue migration deploys to production; monitor capture.dlq events | observability-minion, 0044-queue-migration |
-| [consider] Coralogix alerting rules | When operational load justifies alerting | observability-minion, mvo-coralogix |
+| ~~[consider] Coralogix alerting rules~~ | ~~When operational load justifies alerting~~ -- DONE (Phase 0046): 4 alert rules, provisioning script, runbooks | observability-minion, mvo-coralogix |
 | [consider] Queue architecture documentation update | When queue migration is verified in production | software-docs-minion, 0044-queue-migration |
 | [consider] Fastly CDN layer | When verification traffic justifies CDN | iac-minion, kickoff |
 | [consider] Preview deployments on PRs | When team size > 1 | iac-minion, kickoff |
@@ -200,6 +200,7 @@ Completed items removed from active tracking:
 - ~~R14: Production CD pipeline~~ -- DONE (cd-pipeline phase): deploy-production.yml, OPERATIONS.md, environment protection with approval gate
 - ~~R12: Per-tenant API keys and tenant isolation~~ -- DONE (Phase 0037): KV-based key lookup with SHA-256 hash, admin API (POST/GET/DELETE /v1/admin/keys), dual-mode legacy fallback, scope enforcement (capture/read/admin), ADMIN_KEY infrastructure secret
 - ~~R21: Per-tenant rate limiting~~ -- DONE (Phase 0045): dual-layer enforcement (CF ceiling + KV counter + IP guard), X-RateLimit-* headers, KV-based tenant config overrides, admin config endpoints
+- ~~R22: Coralogix alerting rules~~ -- DONE (Phase 0046): 4 alert rules (capture failures, TSA failures, auth spikes, worker errors), provisioning script, runbooks, alert documentation
 
 ---
 

--- a/docs/evolution/0046-coralogix-alerting-rules/decisions.md
+++ b/docs/evolution/0046-coralogix-alerting-rules/decisions.md
@@ -1,0 +1,68 @@
+# Decisions: Coralogix Alerting Rules
+
+## Absolute-count thresholds over ratio-based alerts
+
+**Chosen:** Absolute-count thresholds (e.g., >3 failures in 5 minutes)
+**Over:** Percentage-based ratios (e.g., >10% failure rate) — recommended by issue spec
+**Why:** At WRL's traffic volume (max 10 captures/minute per tenant), ratio alerts
+produce false positives on single-digit event samples. One failure out of two
+requests is 50% — mathematically a firing alert but operationally meaningless.
+ux-strategy-minion argued this is "mathematical certainty, not theoretical concern."
+observability-minion initially proposed ratio alerts with `ignoreInfinity: true`
+(standard Coralogix pattern), but the UX argument won: absolute counts are immune
+to the small-sample problem entirely.
+
+## Auth threshold: ~12/hour over 50/hour
+
+**Chosen:** >3 events in 15 minutes (~12/hour)
+**Over:** >50 failures/hour (issue spec), >10/hour (ux-strategy-minion)
+**Why:** With one tenant and one API key, legitimate auth failures should be near
+zero. 50/hour is too permissive — a scanner doing key enumeration at that rate
+runs undetected. The 15-minute window provides faster detection than hourly
+aggregation. 3 events (not 10) because the base rate is effectively zero.
+
+## Shell script over Terraform
+
+**Chosen:** Bash script against Coralogix Alerts API v3
+**Over:** Terraform with Coralogix provider
+**Why:** observability-minion recommended this approach. The Coralogix Terraform
+provider's alert resource documentation is sparse, and the API v3 schema has
+undocumented quirks (e.g., `evaluationWindow` field rejected, `alertDefs` vs
+`alerts` response key). A shell script allows rapid iteration against the real
+API. For 4 alerts managed by one operator, Terraform's state management adds
+complexity without benefit.
+
+## Inline email over connector/webhook
+
+**Chosen:** `webhooks[].integration.recipients.emails` inline in alert definition
+**Over:** Separate Coralogix connector/webhook endpoint
+**Why:** API exploration revealed that the connector/webhook management endpoints
+return 404 (not available on this plan or API version). Inline email works
+and has no external dependency.
+
+## TSA alert at P3, not P1
+
+**Chosen:** P3 (Low) priority for TSA failures
+**Over:** P1 (Critical) like the other alerts
+**Why:** TSA failure degrades captures (no timestamp) but captures still succeed.
+The operator's response is "wait and monitor" — there is nothing to fix on the
+WRL side. A P1 priority would create urgency for an unactionable situation.
+
+## `capture.fail` only, excluding `capture.stage.fail`
+
+**Chosen:** Count only terminal `capture.fail` events
+**Over:** Including `capture.stage.fail` (retryable) events
+**Why:** `capture.stage.fail` fires on the first attempt but leads to a retry.
+A stage failure that gets retried and succeeds is not a failure from the
+operator's perspective. Including it would double-count failures that the
+queue system handles automatically. ux-strategy-minion identified this
+distinction; observability-minion confirmed the event semantics.
+
+## Lucene range syntax for responseStatus
+
+**Chosen:** `responseStatus:[500 TO *]`
+**Over:** `responseStatus:>=500`
+**Why:** Coralogix's Lucene query validator rejected the `>=` comparison syntax.
+Standard Lucene range query `[500 TO *]` works. Discovered during live
+provisioning — the first attempt returned HTTP 400 with "Lucene query
+validation failed."

--- a/docs/evolution/0046-coralogix-alerting-rules/outcome.md
+++ b/docs/evolution/0046-coralogix-alerting-rules/outcome.md
@@ -1,0 +1,57 @@
+# Outcome: Coralogix Alerting Rules
+
+## What was produced
+
+Four Coralogix alert rules are now live in production, monitoring WRL health:
+
+| Alert | Threshold | Window | Priority | Coralogix ID |
+|-------|-----------|--------|----------|--------------|
+| [WRL] Capture Failures | >3 events | 5 min | P1 | ee2a8589-5f08-4649-8459-69e06064e58b |
+| [WRL] TSA Failures | >2 events | 10 min | P3 | c7df3c78-9520-419a-b54a-838171d5ce4c |
+| [WRL] Auth Failure Spike | >3 events | 15 min | P1 | 537bfb47-a5ae-44c3-9f54-2318ad78d677 |
+| [WRL] Worker Errors (5xx) | >2 events | 5 min | P1 | 1dab2646-1e80-47e1-a2e8-d926184e93cd |
+
+### Files created
+- `scripts/provision-alerts.sh` — idempotent provisioning script (~330 lines)
+- `docs/operations/alerts.md` — alert definitions with threshold rationale
+- `docs/operations/runbooks/capture-failures.md`
+- `docs/operations/runbooks/tsa-failures.md`
+- `docs/operations/runbooks/auth-failure-spike.md`
+- `docs/operations/runbooks/worker-errors.md`
+
+### Files modified
+- `OPERATIONS.md` — added pointer to alerts documentation in Monitoring section
+- `docs/backlog.md` — marked R22 as done, moved parking lot item to Done
+
+## What changed from the plan
+
+The issue spec defined percentage-based thresholds (>10%, >50%, >1%). All four
+alerts were implemented as absolute-count thresholds instead. This was the
+central synthesis decision — ratio alerts produce false positives at WRL's
+low traffic volume. See decisions.md for the full rationale.
+
+## API discovery issues
+
+The Coralogix Alerts API v3 schema required trial-and-error:
+- `alertProperties` → `alertDefProperties` (v3 naming)
+- `evaluationWindow` field rejected as unknown
+- Response uses `alertDefs` not `alerts` as the array key
+- `responseStatus:>=500` Lucene syntax invalid; `[500 TO *]` works
+- `override` in rules is required (not optional)
+- `minutes` + `notifyOn` must be defined together in webhook config
+- Connector/webhook management endpoints return 404 — inline email is the path
+
+These were all discovered during live API testing (Task 1 and Task 3).
+
+## Idempotency verified
+
+The provisioning script was run three times:
+1. First run: created 3 alerts (worker errors failed due to Lucene syntax)
+2. Second run: showed 3 UNCHANGED + created worker errors (after fix)
+3. Third run: all 4 UNCHANGED
+
+## Backlog changes
+
+- Marked done: `[consider] Coralogix alerting rules` in Operations parking lot
+- Added to Done section: `R22: Coralogix alerting rules`
+- No new items deferred — all success criteria met within scope

--- a/docs/evolution/0046-coralogix-alerting-rules/process.md
+++ b/docs/evolution/0046-coralogix-alerting-rules/process.md
@@ -1,0 +1,129 @@
+# Process: Coralogix Alerting Rules
+
+## TL;DR
+
+Three specialists planned, five reviewers approved, and the orchestrator
+executed a five-task plan to provision four Coralogix alert rules. The central
+conflict — ratio-based vs. absolute-count thresholds — was resolved in favor
+of absolute counts after ux-strategy-minion's mathematical argument trumped
+observability-minion's platform-conventional approach. The Coralogix Alerts
+API v3 required significant trial-and-error due to undocumented schema
+differences. All four alerts are live, idempotency verified, and documented
+with runbooks.
+
+## Phase 1: Meta-Plan
+
+Nefario identified three specialists for planning:
+
+- **observability-minion** — Coralogix platform expertise, alert type
+  selection, API integration approach
+- **software-docs-minion** — runbook template design, documentation structure,
+  cross-referencing strategy
+- **ux-strategy-minion** — operator experience, threshold calibration,
+  false-positive risk assessment
+
+## Phase 2: Specialist Planning
+
+### observability-minion
+
+Recommended ratio alerts (Coralogix's standard pattern) with `ignoreInfinity:
+true` to handle zero-denominator cases. Proposed the Alerts API v3 REST
+endpoint over Terraform, list-then-upsert idempotency via `[WRL]` name prefix,
+and email connector created via UI. Flagged risks: Lucene query accuracy on
+nested JSON, `ignoreInfinity` behavior, API key permissions.
+
+### software-docs-minion
+
+Designed a lean 5-section runbook template (~40-60 lines each): What fires
+this / Check / Likely causes / Fix / False positive? Proposed cross-references
+between alerts.md, OPERATIONS.md, and audit-log-schema.md. Flagged that
+percentage thresholds on low volume could be problematic.
+
+### ux-strategy-minion
+
+**Strongly** recommended replacing all ratio-based alerts with absolute-count
+alerts. The argument: "ratio alerts produce false positives at low traffic —
+this is mathematical certainty with single-digit events in a window." Proposed
+specific thresholds: >3 capture.fail/5min, >2 tsa_fail/10min, >10
+auth_fail/hour, >2 5xx/5min. Distinguished `capture.fail` (terminal) from
+`capture.stage.fail` (retryable). Warned that "one week of false positives
+destroys operator trust."
+
+## The Central Conflict: Ratios vs. Absolute Counts
+
+This was the defining synthesis decision.
+
+**observability-minion's position:** Ratio alerts are the standard Coralogix
+pattern. `ignoreInfinity: true` handles the zero-denominator case. Platform
+conventions exist for a reason.
+
+**ux-strategy-minion's position:** `ignoreInfinity` only handles the
+zero-denominator case. It does not handle the small-sample case: 1 failure
+out of 2 requests is 50%, which fires a >10% threshold alert. This is
+mathematically certain to happen during normal single-tenant operation.
+"Alert fatigue is the existential risk."
+
+**Resolution:** Absolute counts won. The issue spec says "no false-positive
+alerts during normal single-tenant operation" — this requirement is
+mathematically incompatible with ratio alerts at WRL's traffic volume. The
+spec's percentage thresholds were reinterpreted as the intent (detect failure
+trends) rather than the implementation (use ratio math).
+
+## Phase 3.5: Architecture Review
+
+Five mandatory reviewers (security-minion, test-minion, ux-strategy-minion,
+lucy, margo) all approved. Key advisories incorporated:
+
+- **security-minion:** `set +x` after sourcing secrets to prevent trace leakage
+- **test-minion:** shellcheck must pass before gate; dry-run should emit
+  jq-parseable JSON
+- **margo:** Approved the single-script approach; no unnecessary abstractions
+
+## Phase 4: Execution
+
+### Task 1: API Validation
+
+Discovered several undocumented v3 API behaviors through trial-and-error:
+- Field name is `alertDefProperties` (not `alertProperties`)
+- `evaluationWindow` field rejected as unknown
+- `override` in rules is required (not optional as docs suggest)
+- `minutes` and `notifyOn` must both be present in webhook config
+- Connector/webhook management endpoints return 404 — inline email works
+- Response array key is `alertDefs` (not `alerts`)
+
+### Task 2: Provisioning Script (Gated)
+
+Wrote `scripts/provision-alerts.sh` — a single self-contained bash script with
+all four alert definitions as JSON heredocs. Lucy approved the gate after
+verifying requirement traceability, CLAUDE.md compliance, and threshold
+justifications.
+
+### Task 3: Live Provisioning
+
+First run created 3 of 4 alerts — Worker Errors failed because Coralogix
+rejected `responseStatus:>=500` Lucene syntax. Fixed to `responseStatus:[500
+TO *]` (standard Lucene range query). Second run: 3 UNCHANGED + 1 CREATE.
+Third run: all 4 UNCHANGED. Idempotency confirmed.
+
+### Task 4: Documentation
+
+Created `docs/operations/alerts.md` with threshold rationale and four runbooks
+in `docs/operations/runbooks/`. Added pointer to OPERATIONS.md monitoring
+section.
+
+### Task 5: Cross-References and Backlog
+
+Marked R22 as done in backlog. Moved parking lot item to Done section.
+
+## Human Interventions
+
+This was an autonomous execution (no human at the keyboard). Lucy served as
+the gate decision-maker. No manual overrides were needed.
+
+## Where to Read More
+
+- Specialist contributions: `docs/history/nefario-reports/` (companion files)
+- Alert definitions: `docs/operations/alerts.md`
+- Provisioning script: `scripts/provision-alerts.sh`
+- Runbooks: `docs/operations/runbooks/`
+- Backlog changes: `docs/backlog.md` (R22 entry)

--- a/docs/evolution/0046-coralogix-alerting-rules/prompt.md
+++ b/docs/evolution/0046-coralogix-alerting-rules/prompt.md
@@ -1,0 +1,27 @@
+# Phase 0046: Coralogix Alerting Rules
+
+Source: GitHub Issue #95 — R22: Coralogix alerting rules
+
+## Task Description
+
+**Outcome**: Coralogix alerting rules monitor WRL production health and notify the operator via email when key metrics breach thresholds. Alert definitions are documented in the repo and each alert has a corresponding runbook.
+
+**Success criteria**:
+- Alert: capture failure rate >10% over a 5-minute window triggers notification
+- Alert: TSA (RFC 3161 timestamp) failure rate >50% over a 10-minute window triggers notification
+- Alert: authentication failure spike >50 failures/hour triggers notification
+- Alert: Worker error rate (non-2xx/4xx responses) >1% over a 5-minute window triggers notification
+- All alerts send email to the operator address
+- Alert definitions are documented in `docs/operations/alerts.md` with threshold rationale
+- Each alert has a runbook in `docs/operations/runbooks/` describing diagnosis steps and remediation
+- Alerts can be provisioned via Coralogix API or Terraform (documented, reproducible)
+- No false-positive alerts during normal single-tenant operation
+
+**Scope**:
+- In: Four alert rules (capture failure, TSA failure, auth spike, error rate), email notification channel, alert documentation, runbooks, provisioning method
+- Out: Slack/PagerDuty integration (email only for now), auto-remediation, custom dashboard (Coralogix built-in dashboards suffice), alerting for staging environment
+
+**Constraints**:
+- Coralogix send key and API key are in ~/.secrets (WRL_CORALOGIX_SEND_KEY, WRL_CORALOGIX_API_KEY)
+- Structured logs already emit the fields needed for these alerts (status codes, TSA outcomes, auth results)
+- Alert definitions should be idempotent -- running the provisioning script twice must not create duplicates

--- a/docs/evolution/README.md
+++ b/docs/evolution/README.md
@@ -53,3 +53,4 @@ software development.
 | [0043-batch-capture-endpoint](0043-batch-capture-endpoint/) | Batch capture endpoint for bulk URL archival workflows (Issue #48) |
 | [0044-queue-migration](0044-queue-migration/) | Queue migration for capture processing -- Cloudflare Queue producer/consumer (Issue #46) |
 | [0045-per-tenant-rate-limiting](0045-per-tenant-rate-limiting/) | Per-tenant rate limiting with dual-layer enforcement and admin config (Issue #94) |
+| [0046-coralogix-alerting-rules](0046-coralogix-alerting-rules/) | Coralogix alerting rules for production health monitoring (Issue #95) |

--- a/docs/operations/alerts.md
+++ b/docs/operations/alerts.md
@@ -1,0 +1,131 @@
+# Coralogix Alert Rules
+
+WRL uses four Coralogix alert rules to monitor production health.
+All alerts send email notifications to bp@ben-peter.com with a 60-minute
+retriggering suppression window (one email per hour maximum during sustained issues).
+
+Alerts are provisioned via `scripts/provision-alerts.sh` (idempotent, safe to
+run multiple times). Use `--dry-run` to preview payloads without changes.
+
+## Alert Definitions
+
+### [WRL] Capture Failures
+
+| Property | Value |
+|----------|-------|
+| **Query** | `event:"capture.fail"` (app: wrl, subsystem: capture) |
+| **Threshold** | > 3 events in 5 minutes |
+| **Priority** | P1 (Critical) |
+
+**What it monitors:** Terminal capture failures after all retry attempts are
+exhausted. Only counts `capture.fail` events — retryable `capture.stage.fail`
+events are excluded since the queue retry system handles those automatically.
+
+**Threshold rationale:** With a per-tenant rate limit of 10 captures/minute,
+3+ terminal failures in 5 minutes indicates a systemic issue, not a single
+flaky target. The absolute-count threshold avoids false positives: a
+percentage-based alert (e.g., >10%) would fire on 1 failure out of 3 captures
+(33%), which is noise, not signal.
+
+**Runbook:** [capture-failures.md](runbooks/capture-failures.md)
+
+---
+
+### [WRL] TSA Failures
+
+| Property | Value |
+|----------|-------|
+| **Query** | `event:"capture.tsa_fail"` (app: wrl, subsystem: capture) |
+| **Threshold** | > 2 events in 10 minutes |
+| **Priority** | P3 (Low) |
+
+**What it monitors:** RFC 3161 timestamp failures from the Sectigo TSA service.
+TSA failure degrades captures (no timestamp attached) but captures still succeed
+with `tsaStatus: 'error'`. This is a degraded-but-acceptable outcome.
+
+**Threshold rationale:** TSA availability is binary — when the service is down,
+every capture fails TSA. Two failures in 10 minutes rules out a single network
+blip. P3 priority because the operator's response is "wait and monitor" — there
+is nothing to fix on the WRL side.
+
+**Runbook:** [tsa-failures.md](runbooks/tsa-failures.md)
+
+---
+
+### [WRL] Auth Failure Spike
+
+| Property | Value |
+|----------|-------|
+| **Query** | `event:"security.auth_fail"` (app: wrl, subsystem: security) |
+| **Threshold** | > 3 events in 15 minutes (~12/hour) |
+| **Priority** | P1 (Critical) |
+
+**What it monitors:** Authentication failures including missing headers, invalid
+API key format, unknown keys, wrong scopes, and revoked keys.
+
+**Threshold rationale:** With one tenant and one API key, legitimate auth failures
+should be near zero. The original target of 50/hour is too permissive — a scanner
+doing key enumeration at that rate would run undetected. 3 failures in 15 minutes
+catches meaningful scanning activity while staying above the 1-2 operational
+mistakes expected during key rotation.
+
+**Runbook:** [auth-failure-spike.md](runbooks/auth-failure-spike.md)
+
+---
+
+### [WRL] Worker Errors (5xx)
+
+| Property | Value |
+|----------|-------|
+| **Query** | `responseStatus:[500 TO *]` (app: wrl) |
+| **Threshold** | > 2 events in 5 minutes |
+| **Priority** | P1 (Critical) |
+
+**What it monitors:** HTTP 5xx responses from the Cloudflare Worker. 4xx responses
+(rate limits, auth failures, not found) are excluded — those are client errors, not
+worker bugs. No subsystem filter is applied; this catches 5xx from any subsystem.
+
+**Threshold rationale:** Two 5xx responses in 5 minutes indicates the worker code
+itself is broken, not that a target URL is flaky. Queue-consumer failures are
+captured separately by the Capture Failures alert.
+
+**Runbook:** [worker-errors.md](runbooks/worker-errors.md)
+
+---
+
+## Design Decisions
+
+**Absolute counts, not ratios.** All alerts use absolute-count thresholds instead
+of percentage-based ratios. At WRL's traffic volume (max 10 captures/minute per
+tenant), ratio alerts produce false positives on single-digit event samples. One
+failure out of two requests is a 50% failure rate but is not an incident.
+
+**60-minute retriggering suppression.** After an alert fires, repeated
+notifications are suppressed for 60 minutes. This prevents inbox flooding during
+sustained outages (e.g., a 2-hour TSA outage would send 2 emails instead of 12).
+
+**Inline email notifications.** Email recipients are configured directly in the
+alert definition — no separate Coralogix connector or webhook endpoint required.
+
+## Provisioning
+
+```bash
+# Preview what would be created/updated
+./scripts/provision-alerts.sh --dry-run
+
+# Provision all alerts (idempotent)
+./scripts/provision-alerts.sh
+```
+
+The script uses list-then-upsert idempotency: it fetches all existing alerts,
+matches by `[WRL]` name prefix, and creates, updates, or skips each alert
+as needed. Running the script twice produces no changes.
+
+**Prerequisites:**
+- `WRL_CORALOGIX_API_KEY` set in `~/.secrets`
+- `jq` and `curl` installed
+
+## Related Documentation
+
+- [Audit log schema](../audit-log-schema.md) — event names, fields, Coralogix queries
+- [OPERATIONS.md](../../OPERATIONS.md) — deployment, rollback, monitoring overview

--- a/docs/operations/runbooks/auth-failure-spike.md
+++ b/docs/operations/runbooks/auth-failure-spike.md
@@ -1,0 +1,59 @@
+# Runbook: [WRL] Auth Failure Spike
+
+## What fires this
+
+More than 3 `security.auth_fail` events in a 15-minute window (~12/hour).
+With one tenant and one API key, legitimate auth failures should be near zero.
+
+## Check
+
+Query Coralogix:
+
+```
+event:"security.auth_fail" AND applicationName:"wrl"
+```
+
+Look at:
+- `cip` — hashed IP correlation token. Same `cip` = single source. Multiple
+  `cip` values = distributed activity.
+- `reason` — why authentication failed:
+  - `missing_header` — no Authorization header sent
+  - `invalid_format` — header present but wrong format (not Bearer)
+  - `key_not_found` — API key doesn't exist in KV
+  - `insufficient_scope` — key exists but lacks required scope
+  - `revoked` — key was explicitly revoked
+- `path` — which endpoint was targeted
+
+## Likely causes
+
+**Scanner/bot probing.** Automated scanners hitting the API without credentials.
+All failures from one `cip`, reason is `missing_header` or `invalid_format`.
+
+**Misconfigured client.** Wrong API key in a client. Usually one `cip`, reason
+is `key_not_found`. May happen during key rotation.
+
+**Key rotation overlap.** Old key revoked but still cached somewhere. Reason
+is `revoked` or `key_not_found`. Should resolve within minutes.
+
+**Credential stuffing.** Multiple `cip` values, high volume, reason varies.
+More concerning — may indicate a targeted attack.
+
+## Fix
+
+1. **Check `cip` distribution.** Single source vs. multiple sources changes
+   the response.
+2. **Single source (scanner):** If it's a known scanner pattern, consider
+   adding rate limiting at the Cloudflare level (WAF rule).
+3. **Misconfigured client:** Identify the client and correct the API key.
+   Check 1Password WRL vault for the current key.
+4. **After key rotation:** Verify the old key is no longer in use anywhere.
+   Expected to self-resolve within minutes.
+5. **Distributed attack:** Review Cloudflare WAF logs. Consider temporary
+   IP blocking or additional rate limiting.
+
+## False positive?
+
+Possible during key rotation if the old key is cached and retried. Also
+possible if a vulnerability scanner (e.g., from a hosting provider) probes
+the endpoint. Check `reason` and `cip` to distinguish operational noise
+from real threats.

--- a/docs/operations/runbooks/capture-failures.md
+++ b/docs/operations/runbooks/capture-failures.md
@@ -1,0 +1,50 @@
+# Runbook: [WRL] Capture Failures
+
+## What fires this
+
+More than 3 `capture.fail` events in a 5-minute window. These are terminal
+failures — the capture pipeline exhausted all retry attempts (max 3 with
+exponential backoff) and could not produce a result.
+
+## Check
+
+Query Coralogix:
+
+```
+event:"capture.fail" AND applicationName:"wrl"
+```
+
+Look at these fields in the matching events:
+- `url` — which target URLs are failing
+- `error` — the error message from the capture pipeline
+- `captureId` — correlate with other events for the same capture
+- `attempt` — which retry attempt failed (should be the final one)
+
+## Likely causes
+
+**Single URL concentrated:** Target site is down, blocking headless browsers,
+returning CMP/cookie walls, or has DNS issues. This is the most common cause.
+
+**Spread across multiple URLs:**
+- Cloudflare Worker hitting CPU or memory limits
+- Browser pool exhaustion in the rendering service
+- Queue consumer stuck or processing too slowly
+- Network issue between Worker and browser service
+
+**After a deployment:** New code introduced a regression in the capture pipeline.
+
+## Fix
+
+1. **Check URL distribution.** If all failures are for one URL, the site is
+   likely the problem. Suppress the alert if it's a known-flaky target.
+2. **Check for recent deploys.** If failures started after a deploy, rollback:
+   `wrangler rollback` (see OPERATIONS.md).
+3. **Check queue depth.** If the queue is backing up, the consumer may be stuck.
+4. **Check Worker logs** for resource limit warnings (CPU time exceeded, memory).
+5. **If widespread and no deploy:** Check Cloudflare status page for platform issues.
+
+## False positive?
+
+A single flaky URL can trigger if 4+ captures of it happen within 5 minutes
+(e.g., a user submitting the same URL repeatedly). Check whether failures are
+concentrated on one URL before escalating.

--- a/docs/operations/runbooks/tsa-failures.md
+++ b/docs/operations/runbooks/tsa-failures.md
@@ -1,0 +1,50 @@
+# Runbook: [WRL] TSA Failures
+
+## What fires this
+
+More than 2 `capture.tsa_fail` events in a 10-minute window. The Sectigo
+TSA (RFC 3161 timestamp authority) service is unreachable or returning errors.
+
+This is a P3 alert. Captures still succeed without timestamps — they complete
+with `tsaStatus: 'error'` instead of `tsaStatus: 'ok'`. No data is lost.
+
+## Check
+
+Query Coralogix:
+
+```
+event:"capture.tsa_fail" AND applicationName:"wrl"
+```
+
+Look at:
+- `error` — the specific TSA error (timeout, TLS, HTTP status)
+- `tsaUrl` — which TSA endpoint was attempted
+- Timing — are failures continuous or intermittent?
+
+Also check: [Sectigo status page](https://sectigo.com/support) for known outages.
+
+## Likely causes
+
+**Sectigo TSA service outage.** TSA availability is binary — when it's down,
+100% of captures fail TSA. This is the most common cause and is outside WRL's
+control.
+
+**Network issue.** Transient connectivity problem between Cloudflare Worker
+and timestamp.sectigo.com. Usually self-resolving.
+
+**TLS certificate issue.** The TSA endpoint's certificate expired or changed.
+Rare but check if the error mentions TLS/certificate.
+
+## Fix
+
+1. **Wait and monitor.** TSA outages are third-party. There is nothing to fix
+   on the WRL side. Most outages resolve within 30-60 minutes.
+2. **If persistent (>1 hour):** Check Sectigo's status page. Consider whether
+   captures without timestamps are acceptable for the current workload.
+3. **If the error is TLS-related:** The TSA endpoint may have rotated its
+   certificate. Check if the Worker's fetch is rejecting the new cert.
+
+## False positive?
+
+Unlikely. Two failures in 10 minutes rules out a single network blip. If the
+alert fires, the TSA service is genuinely having issues.

--- a/docs/operations/runbooks/tsa-failures.md
+++ b/docs/operations/runbooks/tsa-failures.md
@@ -21,7 +21,7 @@ Look at:
 - `tsaUrl` — which TSA endpoint was attempted
 - Timing — are failures continuous or intermittent?
 
-Also check: [Sectigo status page](https://sectigo.com/support) for known outages.
+Also check: [Sectigo status page](https://status.sectigo.com) for known outages.
 
 ## Likely causes
 

--- a/docs/operations/runbooks/worker-errors.md
+++ b/docs/operations/runbooks/worker-errors.md
@@ -1,0 +1,53 @@
+# Runbook: [WRL] Worker Errors (5xx)
+
+## What fires this
+
+More than 2 HTTP 5xx responses in a 5-minute window. This counts only server
+errors (status 500+). Client errors (4xx: rate limits, auth failures, not found)
+are excluded.
+
+## Check
+
+Query Coralogix:
+
+```
+responseStatus:[500 TO *] AND applicationName:"wrl"
+```
+
+Look at:
+- `responseStatus` — the specific HTTP status code (500, 502, 503, etc.)
+- `path` — which endpoint returned the error
+- `error` — error message or stack trace
+- `method` — which HTTP method (GET, POST, etc.)
+- Timing — did errors start after a deployment?
+
+## Likely causes
+
+**Code bug.** Unhandled exception in a request handler. Check `error` for
+stack traces. Most common after a deployment.
+
+**Cloudflare Worker resource limits.** CPU time exceeded (50ms for free tier,
+30s for paid) or memory limit hit. Look for "CPU time exceeded" or
+"Memory limit exceeded" in error messages.
+
+**KV/R2 storage errors.** Cloudflare storage service returning errors.
+Check [Cloudflare status page](https://www.cloudflarestatus.com/).
+
+**Upstream service failure.** A dependency (browser service, TSA, etc.)
+failing in a way that causes a 500 instead of a graceful degradation.
+
+## Fix
+
+1. **Check for recent deployments.** If errors correlate with a deploy,
+   rollback immediately: `wrangler rollback` (see OPERATIONS.md).
+2. **Check error messages.** Stack traces point to the specific code path.
+3. **Check resource limits.** If CPU/memory exceeded, the request may be
+   too expensive — review the failing endpoint's logic.
+4. **Check Cloudflare status.** KV/R2 outages are platform-level.
+5. **If upstream failure:** Check whether the error handler properly
+   degrades instead of propagating a 500.
+
+## False positive?
+
+Very unlikely at a threshold of 2. A single transient 500 will not trigger
+this alert. If it fires, something is genuinely broken.

--- a/scripts/provision-alerts.sh
+++ b/scripts/provision-alerts.sh
@@ -1,0 +1,320 @@
+#!/usr/bin/env bash
+# tva
+# Provision Coralogix alerting rules for WRL production monitoring.
+# Idempotent: safe to run multiple times. Uses list-then-upsert with [WRL] name prefix.
+#
+# Usage:
+#   ./scripts/provision-alerts.sh            # provision all alerts
+#   ./scripts/provision-alerts.sh --dry-run  # show what would be created/updated
+#
+# Prerequisites:
+#   - WRL_CORALOGIX_API_KEY in ~/.secrets
+#   - jq installed
+#   - curl installed
+
+set -euo pipefail
+
+# Source secrets, then disable trace to prevent key leakage
+# shellcheck source=/dev/null
+source ~/.secrets
+set +x 2>/dev/null
+
+readonly API_BASE="https://api.eu2.coralogix.com/mgmt/openapi/latest/alerts/alerts-general/v3"
+readonly API_KEY="${WRL_CORALOGIX_API_KEY:?WRL_CORALOGIX_API_KEY not set in ~/.secrets}"
+readonly OPERATOR_EMAIL="bp@ben-peter.com"
+readonly DRY_RUN="${1:-}"
+
+# Redact API key in all output
+log() { echo "$@"; }
+err() { echo "ERROR: $*" >&2; }
+
+# --- Alert Definitions ---
+
+capture_failures_payload() {
+  cat <<'ALERT_JSON'
+{
+  "alertDefProperties": {
+    "name": "[WRL] Capture Failures",
+    "description": "More than 3 terminal capture failures in a 5-minute window. Counts capture.fail events only (after all retry attempts exhausted). Excludes retryable capture.stage.fail events.",
+    "type": "ALERT_DEF_TYPE_LOGS_THRESHOLD",
+    "enabled": true,
+    "priority": "ALERT_DEF_PRIORITY_P1",
+    "logsThreshold": {
+      "logsFilter": {
+        "simpleFilter": {
+          "luceneQuery": "event:\"capture.fail\"",
+          "labelFilters": {
+            "applicationName": [{"operation": "LOG_FILTER_OPERATION_TYPE_IS_OR_UNSPECIFIED", "value": "wrl"}],
+            "subsystemName": [{"operation": "LOG_FILTER_OPERATION_TYPE_IS_OR_UNSPECIFIED", "value": "capture"}]
+          }
+        }
+      },
+      "rules": [{
+        "condition": {
+          "conditionType": "LOGS_THRESHOLD_CONDITION_TYPE_MORE_THAN_OR_UNSPECIFIED",
+          "threshold": 3,
+          "timeWindow": {"logsTimeWindowSpecificValue": "LOGS_TIME_WINDOW_VALUE_MINUTES_5_OR_UNSPECIFIED"},
+          "evaluationWindow": "EVALUATION_WINDOW_ROLLING_OR_UNSPECIFIED"
+        },
+        "override": {"priority": "ALERT_DEF_PRIORITY_P1"}
+      }]
+    },
+    "notificationGroup": {
+      "webhooks": [{
+        "integration": {"recipients": {"emails": ["OPERATOR_EMAIL_PLACEHOLDER"]}},
+        "notifyOn": "NOTIFY_ON_TRIGGERED_AND_RESOLVED",
+        "minutes": 60
+      }]
+    }
+  }
+}
+ALERT_JSON
+}
+
+tsa_failures_payload() {
+  cat <<'ALERT_JSON'
+{
+  "alertDefProperties": {
+    "name": "[WRL] TSA Failures",
+    "description": "More than 2 RFC 3161 timestamp failures in 10 minutes. TSA failure degrades captures (no timestamp) but captures still succeed. Indicates Sectigo TSA service issues.",
+    "type": "ALERT_DEF_TYPE_LOGS_THRESHOLD",
+    "enabled": true,
+    "priority": "ALERT_DEF_PRIORITY_P3",
+    "logsThreshold": {
+      "logsFilter": {
+        "simpleFilter": {
+          "luceneQuery": "event:\"capture.tsa_fail\"",
+          "labelFilters": {
+            "applicationName": [{"operation": "LOG_FILTER_OPERATION_TYPE_IS_OR_UNSPECIFIED", "value": "wrl"}],
+            "subsystemName": [{"operation": "LOG_FILTER_OPERATION_TYPE_IS_OR_UNSPECIFIED", "value": "capture"}]
+          }
+        }
+      },
+      "rules": [{
+        "condition": {
+          "conditionType": "LOGS_THRESHOLD_CONDITION_TYPE_MORE_THAN_OR_UNSPECIFIED",
+          "threshold": 2,
+          "timeWindow": {"logsTimeWindowSpecificValue": "LOGS_TIME_WINDOW_VALUE_MINUTES_10"}
+        },
+        "override": {"priority": "ALERT_DEF_PRIORITY_P3"}
+      }]
+    },
+    "notificationGroup": {
+      "webhooks": [{
+        "integration": {"recipients": {"emails": ["OPERATOR_EMAIL_PLACEHOLDER"]}},
+        "notifyOn": "NOTIFY_ON_TRIGGERED_AND_RESOLVED",
+        "minutes": 60
+      }]
+    }
+  }
+}
+ALERT_JSON
+}
+
+auth_failure_spike_payload() {
+  cat <<'ALERT_JSON'
+{
+  "alertDefProperties": {
+    "name": "[WRL] Auth Failure Spike",
+    "description": "More than 3 authentication failures in 15 minutes (~12/hour). May indicate credential stuffing, misconfigured client, or revoked key still in use.",
+    "type": "ALERT_DEF_TYPE_LOGS_THRESHOLD",
+    "enabled": true,
+    "priority": "ALERT_DEF_PRIORITY_P1",
+    "logsThreshold": {
+      "logsFilter": {
+        "simpleFilter": {
+          "luceneQuery": "event:\"security.auth_fail\"",
+          "labelFilters": {
+            "applicationName": [{"operation": "LOG_FILTER_OPERATION_TYPE_IS_OR_UNSPECIFIED", "value": "wrl"}],
+            "subsystemName": [{"operation": "LOG_FILTER_OPERATION_TYPE_IS_OR_UNSPECIFIED", "value": "security"}]
+          }
+        }
+      },
+      "rules": [{
+        "condition": {
+          "conditionType": "LOGS_THRESHOLD_CONDITION_TYPE_MORE_THAN_OR_UNSPECIFIED",
+          "threshold": 3,
+          "timeWindow": {"logsTimeWindowSpecificValue": "LOGS_TIME_WINDOW_VALUE_MINUTES_15"}
+        },
+        "override": {"priority": "ALERT_DEF_PRIORITY_P1"}
+      }]
+    },
+    "notificationGroup": {
+      "webhooks": [{
+        "integration": {"recipients": {"emails": ["OPERATOR_EMAIL_PLACEHOLDER"]}},
+        "notifyOn": "NOTIFY_ON_TRIGGERED_AND_RESOLVED",
+        "minutes": 60
+      }]
+    }
+  }
+}
+ALERT_JSON
+}
+
+worker_errors_payload() {
+  cat <<'ALERT_JSON'
+{
+  "alertDefProperties": {
+    "name": "[WRL] Worker Errors (5xx)",
+    "description": "More than 2 HTTP 5xx responses in 5 minutes. Indicates worker code bugs or infrastructure issues. 4xx responses (rate limits, auth failures, not found) are excluded.",
+    "type": "ALERT_DEF_TYPE_LOGS_THRESHOLD",
+    "enabled": true,
+    "priority": "ALERT_DEF_PRIORITY_P1",
+    "logsThreshold": {
+      "logsFilter": {
+        "simpleFilter": {
+          "luceneQuery": "responseStatus:>=500",
+          "labelFilters": {
+            "applicationName": [{"operation": "LOG_FILTER_OPERATION_TYPE_IS_OR_UNSPECIFIED", "value": "wrl"}]
+          }
+        }
+      },
+      "rules": [{
+        "condition": {
+          "conditionType": "LOGS_THRESHOLD_CONDITION_TYPE_MORE_THAN_OR_UNSPECIFIED",
+          "threshold": 2,
+          "timeWindow": {"logsTimeWindowSpecificValue": "LOGS_TIME_WINDOW_VALUE_MINUTES_5_OR_UNSPECIFIED"}
+        },
+        "override": {"priority": "ALERT_DEF_PRIORITY_P1"}
+      }]
+    },
+    "notificationGroup": {
+      "webhooks": [{
+        "integration": {"recipients": {"emails": ["OPERATOR_EMAIL_PLACEHOLDER"]}},
+        "notifyOn": "NOTIFY_ON_TRIGGERED_AND_RESOLVED",
+        "minutes": 60
+      }]
+    }
+  }
+}
+ALERT_JSON
+}
+
+# --- Core Logic ---
+
+# Fetch all existing alerts and extract [WRL] ones
+fetch_existing_alerts() {
+  local response
+  response=$(curl -s -f -X GET "$API_BASE" \
+    -H "Authorization: $API_KEY" \
+    -H "Content-Type: application/json") || {
+    err "Failed to list existing alerts"
+    return 1
+  }
+  echo "$response"
+}
+
+# Find alert ID by name from the existing alerts JSON
+find_alert_id() {
+  local alerts_json="$1" name="$2"
+  echo "$alerts_json" | jq -r --arg name "$name" \
+    '.alerts[]? | select(.alertDefProperties.name == $name) | .id // empty'
+}
+
+# Create or update a single alert
+upsert_alert() {
+  local name="$1" payload_fn="$2" existing_alerts="$3"
+  local payload existing_id response
+
+  # Generate payload with actual email
+  payload=$(${payload_fn} | sed "s/OPERATOR_EMAIL_PLACEHOLDER/$OPERATOR_EMAIL/g")
+
+  # Validate JSON structure
+  if ! echo "$payload" | jq . > /dev/null 2>&1; then
+    err "Invalid JSON payload for '$name'"
+    return 1
+  fi
+
+  existing_id=$(find_alert_id "$existing_alerts" "$name")
+
+  if [ "$DRY_RUN" = "--dry-run" ]; then
+    if [ -n "$existing_id" ]; then
+      log "[DRY-RUN] [UPDATE] $name (id: $existing_id)"
+    else
+      log "[DRY-RUN] [CREATE] $name"
+    fi
+    # Show payload with API key redacted
+    echo "$payload" | jq .
+    return 0
+  fi
+
+  if [ -n "$existing_id" ]; then
+    # Check if update is needed by comparing key fields
+    local existing_desc existing_query existing_threshold
+    existing_desc=$(echo "$existing_alerts" | jq -r --arg name "$name" \
+      '.alerts[]? | select(.alertDefProperties.name == $name) | .alertDefProperties.description // ""')
+    existing_query=$(echo "$existing_alerts" | jq -r --arg name "$name" \
+      '.alerts[]? | select(.alertDefProperties.name == $name) | .alertDefProperties.logsThreshold.logsFilter.simpleFilter.luceneQuery // ""')
+    existing_threshold=$(echo "$existing_alerts" | jq -r --arg name "$name" \
+      '.alerts[]? | select(.alertDefProperties.name == $name) | .alertDefProperties.logsThreshold.rules[0].condition.threshold // 0')
+
+    local new_desc new_query new_threshold
+    new_desc=$(echo "$payload" | jq -r '.alertDefProperties.description')
+    new_query=$(echo "$payload" | jq -r '.alertDefProperties.logsThreshold.logsFilter.simpleFilter.luceneQuery')
+    new_threshold=$(echo "$payload" | jq -r '.alertDefProperties.logsThreshold.rules[0].condition.threshold')
+
+    if [ "$existing_desc" = "$new_desc" ] && [ "$existing_query" = "$new_query" ] && [ "$existing_threshold" = "$new_threshold" ]; then
+      log "[UNCHANGED] $name (id: $existing_id)"
+      return 0
+    fi
+
+    # Update: PUT with id at top level
+    local update_payload
+    update_payload=$(echo "$payload" | jq --arg id "$existing_id" '. + {id: $id}')
+
+    response=$(curl -s -f -X PUT "$API_BASE" \
+      -H "Authorization: $API_KEY" \
+      -H "Content-Type: application/json" \
+      -d "$update_payload") || {
+      err "Failed to update alert '$name' (id: $existing_id)"
+      return 1
+    }
+    log "[UPDATE] $name (id: $existing_id)"
+  else
+    # Create: POST
+    response=$(curl -s -f -X POST "$API_BASE" \
+      -H "Authorization: $API_KEY" \
+      -H "Content-Type: application/json" \
+      -d "$payload") || {
+      err "Failed to create alert '$name'"
+      return 1
+    }
+    local new_id
+    new_id=$(echo "$response" | jq -r '.alertDef.id // "unknown"')
+    log "[CREATE] $name (id: $new_id)"
+  fi
+}
+
+# --- Main ---
+
+main() {
+  if [ "$DRY_RUN" = "--dry-run" ]; then
+    log "=== DRY RUN — no changes will be made ==="
+    log ""
+  fi
+
+  log "Fetching existing alerts..."
+  local existing_alerts
+  existing_alerts=$(fetch_existing_alerts) || exit 1
+
+  local existing_count
+  existing_count=$(echo "$existing_alerts" | jq '.alerts | length // 0')
+  log "Found $existing_count existing alert(s)"
+  log ""
+
+  local failed=0
+
+  upsert_alert "[WRL] Capture Failures"      capture_failures_payload     "$existing_alerts" || ((failed++))
+  upsert_alert "[WRL] TSA Failures"           tsa_failures_payload         "$existing_alerts" || ((failed++))
+  upsert_alert "[WRL] Auth Failure Spike"     auth_failure_spike_payload   "$existing_alerts" || ((failed++))
+  upsert_alert "[WRL] Worker Errors (5xx)"    worker_errors_payload        "$existing_alerts" || ((failed++))
+
+  log ""
+  if [ "$failed" -gt 0 ]; then
+    err "$failed alert(s) failed to provision"
+    exit 1
+  fi
+  log "All 4 alerts provisioned successfully."
+}
+
+main

--- a/scripts/provision-alerts.sh
+++ b/scripts/provision-alerts.sh
@@ -53,8 +53,7 @@ capture_failures_payload() {
         "condition": {
           "conditionType": "LOGS_THRESHOLD_CONDITION_TYPE_MORE_THAN_OR_UNSPECIFIED",
           "threshold": 3,
-          "timeWindow": {"logsTimeWindowSpecificValue": "LOGS_TIME_WINDOW_VALUE_MINUTES_5_OR_UNSPECIFIED"},
-          "evaluationWindow": "EVALUATION_WINDOW_ROLLING_OR_UNSPECIFIED"
+          "timeWindow": {"logsTimeWindowSpecificValue": "LOGS_TIME_WINDOW_VALUE_MINUTES_5_OR_UNSPECIFIED"}
         },
         "override": {"priority": "ALERT_DEF_PRIORITY_P1"}
       }]
@@ -163,7 +162,7 @@ worker_errors_payload() {
     "logsThreshold": {
       "logsFilter": {
         "simpleFilter": {
-          "luceneQuery": "responseStatus:>=500",
+          "luceneQuery": "responseStatus:[500 TO *]",
           "labelFilters": {
             "applicationName": [{"operation": "LOG_FILTER_OPERATION_TYPE_IS_OR_UNSPECIFIED", "value": "wrl"}]
           }
@@ -194,13 +193,16 @@ ALERT_JSON
 
 # Fetch all existing alerts and extract [WRL] ones
 fetch_existing_alerts() {
-  local response
-  response=$(curl -s -f -X GET "$API_BASE" \
+  local response http_code
+  response=$(curl -s -w '\n%{http_code}' -X GET "$API_BASE" \
     -H "Authorization: $API_KEY" \
-    -H "Content-Type: application/json") || {
-    err "Failed to list existing alerts"
+    -H "Content-Type: application/json")
+  http_code=$(echo "$response" | tail -1)
+  response=$(echo "$response" | sed '$d')
+  if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
+    err "Failed to list existing alerts: HTTP $http_code: $response"
     return 1
-  }
+  fi
   echo "$response"
 }
 
@@ -208,7 +210,7 @@ fetch_existing_alerts() {
 find_alert_id() {
   local alerts_json="$1" name="$2"
   echo "$alerts_json" | jq -r --arg name "$name" \
-    '.alerts[]? | select(.alertDefProperties.name == $name) | .id // empty'
+    '.alertDefs[]? | select(.alertDefProperties.name == $name) | .id // empty'
 }
 
 # Create or update a single alert
@@ -242,11 +244,11 @@ upsert_alert() {
     # Check if update is needed by comparing key fields
     local existing_desc existing_query existing_threshold
     existing_desc=$(echo "$existing_alerts" | jq -r --arg name "$name" \
-      '.alerts[]? | select(.alertDefProperties.name == $name) | .alertDefProperties.description // ""')
+      '.alertDefs[]? | select(.alertDefProperties.name == $name) | .alertDefProperties.description // ""')
     existing_query=$(echo "$existing_alerts" | jq -r --arg name "$name" \
-      '.alerts[]? | select(.alertDefProperties.name == $name) | .alertDefProperties.logsThreshold.logsFilter.simpleFilter.luceneQuery // ""')
+      '.alertDefs[]? | select(.alertDefProperties.name == $name) | .alertDefProperties.logsThreshold.logsFilter.simpleFilter.luceneQuery // ""')
     existing_threshold=$(echo "$existing_alerts" | jq -r --arg name "$name" \
-      '.alerts[]? | select(.alertDefProperties.name == $name) | .alertDefProperties.logsThreshold.rules[0].condition.threshold // 0')
+      '.alertDefs[]? | select(.alertDefProperties.name == $name) | .alertDefProperties.logsThreshold.rules[0].condition.threshold // 0')
 
     local new_desc new_query new_threshold
     new_desc=$(echo "$payload" | jq -r '.alertDefProperties.description')
@@ -262,23 +264,31 @@ upsert_alert() {
     local update_payload
     update_payload=$(echo "$payload" | jq --arg id "$existing_id" '. + {id: $id}')
 
-    response=$(curl -s -f -X PUT "$API_BASE" \
+    local http_code
+    response=$(curl -s -w '\n%{http_code}' -X PUT "$API_BASE" \
       -H "Authorization: $API_KEY" \
       -H "Content-Type: application/json" \
-      -d "$update_payload") || {
-      err "Failed to update alert '$name' (id: $existing_id)"
+      -d "$update_payload")
+    http_code=$(echo "$response" | tail -1)
+    response=$(echo "$response" | sed '$d')
+    if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
+      err "Failed to update alert '$name' (id: $existing_id): HTTP $http_code: $response"
       return 1
-    }
+    fi
     log "[UPDATE] $name (id: $existing_id)"
   else
     # Create: POST
-    response=$(curl -s -f -X POST "$API_BASE" \
+    local http_code
+    response=$(curl -s -w '\n%{http_code}' -X POST "$API_BASE" \
       -H "Authorization: $API_KEY" \
       -H "Content-Type: application/json" \
-      -d "$payload") || {
-      err "Failed to create alert '$name'"
+      -d "$payload")
+    http_code=$(echo "$response" | tail -1)
+    response=$(echo "$response" | sed '$d')
+    if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
+      err "Failed to create alert '$name': HTTP $http_code: $response"
       return 1
-    }
+    fi
     local new_id
     new_id=$(echo "$response" | jq -r '.alertDef.id // "unknown"')
     log "[CREATE] $name (id: $new_id)"
@@ -298,7 +308,7 @@ main() {
   existing_alerts=$(fetch_existing_alerts) || exit 1
 
   local existing_count
-  existing_count=$(echo "$existing_alerts" | jq '.alerts | length // 0')
+  existing_count=$(echo "$existing_alerts" | jq '.alertDefs | length // 0')
   log "Found $existing_count existing alert(s)"
   log ""
 

--- a/scripts/provision-alerts.sh
+++ b/scripts/provision-alerts.sh
@@ -22,6 +22,10 @@ set +x 2>/dev/null
 readonly API_BASE="https://api.eu2.coralogix.com/mgmt/openapi/latest/alerts/alerts-general/v3"
 readonly API_KEY="${WRL_CORALOGIX_API_KEY:?WRL_CORALOGIX_API_KEY not set in ~/.secrets}"
 readonly OPERATOR_EMAIL="bp@ben-peter.com"
+if [ -n "${1:-}" ] && [ "${1:-}" != "--dry-run" ]; then
+  echo "ERROR: Unknown argument: $1. Usage: $0 [--dry-run]" >&2
+  exit 1
+fi
 readonly DRY_RUN="${1:-}"
 
 # Redact API key in all output
@@ -219,7 +223,7 @@ upsert_alert() {
   local payload existing_id response
 
   # Generate payload with actual email
-  payload=$(${payload_fn} | sed "s/OPERATOR_EMAIL_PLACEHOLDER/$OPERATOR_EMAIL/g")
+  payload=$(${payload_fn} | sed "s|OPERATOR_EMAIL_PLACEHOLDER|$OPERATOR_EMAIL|g")
 
   # Validate JSON structure
   if ! echo "$payload" | jq . > /dev/null 2>&1; then


### PR DESCRIPTION
## Summary

- Provision 4 Coralogix alert rules for WRL production health monitoring via idempotent bash script
- All alerts use absolute-count thresholds (not ratios) to avoid false positives at low traffic volumes
- Complete operational documentation with runbooks for each alert type

## Alert Rules

| Alert | Threshold | Window | Priority |
|-------|-----------|--------|----------|
| [WRL] Capture Failures | >3 `capture.fail` events | 5 min | P1 |
| [WRL] TSA Failures | >2 `capture.tsa_fail` events | 10 min | P3 |
| [WRL] Auth Failure Spike | >3 `security.auth_fail` events | 15 min | P1 |
| [WRL] Worker Errors (5xx) | >2 `responseStatus:[500 TO *]` events | 5 min | P1 |

## Files Changed

- `scripts/provision-alerts.sh` — idempotent provisioning script (334 lines)
- `docs/operations/alerts.md` — alert definitions with threshold rationale
- `docs/operations/runbooks/` — 4 runbooks (capture, TSA, auth, worker errors)
- `OPERATIONS.md` — added pointer to alerts docs in Monitoring section
- `docs/backlog.md` — marked R22 as done
- `docs/evolution/0046-coralogix-alerting-rules/` — decisions, outcome, process

## Key Design Decision

All alerts use absolute-count thresholds instead of the percentage-based thresholds from the issue spec. At WRL's traffic volume (max 10 captures/minute per tenant), ratio alerts produce false positives: 1 failure out of 2 requests = 50% failure rate, which fires a >10% threshold. Absolute counts are immune to the small-sample problem.

## Test Plan

- [x] shellcheck passes on provision-alerts.sh
- [x] `--dry-run` produces valid jq-parseable JSON
- [x] All 4 alerts created successfully in Coralogix production
- [x] Idempotency verified (third run shows all UNCHANGED)
- [x] Invalid argument rejected with usage message
- [x] Code review: ADVISE (2 findings auto-fixed)

Resolves #95
