### PR TITLE
fix(ops): apply session protocol learnings to autonomous orchestrator

### DIFF
--- a/scripts/autonomous/coordinator-prompt.md
+++ b/scripts/autonomous/coordinator-prompt.md
@@ -52,5 +52,18 @@ The orchestrator resumes from the first non-`success` phase automatically.
 
 ## Current state
 
-Phases 0042-0046 complete. 0047 (D1 migration) and 0048 (brand identity)
-are pending. The orchestrator will resume from 0047.
+Check phase status files to see what's done:
+
+```bash
+for f in scripts/autonomous/logs/current/phase-*.status; do
+  echo "$(basename "$f" .status): $(cat "$f")"
+done
+```
+
+## Budget & Timing (observed from 14 phases)
+
+- **Cost per phase**: ~$34 average (range $12-$60)
+- **Time per phase**: ~1 hour average (range 30 min to 2+ hours)
+- **CI budget**: GitHub Free plan = 2,000 min/month. Each phase uses ~5 min
+  CI, but retries, deploys, and integration tests add up.
+- **Full run estimate**: ~$1,600 for 28 phases over ~30 hours

--- a/scripts/autonomous/create-issues.sh
+++ b/scripts/autonomous/create-issues.sh
@@ -35,6 +35,9 @@ for i in $(seq 0 $((PHASE_COUNT - 1))); do
     continue
   fi
 
+  # Ensure act label exists
+  gh label create "act-${ACT}" --color "0e8a16" --force 2>/dev/null || true
+
   # Check if spec file exists
   SPEC_FILE="$SPECS_DIR/${ITEM}.md"
   if [[ ! -f "$SPEC_FILE" ]]; then

--- a/scripts/autonomous/issue-specs/LEGAL.md
+++ b/scripts/autonomous/issue-specs/LEGAL.md
@@ -1,0 +1,71 @@
+## Outcome
+
+Host Stripe-required legal and policy pages on webresourceledger.com so the
+site passes Stripe's business website verification. All pages served as static
+HTML under the existing landing site (Cloudflare Workers Static Assets).
+
+## Business Identity
+
+The Stripe account holder is a sole proprietor (Einzelunternehmer):
+
+- **Business name**: Gerhard Benjamin Peter
+- **Address**: Weidenhäuser Str. 73, 35037 Marburg, Germany
+- **Email**: bp@ben-peter.com
+
+Use this name and address on all legal pages and the landing page footer.
+
+## Stripe Requirements (from support.stripe.com/questions/business-website-for-account-activation-faq)
+
+The business website must include:
+
+- [x] Business name (already on landing page as "Web Resource Ledger" -- add operator identity to footer/legal pages)
+- [x] Description of goods/services (already on landing page)
+- [ ] Customer service contact details (phone, email, address, contact form, or messaging)
+- [ ] Refund and dispute policy
+- [ ] Cancelation policy
+- [ ] Privacy policy (not listed by Stripe FAQ but required by Stripe Checkout and GDPR)
+
+## Success Criteria
+
+1. `/privacy` serves a Privacy Policy page explaining what data WRL collects,
+   how it's used, retention, GDPR rights, and contact for data requests
+2. `/refund-policy` serves a Refund, Cancelation & Dispute Policy page covering
+   subscription cancelation, refund eligibility, and how to dispute charges
+3. `/terms` serves the existing Terms of Service (currently only on GitHub)
+4. `/content-policy` serves the existing Content Policy (currently only on GitHub)
+5. All four pages use the same design system and layout as the landing page
+   (header, footer, CSS custom properties from design-system.css)
+6. Landing page footer updated: links point to hosted `/terms`, `/privacy`,
+   `/refund-policy`, `/content-policy` instead of GitHub
+7. Landing page footer includes operator identity and contact details:
+   "Gerhard Benjamin Peter · Weidenhäuser Str. 73, 35037 Marburg · bp@ben-peter.com"
+   -- satisfies Stripe's "customer service contact details" requirement
+8. All pages accessible without authentication, crawlable by search engines
+9. `sitemap.xml` updated to include the new pages
+
+## Scope
+
+### In
+
+- Privacy Policy page (new content)
+- Refund, Cancelation & Dispute Policy page (new content)
+- Terms of Service page (render existing TERMS.md as HTML)
+- Content Policy page (render existing CONTENT-POLICY.md as HTML)
+- Landing page footer updates (links + contact email)
+- sitemap.xml update
+
+### Out
+
+- Cookie consent banner (no cookies used currently)
+- GDPR consent management platform
+- Imprint/Impressum (evaluate later based on German TMG requirements)
+- Dynamic legal page CMS -- these are static HTML files
+
+## Constraints
+
+- Depends on 0052 (landing page exists with design system)
+- Pure HTML + CSS, no JS framework needed -- these are static content pages
+- Pages must match the landing page's visual style (use design-system.css)
+- Keep legal language clear and honest -- these are reasonable-effort templates
+  for an early-stage project, not attorney-reviewed documents (include disclaimer)
+- Budget: $40 -- this is mostly content creation and HTML templating

--- a/scripts/autonomous/lib/fix-deploy.sh
+++ b/scripts/autonomous/lib/fix-deploy.sh
@@ -19,7 +19,7 @@ try_fix_deploy() {
 
   # Pattern: Queue "X" does not exist
   local missing_queues
-  missing_queues=$(echo "$failed_log" | grep -oP 'Queue "\K[^"]+(?=" does not exist)' || true)
+  missing_queues=$(echo "$failed_log" | sed -n 's/.*Queue "\([^"]*\)" does not exist.*/\1/p' || true)
   for queue in $missing_queues; do
     log_info "Provisioning missing queue: $queue"
     if (unset CLOUDFLARE_API_TOKEN && npx wrangler queues create "$queue" 2>&1); then
@@ -32,11 +32,21 @@ try_fix_deploy() {
 
   # Pattern: D1 database "X" does not exist
   local missing_d1
-  missing_d1=$(echo "$failed_log" | grep -oP 'D1 database "\K[^"]+(?=" does not exist)' || true)
+  missing_d1=$(echo "$failed_log" | sed -n 's/.*D1 database "\([^"]*\)" does not exist.*/\1/p' || true)
   for db in $missing_d1; do
     log_info "Provisioning missing D1 database: $db"
     if (unset CLOUDFLARE_API_TOKEN && npx wrangler d1 create "$db" 2>&1); then
       log_info "D1 database $db created"
+      # Run migrations if they exist
+      local repo_dir
+      repo_dir=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+      local migrations_dir="$repo_dir/migrations"
+      if [[ -d "$migrations_dir" ]] && ls "$migrations_dir"/*.sql &>/dev/null; then
+        log_info "Running D1 migrations for $db..."
+        (unset CLOUDFLARE_API_TOKEN && npx wrangler d1 migrations apply "$db" --remote 2>&1) || {
+          log_warn "D1 migrations failed for $db (may need manual intervention)"
+        }
+      fi
       fixed=true
     else
       log_error "Failed to create D1 database $db"
@@ -63,7 +73,7 @@ try_fix_deploy() {
         local create_output
         create_output=$(unset CLOUDFLARE_API_TOKEN && npx wrangler d1 create "$db_name" 2>&1 || true)
         local new_id
-        new_id=$(echo "$create_output" | grep -oP 'database_id = "\K[^"]+' || true)
+        new_id=$(echo "$create_output" | sed -n 's/.*database_id = "\([^"]*\)".*/\1/p' | head -1 || true)
         if [[ -n "$new_id" ]]; then
           log_info "D1 database $db_name created with ID $new_id"
           # Find the placeholder line that corresponds to this database_name
@@ -92,7 +102,7 @@ try_fix_deploy() {
 
   # Pattern: KV namespace "X" does not exist
   local missing_kv
-  missing_kv=$(echo "$failed_log" | grep -oP 'KV namespace "\K[^"]+(?=" does not exist)' || true)
+  missing_kv=$(echo "$failed_log" | sed -n 's/.*KV namespace "\([^"]*\)" does not exist.*/\1/p' || true)
   for ns in $missing_kv; do
     log_info "Provisioning missing KV namespace: $ns"
     if (unset CLOUDFLARE_API_TOKEN && npx wrangler kv namespace create "$ns" 2>&1); then

--- a/scripts/autonomous/lib/verify-phase.sh
+++ b/scripts/autonomous/lib/verify-phase.sh
@@ -263,10 +263,10 @@ extract_pr_number() {
 
   # Try to find PR URL in the output
   local pr_url
-  pr_url=$(grep -oE 'https://github\.com/[^/]+/[^/]+/pull/\d+' "$json_file" 2>/dev/null | head -1 || true)
+  pr_url=$(grep -oE 'https://github\.com/[^/]+/[^/]+/pull/[0-9]+' "$json_file" 2>/dev/null | head -1 || true)
 
   if [[ -n "$pr_url" ]]; then
-    echo "$pr_url" | grep -oE '\d+$'
+    echo "$pr_url" | grep -oE '[0-9]+$'
     return 0
   fi
 

--- a/scripts/autonomous/manifest.json
+++ b/scripts/autonomous/manifest.json
@@ -169,6 +169,18 @@
       "act_last": false
     },
     {
+      "phase": "0070",
+      "item": "LEGAL",
+      "issue": 131,
+      "title": "Stripe-required legal pages",
+      "act": 4,
+      "budget_usd": 40,
+      "depends_on": [
+        "0052"
+      ],
+      "act_last": false
+    },
+    {
       "phase": "0057",
       "item": "E2E",
       "issue": 105,
@@ -189,7 +201,8 @@
       "budget_usd": 100,
       "depends_on": [
         "0055",
-        "0056"
+        "0056",
+        "0070"
       ],
       "act_last": false
     },

--- a/scripts/autonomous/orchestrate.sh
+++ b/scripts/autonomous/orchestrate.sh
@@ -158,8 +158,15 @@ for i in $(seq 0 $((PHASE_COUNT - 1))); do
   log_info "Budget: \$$BUDGET | Issue: ${ISSUE:-TBD}"
   echo "=========================================="
 
-  # Ensure main is up-to-date
-  git checkout main --quiet 2>/dev/null || true
+  # Ensure main is up-to-date (stash if dirty to avoid silent checkout failure)
+  if ! git diff --quiet HEAD 2>/dev/null; then
+    log_warn "Dirty working tree detected -- stashing before checkout"
+    git stash push -m "orchestrator-auto-stash-phase-${PHASE}" --quiet
+  fi
+  git checkout main --quiet 2>/dev/null || {
+    log_error "Failed to checkout main"
+    exit 1
+  }
   git pull --quiet --rebase 2>/dev/null || true
 
   # Notify start

--- a/scripts/autonomous/session-prompt.md
+++ b/scripts/autonomous/session-prompt.md
@@ -104,6 +104,12 @@ Examples:
 This applies to ALL environments (production and staging). If you add a
 binding to both environments, provision the resource for both.
 
+**wrangler.test.toml**: If you modify `wrangler.toml` (new bindings, changed
+rate limits, new queues), regenerate `wrangler.test.toml` by copying
+`wrangler.toml` and removing all `[[queues.consumers]]` sections. Queue
+consumers cause miniflare to auto-consume messages during tests, crashing
+the workerd runtime. CI will fail if `wrangler.test.toml` is stale.
+
 ### Error Signaling
 
 If an unrecoverable error occurs, output a line starting with

--- a/scripts/autonomous/supervisor-prompt.md
+++ b/scripts/autonomous/supervisor-prompt.md
@@ -32,22 +32,70 @@ When the orchestrator pauses on a failure, you must:
 
 1. **Read the logs** — `scripts/autonomous/logs/current/orchestrator.log`
    and the phase JSON output (`phase-NNNN.json`)
-2. **Diagnose the root cause** — common failures:
-   - **No PR created**: session stopped at compaction checkpoint or gate
-     (check `result` field in JSON for "compaction" or "wait for user")
-   - **CI failed**: read `gh run view <id> --log-failed`, fix the code on
-     the PR branch, push, wait for CI to pass
-   - **Deploy failed**: missing Cloudflare resources (D1, queues) — create
-     them with wrangler, update wrangler.toml if needed
-   - **Merge conflicts**: resolve on the PR branch, push
-   - **CI never triggered**: close/reopen PR or push empty commit
-   - **Session crashed**: transient error, just retry
+2. **Diagnose the root cause** — see Diagnostic Playbook below
 3. **Fix it** — edit files, commit, push, provision resources, merge PRs,
    whatever is needed
 4. **Mark the phase as success** — `echo "success" > scripts/autonomous/logs/current/phase-NNNN.status`
 5. **Clean up** — remove orphan worktrees (`git worktree remove ... --force`)
 6. **Resume** — `touch ~/wrl-go` (the orchestrator verifies the phase is
    success before continuing; if not, it exits)
+
+## Diagnostic Playbook
+
+Check `scripts/autonomous/logs/current/phase-NNNN.json` and the status file.
+The status tells you the failure category; the JSON tells you why.
+
+### `failed_session` — Claude session exited non-zero
+
+Check the phase JSON for these patterns:
+
+| What to check | How | Diagnosis |
+|---------------|-----|-----------|
+| Compaction block | `grep -i 'compaction.*clipboard\|wait.*user\|Phase [0-9].* complete\. Compaction' phase-NNNN.json` | Session stopped at nefario compaction checkpoint. Reinforce session prompt and retry. |
+| Permission denials | `jq '.permission_denials \| length' phase-NNNN.json` — if >5 | Session tried AskUserQuestion repeatedly. Lucy gate protocol not working. |
+| Budget exceeded | `jq '.stop_reason' phase-NNNN.json` = `"budget_exceeded"` | Increase budget in manifest.json (50% bump) and retry. |
+| Too short (<5 turns) | `jq '.num_turns' phase-NNNN.json` < 5 | Likely transient. Just retry. |
+| Planning only | Many turns but no PR, `failed_no_pr` | Session did planning but never executed. Retry with reinforcement. |
+
+### `failed_ci` — Tests failed after PR creation
+
+1. `gh pr checks <N>` to see which check failed
+2. `gh run view <id> --log-failed` to read the error
+3. Fix the code on the PR branch, push, wait for green
+4. Common CI issues:
+   - **wrangler.test.toml stale**: if wrangler.toml was modified, regenerate
+     wrangler.test.toml (copy without `[[queues.consumers]]` sections)
+   - **Rate limit values changed**: wrangler.test.toml may have old values
+   - **New binding not in test config**: add it to wrangler.test.toml
+
+### `failed_merge` — PR couldn't be merged
+
+1. Check for merge conflicts: `gh pr view <N> --json mergeable`
+2. If conflicts: checkout the PR branch, rebase onto main, force-push
+3. If CI never triggered: close and reopen the PR, or push an empty commit
+
+### `failed_deploy` — Deploy failed after merge
+
+1. Check `gh run list --workflow deploy-staging.yml --limit 1`
+2. `gh run view <id> --log-failed` to read the wrangler error
+3. Common deploy failures:
+   - **Missing queue/KV**: `unset CLOUDFLARE_API_TOKEN && npx wrangler queues create <name>`
+   - **Missing D1 database**: create with wrangler, then run migrations:
+     `unset CLOUDFLARE_API_TOKEN && npx wrangler d1 create <name>`
+     `unset CLOUDFLARE_API_TOKEN && npx wrangler d1 migrations apply <name> --remote`
+   - **Placeholder D1 ID in wrangler.toml**: replace with real ID from create output,
+     commit and push to main
+4. After fixing, re-trigger deploy or wait for next push
+
+### Claude CLI rate limits
+
+Three distinct failure modes — handle differently:
+
+| Mode | Signal | Action |
+|------|--------|--------|
+| HTTP 429 (rate limit) | Exit code, "rate limit" in stderr | Wait 5 min, retry (max 3) |
+| Daily spend limit | "daily spend limit" in output | Pause gracefully, notify operator |
+| Session budget cap | `stop_reason: "budget_exceeded"` | Bump budget in manifest, retry |
 
 ### If you CANNOT fix it
 


### PR DESCRIPTION
## Summary

- Fix critical grep portability bugs (grep -oP, \d) that broke auto-provisioning on macOS
- Fix silent git checkout failure that caused stale worktrees and merge conflicts
- Add diagnostic playbook to supervisor prompt with structured failure taxonomy
- Add wrangler.test.toml regeneration mandate and D1 migration step
- Add Stripe-required legal pages phase (0070) to Act 4 manifest (#131)
- Update coordinator prompt with observed budget/timing data

All learnings extracted from the until-the-end-of-the-world worktree session protocols
that the running supervisor session (de741791) had not incorporated.

## Test plan

- [ ] `shellcheck scripts/autonomous/*.sh scripts/autonomous/lib/*.sh` passes
- [ ] `grep -rn 'grep -.*P\b' scripts/autonomous/` returns 0 matches
- [ ] `grep -rn '\\d' scripts/autonomous/lib/` returns 0 matches in grep contexts
- [ ] Verify manifest.json is valid: `jq . scripts/autonomous/manifest.json`
- [ ] Verify phase 0070 appears between 0056 and 0057 in manifest
- [ ] Verify 0058 depends on 0070

🤖 Generated with [Claude Code](https://claude.com/claude-code)
