### PR TITLE
R26: Tenant Quotas

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -153,7 +153,7 @@ Deferred items with explicit activation triggers. Revisit when condition is met.
 | [consider] Watch lists / bulk monitoring | Requires scheduling (also parked) | MVP.md |
 | [consider] Change detection / diffing | Requires multiple captures over time; no demand | MVP.md |
 | [consider] Notifications | When event-driven workflows needed | MVP.md |
-| [consider] Billing and quotas | When monetization actively planned | MVP.md |
+| ~~[consider] Billing and quotas~~ | ~~When monetization actively planned~~ -- DONE (Phase 0056): tier-based quotas (free/pro), pre-capture enforcement, usage dashboard, per-tenant D1 overrides (Issue #104) | MVP.md |
 | ~~[consider] Capture ID recovery~~ | ~~Solved by R1; remove after R1 ships~~ -- Resolved: R1 shipped. | ux-strategy-minion, kickoff |
 | [consider] E2E Playwright browser tests for Web UI | When client-side JS complexity grows beyond current 3-view scope | Phase 0049, test-minion |
 | [consider] AbortController for auth validation timeout | When auth UX polish is prioritized; currently low-risk race window | Phase 0049, code-review-minion |
@@ -226,6 +226,7 @@ Completed items removed from active tracking:
 - ~~R25: Usage Metering~~ -- DONE (Phase 0053): D1 usage_counters table, per-tenant capture/storage/API counters via UPSERT, admin usage endpoint, waitUntil deferred writes (Issue #101)
 - ~~R27: Webhooks / outbound callbacks~~ -- DONE (Phase 0054): CRUD API (POST/GET/DELETE + ping), HMAC-SHA256 signing (Stripe model), Cloudflare Queue dispatch with exponential backoff retry, Coralogix delivery logging, 68 tests (Issue #102)
 - ~~R24: Self-serve signup (OAuth)~~ -- DONE (Phase 0055): GitHub OAuth 2.0 with PKCE, auto-tenant provisioning, first-key display, session management, account settings (key CRUD), ToS enforcement, 10 new routes (Issue #103)
+- ~~R26: Tenant Quotas~~ -- DONE (Phase 0056): tier-based quotas (free: 100 captures/month, 1 GB; pro: 5000/month, 50 GB), pre-capture enforcement with 429 quota_exceeded, per-tenant D1 overrides, web UI usage dashboard with progress bars, tier field on tenant record (Issue #104)
 
 ---
 

--- a/docs/evolution/0056-tenant-quotas/decisions.md
+++ b/docs/evolution/0056-tenant-quotas/decisions.md
@@ -1,0 +1,152 @@
+# Decisions: R26 Tenant Quotas
+
+## D1: Tier as column vs JSON field
+
+**Chosen**: `tier TEXT NOT NULL DEFAULT 'free'` as a real column on `tenants` table.
+
+**Rejected**: Storing tier inside the existing `config` JSON blob.
+
+**Rationale**: Tier is a core business attribute that every capture request reads
+and that operators may want to query/filter. A real column enables indexed lookups
+and gets picked up automatically by the existing `INSERT OR IGNORE INTO tenants(id)`
+statements -- auto-provisioned tenants become free tier with zero code changes.
+The config JSON is for optional operator overrides, not core identity.
+
+**Source**: data-minion planning, validated by api-design-minion.
+
+## D2: Default quotas in code, not D1
+
+**Chosen**: `TIER_QUOTAS` constant map in `src/quotas.js`, mirroring
+`RATE_LIMITS` in `src/rate-limits.js`.
+
+**Rejected**: Storing default quotas in a D1 table.
+
+**Rationale**: Quota defaults are product policy, not tenant data. They change
+with code releases and should deploy atomically. The existing rate limit pattern
+proves this works well -- operators override per-tenant via config JSON;
+defaults live in code.
+
+**Source**: data-minion recommendation, consensus across all specialists.
+
+## D3: RFC 9457 Problem Detail with limitType discriminator
+
+**Chosen**: Reuse existing `problemResponse(429)` with `limitType: 'quota'` and
+a nested `quota` object containing `limit`, `used`, `resource`, `resetsAt`.
+
+**Rejected**: (a) Custom error shape matching the issue's `{ error: "quota_exceeded" }`
+format -- would diverge from the established RFC 7807/9457 pattern. (b) Separate
+endpoint returning quota status before capture -- YAGNI, adds latency.
+
+**Rationale**: The codebase already uses RFC 9457 Problem Detail for all error
+responses. Rate limit 429s use `limitType: 'tenant'`. Adding `limitType: 'quota'`
+gives clients a clean discriminator with no breaking changes. The nested quota
+object adds structured context without cluttering the top-level error shape.
+
+**Source**: api-design-minion, validated by software-docs-minion.
+
+## D4: Quota check placement -- after rate limit, before body parse
+
+**Chosen**: Quota check sits after the per-tenant rate limit (Step 3) and before
+URL validation/body parsing (Step 6) in the capture pipeline.
+
+**Rejected**: (a) Before rate limit -- rate limit is cheaper (KV read vs D1 batch),
+so it should short-circuit first. (b) After body parse -- wastes CPU parsing a
+request body that will be rejected. (c) In the queue consumer -- the 202 has
+already been returned; reject at the HTTP handler for fail-fast.
+
+**Rationale**: Rate limit is O(1) KV lookup. Quota check is a D1 batch (two PK
+lookups, sub-2ms). Ordering cheaper checks first minimizes wasted work.
+
+**Source**: api-design-minion and iac-minion alignment.
+
+## D5: No KV caching for quota check
+
+**Chosen**: Direct D1 read on every capture request.
+
+**Rejected**: Caching tier/quota data in KV with short TTL.
+
+**Rationale**: iac-minion confirmed D1 edge-colocated reads are sub-5ms for simple
+PK lookups. The `db.batch()` two-statement pattern stays well within the 10ms
+latency budget. Adding KV caching would introduce staleness, cache invalidation
+complexity, and additional KV reads -- all for marginal latency savings. YAGNI.
+
+**Source**: iac-minion planning.
+
+## D6: Whole-batch rejection
+
+**Chosen**: Batch captures check quota upfront for the full batch size. If
+`captureCount + urls.length > quota`, the entire batch is rejected with 429.
+
+**Rejected**: Partial acceptance -- accept captures up to the remaining quota,
+reject the rest with a 207 Multi-Status response.
+
+**Rationale**: Partial acceptance creates confusing accounting for the tenant.
+They would need to track which URLs from a batch succeeded and which were quota-
+rejected, then decide whether to retry the rejected subset. Whole-batch rejection
+is simpler for clients: either everything goes through or nothing does.
+
+**Source**: api-design-minion, endorsed by ux-strategy-minion.
+
+## D7: Usage dashboard in settings, not new route
+
+**Chosen**: Usage section within the existing `#/settings` view, between Account
+and API Keys cards.
+
+**Rejected**: (a) New `#/usage` route -- adds navigation complexity for a
+single-page feature. (b) Inline usage in the session boot response -- bloats the
+critical auth path.
+
+**Rationale**: Settings is where users go for account management. Usage is account
+info. A dedicated route would be empty space for two progress bars. The data source
+is a dedicated `GET /v1/account/usage` endpoint (not inline in session response)
+to keep the auth boot payload lightweight.
+
+**Source**: frontend-minion and ux-strategy-minion alignment.
+
+## D8: "Starter" display name for free tier
+
+**Chosen**: Internal code uses `free`/`pro`. UI shows `Starter`/`Pro`. Tier name
+never appears in error responses.
+
+**Rejected**: (a) Showing "Free" in the UI -- ux-strategy-minion flagged negative
+connotations ("you're on the cheapest plan"). (b) Exposing tier name in 429
+responses -- security-minion flagged potential information disclosure.
+
+**Rationale**: "Starter" is neutral and forward-looking. Keeping tier names out
+of error responses prevents tenants from inferring tier assignment of other
+tenants through error message differences.
+
+**Source**: Conflict resolution between ux-strategy-minion (naming) and
+security-minion (information disclosure).
+
+## D9: Overruled security-minion on queue consumer check
+
+**Chosen**: Quota enforcement only at the HTTP handler (fail-fast at capture
+submission), not at the queue consumer.
+
+**Rejected**: security-minion recommended a dual-check -- validate quota both at
+HTTP submission and again in the queue consumer before browser launch.
+
+**Rationale**: By the time the queue consumer runs, the 202 response has already
+been returned to the client. Rejecting in the consumer would create a silent
+failure (capture accepted, then quietly dropped). The TOCTOU window is bounded by
+the per-tenant rate limit -- at most a handful of concurrent captures can slip
+through before the counter updates. Slight overages are explicitly acceptable
+per the issue constraints.
+
+**Source**: Overruled security-minion recommendation during synthesis.
+
+## D10: checkQuota reuse in usage endpoint
+
+**Chosen**: `GET /v1/account/usage` calls `checkQuota(db, tenantId, 0)` to get
+quota and usage data, then reshapes the result for the API response.
+
+**Rejected**: Duplicate D1 batch query in the usage endpoint handler.
+
+**Rationale**: Multiple reviewers (Lucy, Margo) flagged that Task 3 would
+duplicate the exact D1 batch query from `checkQuota`. Calling with `count=0`
+effectively becomes a usage-only query. A fallback path handles the edge case
+where the tenant is over limit (checkQuota returns `allowed: false` but the usage
+endpoint still needs to return data, not an error).
+
+**Source**: Lucy and Margo ADVISE during Phase 3.5, incorporated into Task 3.

--- a/docs/evolution/0056-tenant-quotas/outcome.md
+++ b/docs/evolution/0056-tenant-quotas/outcome.md
@@ -1,0 +1,89 @@
+# Outcome: R26 Tenant Quotas
+
+## What was built
+
+Per-tenant usage quotas for WRL. Tenants are assigned tiers (free/pro) with
+default capture and storage limits. The capture pipeline enforces quotas before
+accepting work, and tenants can view their usage in the web UI settings page.
+
+### New files
+
+| File | Purpose |
+|------|---------|
+| `migrations/0005_tenant_tiers.sql` | Adds `tier` column to tenants table |
+| `src/quotas.js` | Quota constants, `checkQuota`, `getEffectiveQuota`, `computeQuotaReset` |
+| `test/quotas.test.js` | 21 unit tests for quota module |
+| `test/quota-enforcement.test.js` | 14 integration tests for pipeline quota check |
+| `test/account-usage.test.js` | 23 tests for usage endpoint |
+| `test/ui-settings-usage.test.js` | 58 UI tests for dashboard, formatBytes, ARIA |
+| `site/content/limits.md` | Consolidated "Limits & Quotas" docs guide (171 lines) |
+
+### Modified files
+
+| File | Change |
+|------|--------|
+| `src/index.js` | Quota check in handleCreateCapture and handleBatchCapture; route for usage endpoint; buildQuotaHeaders helper; quotas catch block |
+| `src/db.js` | Quota override validation in setTenantConfig; setTenantTier function; VALID_TIERS export |
+| `src/account.js` | `handleAccountGetUsage` handler reusing checkQuota |
+| `src/ui/ui-settings.js` | Usage dashboard with progress bars, formatBytes, formatPeriod, refresh button |
+| `src/ui/ui-css.js` | Usage section styles (bars, thresholds, refresh button) |
+| `src/ui/ui-submit.js` | Quota-specific 429 handling with reset date |
+| `openapi.yaml` | QuotaDetail, UsageMetric, AccountUsageResponse schemas; X-Quota-* headers; updated 429 |
+| `test/db.test.js` | 16 new tests for quota validation and setTenantTier |
+| `site/content/batch.md` | Cross-reference to limits guide |
+| `site/_data/site.js` | Nav entry for limits page |
+| `site/content/index.md` | Cross-reference to limits guide |
+
+### Numbers
+
+- 18 files changed, +2410/-20 lines
+- 7 commits on `nefario/tenant-quotas` branch
+- 991 tests pass across 37 test files
+- 132 new tests added (21 + 14 + 23 + 58 + 16)
+
+## What deviated from the plan
+
+1. **formatBytes MB ternary bug** -- Phase 5 code review caught that the MB
+   branch in `formatBytes` had `.toFixed(n % 1000000 === 0 ? 0 : 0)` -- both
+   branches returning 0, which silently discarded fractional precision for MB
+   values. Fixed to `.toFixed(n % 1000000 === 0 ? 0 : 1)` in a separate commit.
+
+2. **Phase 3.5 advisory incorporation** -- Several adjustments from reviewers
+   were woven into task prompts rather than treated as deviations:
+   - security-minion: catch block for quotas validation errors (Task 1)
+   - Lucy/Margo: reuse checkQuota in usage endpoint (Task 3)
+   - Margo: extract computeQuotaReset and buildQuotaHeaders helpers (Tasks 1, 2)
+   - accessibility-minion: ARIA value formatting for storage bars (Task 4)
+   - ux-strategy-minion: manual refresh button (Task 4)
+
+3. **Team composition adjustment** -- Initial meta-plan had 5 specialists.
+   Lucy review added ux-strategy-minion and software-docs-minion (flagged as
+   "ALWAYS include" in cross-cutting checklist). This triggered a Phase 1
+   re-run, not a deviation from the workflow.
+
+## Issues created
+
+None.
+
+## Backlog changes
+
+- **Marked done**: R26 (Tenant Quotas) in Product Features parking lot --
+  `[consider] Billing and quotas` marked done
+- **Deferred**: Per-endpoint differentiated quotas (only captures and storage
+  for now, per issue scope). Already tracked in parking lot as
+  `[consider] Per-endpoint differentiated limits`.
+- **No new parking lot items** -- all scope items were delivered. The "storage
+  cleanup/eviction on quota breach" and "quota alerts/notifications" exclusions
+  were already out-of-scope per the issue definition.
+
+## Surprises
+
+- The D1 `db.batch()` pattern (two PK lookups in one round-trip) was trivially
+  fast -- no evidence that KV caching would ever be needed. The iac-minion's
+  YAGNI recommendation was well-calibrated.
+- Auto-provisioned tenants getting the free tier via `DEFAULT 'free'` on the
+  column meant zero changes to the OAuth signup flow from Phase 0055. The
+  `INSERT OR IGNORE INTO tenants(id)` in the signup handler picks up the default.
+- The accessibility-minion Phase 3.5 review (discretionary reviewer) caught a
+  legitimate WCAG concern: progress bars for storage bytes need
+  `aria-valuenow` in human-readable format (formatBytes), not raw byte counts.

--- a/docs/evolution/0056-tenant-quotas/process.md
+++ b/docs/evolution/0056-tenant-quotas/process.md
@@ -1,0 +1,188 @@
+# Process: R26 Tenant Quotas
+
+## TL;DR
+
+Seven specialists planned a per-tenant quota system, six reviewers vetted the
+architecture, and five execution agents built it in six tasks across two approval
+gates. 132 new tests, 2410 lines added, one code review bug caught and fixed.
+The interesting decisions: overruling security-minion on dual-check enforcement,
+resolving a naming conflict between security and UX ("free" vs "Starter"), and
+the Lucy-triggered team expansion that added two specialists before planning began.
+
+## Team Composition
+
+### The Lucy Intervention
+
+The initial meta-plan proposed five specialists: data-minion, api-design-minion,
+iac-minion, frontend-minion, and security-minion. Lucy (running as autonomous
+gate decision-maker) flagged that two cross-cutting agents were missing:
+
+- **ux-strategy-minion**: Quotas are a user-facing concept touching multiple UI
+  surfaces (settings, submit form, 429 error). Journey coherence analysis needed.
+- **software-docs-minion**: The distinction between rate limits (per-minute,
+  Cloudflare rate limiter) and quotas (per-month, D1 counters) is subtle enough
+  to confuse API consumers. Documentation planning needed upfront.
+
+Both were flagged as "ALWAYS include" in the cross-cutting checklist. This
+triggered a Phase 1 re-run with the expanded team, regenerating all planning
+questions to account for the new specialists' domains. The re-run was substantive,
+not cosmetic -- the ux-strategy-minion's planning question asked about cognitive
+load in the capture submission flow, warning thresholds, and tier naming, none of
+which the original five-agent plan addressed.
+
+### Planning Agents (Phase 2)
+
+All seven specialists ran in parallel:
+
+1. **data-minion** argued for tier as a real column (not JSON), quotas as code
+   constants (not D1), and `db.batch()` for single-roundtrip quota checks. Clean
+   consensus -- no pushback from other agents.
+
+2. **api-design-minion** recommended RFC 9457 Problem Detail with `limitType:
+   'quota'` discriminator, whole-batch rejection, and placement after rate limit
+   but before body parse. The key insight: two types of 429 (rate limit vs quota)
+   need a clean discriminator, and the existing `problemResponse` helper already
+   supports `extra` fields.
+
+3. **iac-minion** confirmed D1 reads are sub-5ms for PK lookups, well within the
+   10ms latency budget. Explicitly recommended against KV caching -- YAGNI. This
+   was the simplest recommendation but arguably the most important: it prevented
+   a caching layer that would have added complexity without demonstrated need.
+
+4. **frontend-minion** recommended usage as a settings section (not new route),
+   a dedicated `GET /v1/account/usage` endpoint (not inline in session), and
+   vanilla CSS progress bars with threshold classes. The routing decision was
+   obvious in hindsight -- two progress bars don't justify their own page.
+
+5. **security-minion** identified the key threat vectors: quota bypass via
+   multiple API keys (ruled out -- quotas are per-tenant, not per-key), overage
+   exploitation via concurrent requests (bounded by rate limit), and information
+   disclosure via tier names in errors. The dual-check recommendation (enforce
+   quota at both HTTP handler and queue consumer) was the most contentious -- it
+   was ultimately overruled.
+
+6. **ux-strategy-minion** made three recommendations that shaped the final product:
+   (a) warning thresholds at 80% and 95% (three-state visual), (b) "Starter" not
+   "Free" for the tier display name (psychological framing), and (c) no quota
+   info on the submit form unless approaching limits (cognitive load reduction).
+
+7. **software-docs-minion** recommended consolidating rate limits and quotas into
+   a single "Limits & Quotas" guide rather than separate docs. This avoided the
+   confusion of two documents covering related-but-different enforcement
+   mechanisms.
+
+### Architecture Reviewers (Phase 3.5)
+
+Six reviewers: five mandatory (security-minion, test-minion, ux-strategy-minion,
+lucy, margo) plus one discretionary (accessibility-minion, for progress bar WCAG).
+All returned ADVISE (zero BLOCKs).
+
+Key advisories that changed the implementation:
+
+- **security-minion**: The existing `handlePutTenantConfig` catch block only
+  matched errors starting with `rateLimit.` or `Invalid tenantId`. New quota
+  validation errors (starting with `quotas.`) would fall through as 500s. Added
+  to the catch condition in Task 1.
+
+- **lucy + margo**: Both independently flagged that the usage endpoint (Task 3)
+  would duplicate the exact D1 batch query from `checkQuota`. Solution: call
+  `checkQuota(db, tenantId, 0)` -- the `count=0` turns it into a usage-only
+  query. A fallback path handles the over-limit edge case.
+
+- **margo**: Extract `computeQuotaReset()` as a named helper (was inline in
+  checkQuota) and `buildQuotaHeaders()` for DRY header construction across single
+  and batch endpoints. Classic margo -- eliminating duplication before it ships.
+
+- **accessibility-minion**: Progress bars for storage bytes need `aria-valuenow`
+  in human-readable format (`formatBytes(n)`) rather than raw byte counts. A
+  screen reader announcing "214748364800 of 53687091200" is not useful.
+
+## Conflict Resolutions
+
+### Tier Naming (security-minion vs ux-strategy-minion)
+
+**Conflict**: security-minion said never expose tier name anywhere user-visible
+(information disclosure risk). ux-strategy-minion said show "Starter" / "Pro" in
+the UI (users need to know their plan level).
+
+**Resolution**: Three-layer naming. Internal code uses `free`/`pro` (the data
+layer). API responses include `tierDisplay: 'Starter'`/`'Pro'` (the presentation
+layer). Error responses never include tier information (the security layer). Both
+agents' concerns are addressed without compromise.
+
+### Queue Consumer Dual-Check (security-minion overruled)
+
+**Conflict**: security-minion recommended enforcing quotas both at the HTTP
+handler (before queueing) and at the queue consumer (before browser launch), to
+prevent TOCTOU exploitation.
+
+**Resolution**: Overruled. By the time the queue consumer runs, the 202 has
+already been sent to the client. Rejecting in the consumer would silently drop
+a capture the client thinks was accepted. The TOCTOU window is bounded by the
+per-tenant rate limit -- at most a handful of concurrent requests can slip
+through. The issue explicitly states "slight overages are acceptable."
+
+This was the right call. The dual-check would have added complexity (the consumer
+would need quota awareness and a failure reporting mechanism) to prevent a
+scenario that is both bounded and acceptable by design.
+
+## Human Interventions
+
+This was a fully autonomous orchestration (no interactive user). Lucy agent made
+all gate decisions:
+
+- **Team gate**: Adjusted from 5 to 7 agents (added ux-strategy-minion and
+  software-docs-minion).
+- **Reviewer gate**: Approved 5 mandatory + 1 discretionary (accessibility-minion).
+- **Execution plan gate**: Approved 6 tasks, 2 gates.
+- **Task 1 gate**: Approved data layer (migration + quotas module).
+- **Task 2 gate**: Approved pipeline integration.
+- **Post-execution**: Selected "Run all" (code review, tests, documentation).
+- **Calibration check**: Selected "Gates are fine."
+- **PR gate**: Selected "Create PR."
+
+No human changes were made to the plan or implementation. The autonomous gate
+protocol worked as designed -- Lucy validated each gate against the issue's
+success criteria and CLAUDE.md conventions.
+
+## Phase 5 Bug Catch
+
+Code review found a real bug in `formatBytes()` in `ui-settings.js`:
+
+```js
+// Bug: both ternary branches return 0
+(n / 1000000).toFixed(n % 1000000 === 0 ? 0 : 0)
+
+// Fix: second branch returns 1 (matching KB and GB patterns)
+(n / 1000000).toFixed(n % 1000000 === 0 ? 0 : 1)
+```
+
+The MB branch silently discarded fractional precision (e.g., `1.5 MB` would
+display as `2 MB`). The same pattern in the KB and GB branches correctly used
+`? 0 : 1`. This was committed as a separate fix before the wrap-up.
+
+## What Went Well
+
+- **db.batch() performance**: The two-statement D1 batch (tenant tier + usage
+  counters) was trivially fast. iac-minion's YAGNI call on KV caching was
+  well-calibrated.
+
+- **Auto-provisioning compatibility**: The `DEFAULT 'free'` on the tier column
+  meant the OAuth signup flow from Phase 0055 needed zero changes. The
+  `INSERT OR IGNORE INTO tenants(id)` picks up the default automatically.
+
+- **Advisory quality**: All six Phase 3.5 reviewers returned substantive ADVISE
+  (not rubber-stamp APPROVEs). The catch block fix, checkQuota reuse, and ARIA
+  formatting were real improvements that would have been bugs or tech debt
+  without the review.
+
+## Where to Read More
+
+- Full specialist discussions: `docs/history/nefario-reports/2026-03-23-030747-tenant-quotas/`
+  - `phase2-*.md` -- seven specialist planning contributions
+  - `phase3-synthesis.md` -- full delegation plan with task prompts
+  - `phase3.5-*.md` -- six architecture review verdicts
+  - `phase5-code-review-minion.md` -- code review findings
+- Nefario report: `docs/history/nefario-reports/2026-03-23-030747-tenant-quotas.md`
+- Design decisions: `docs/evolution/0056-tenant-quotas/decisions.md`
+- PR: https://github.com/benpeter/web-resource-ledger/pull/135

--- a/docs/evolution/0056-tenant-quotas/prompt.md
+++ b/docs/evolution/0056-tenant-quotas/prompt.md
@@ -1,0 +1,24 @@
+## R26: Tenant Quotas
+
+**Source**: GitHub Issue #104
+
+**Outcome**: Tenants are subject to usage quotas (captures/month, storage GB) based on their tier. Quota checks happen before expensive operations (browser launch), and tenants can see their usage in the web UI.
+
+**Success criteria**:
+- Default quotas defined per tier: free (e.g., 100 captures/month, 1 GB storage), pro (e.g., 5000 captures/month, 50 GB)
+- Quota check runs before browser session creation in the capture pipeline
+- Exceeding quota returns 429 with `{ "error": "quota_exceeded", "detail": "monthly capture limit reached", "limit": N, "used": N }`
+- Per-tenant quota overrides stored in D1 (operator can grant custom limits)
+- Web UI usage dashboard shows current period usage vs. quota with a progress bar per metric
+- Usage dashboard updates on page load (not real-time; reads from D1 usage counters)
+- Quota enforcement is best-effort (eventual consistency of usage counters means slight overages are acceptable)
+- Tier assignment is stored per tenant in D1 and defaults to "free" on auto-provisioning
+
+**Scope**:
+- In: Tier-based default quotas, pre-capture quota check, 429 quota_exceeded response, per-tenant D1 overrides, web UI usage dashboard, tier field on tenant record
+- Out: Automatic tier upgrades (manual or via billing), storage cleanup/eviction on quota breach, per-endpoint API call quotas (only captures and storage for now), quota alerts/notifications
+
+**Constraints**:
+- Depends on R25 (usage metering) for counter data and R21 (per-tenant rate limiting) for the rate limit infrastructure
+- Quota check must not add >10ms latency to the capture request (single D1 read, cached if possible)
+- Must handle race conditions gracefully -- two concurrent captures from the same tenant near quota limit may both proceed; slight overages are acceptable

--- a/docs/evolution/README.md
+++ b/docs/evolution/README.md
@@ -63,3 +63,4 @@ software development.
 | [0053-usage-metering](0053-usage-metering/) | Per-tenant usage metering with D1 counters and admin endpoint (Issue #101) |
 | [0054-webhooks-outbound-callbacks](0054-webhooks-outbound-callbacks/) | Outbound webhook notifications for capture lifecycle events (Issue #102) |
 | [0055-self-serve-signup-oauth](0055-self-serve-signup-oauth/) | GitHub OAuth self-serve signup with auto-tenant provisioning, session management, account settings UI (Issue #103) |
+| [0056-tenant-quotas](0056-tenant-quotas/) | Per-tenant usage quotas with tier-based limits, pre-capture enforcement, web UI usage dashboard (Issue #104) |

--- a/docs/history/nefario-reports/2026-03-23-030747-tenant-quotas.md
+++ b/docs/history/nefario-reports/2026-03-23-030747-tenant-quotas.md
@@ -1,0 +1,128 @@
+---
+task: "R26: Tenant Quotas"
+date: 2026-03-23
+source-issue: 104
+mode: execution
+task-count: 6
+gate-count: 2
+agents: data-minion, api-design-minion, frontend-minion, api-spec-minion, software-docs-minion
+reviewers: security-minion, test-minion, ux-strategy-minion, lucy, margo, accessibility-minion
+compaction-events: 0
+---
+
+## Summary
+
+Per-tenant usage quotas for WRL. Tenants are assigned tiers (free/pro) with default capture and storage limits. The capture pipeline checks quotas before accepting work, returning 429 with `limitType: 'quota'` and structured quota context. A web UI usage dashboard in Settings shows captures and storage usage with progress bars. Operators can override quotas per-tenant via admin config API. 7 commits, 991 tests pass across 37 test files. New files: migration, quotas module, 4 test files, docs guide. Modified: index.js (pipeline), account.js (usage endpoint), UI (settings, CSS, submit), OpenAPI spec, docs site.
+
+## Original Prompt
+
+GitHub Issue #104: R26 -- Tenant Quotas
+
+Tenants are subject to usage quotas (captures/month, storage GB) based on their tier. Quota checks happen before expensive operations (browser launch), and tenants can see their usage in the web UI.
+
+Success criteria: Default quotas per tier (free: 100 captures/month, 1 GB; pro: 5000/month, 50 GB), pre-capture quota check, 429 quota_exceeded response, per-tenant D1 overrides, web UI usage dashboard with progress bars, tier field on tenant record defaulting to "free".
+
+## Key Design Decisions
+
+1. **Tier as column, not JSON** -- `tier TEXT NOT NULL DEFAULT 'free'` on the tenants table. Core business attribute needing potential indexed queries. Existing `INSERT OR IGNORE INTO tenants(id)` statements pick up the default automatically, so auto-provisioned tenants get free tier with zero code changes.
+
+2. **Default quotas in code, not D1** -- `TIER_QUOTAS` constant map in `src/quotas.js`, mirroring `RATE_LIMITS` in `src/rate-limits.js`. Changes deploy atomically with the code. Per-tenant overrides in config JSON (`config.quotas`) follow the existing `config.rateLimit` pattern.
+
+3. **RFC 9457 with limitType discriminator** -- Reuse existing `problemResponse(429)` with `limitType: 'quota'` to distinguish from rate limit 429s (`limitType: 'tenant'`). Nested `quota` object contains `limit`, `used`, `resource`, `resetsAt`. Backward-compatible with existing error handling.
+
+4. **Quota check after rate limit, before body parse** -- Rate limit is cheaper (KV read). Quota check uses `db.batch()` with two PK lookups in a single D1 round-trip (sub-2ms). No KV caching needed — YAGNI.
+
+5. **Whole-batch rejection** -- Batch captures check quota upfront for the full batch size. If insufficient, entire batch is rejected. Partial acceptance would create confusing accounting.
+
+6. **Usage as settings section, not new route** -- Reuses existing card pattern in settings view. Dedicated `GET /v1/account/usage` endpoint (not inline in session response) keeps the boot payload lightweight.
+
+7. **"Starter" display name for free tier** -- Internal code uses `free`/`pro`. API responses expose `tierDisplay: 'Starter'`/`'Pro'`. Tier name never exposed in error responses (security advisory).
+
+## Phases
+
+### Phase 1-2: Planning (7 specialists)
+Consulted data-minion (schema design), api-design-minion (pipeline placement, 429 format, batch semantics), iac-minion (latency budget, D1 vs KV caching), frontend-minion (UI architecture, routing, data source), security-minion (bypass vectors, overage exploitation), ux-strategy-minion (journey coherence, warning thresholds, tier naming), software-docs-minion (OpenAPI strategy, rate limit vs quota docs).
+
+Team adjusted from 5 to 7 after Lucy review: added ux-strategy-minion and software-docs-minion (both flagged "ALWAYS include" in cross-cutting checklist).
+
+### Phase 3: Synthesis
+6 tasks, 2 gates. Key conflicts resolved: (1) Tier naming — internal `free`/`pro`, display `Starter`/`Pro`, never in errors. (2) No queue consumer check — overruled security-minion; fail-fast at HTTP handler, TOCTOU overage bounded by rate limit.
+
+### Phase 3.5: Architecture Review (6 reviewers)
+5 mandatory + 1 discretionary (accessibility-minion for progress bar WCAG). Zero BLOCKs, 6 ADVISE. Key advisories incorporated: catch block for quotas validation errors, reuse checkQuota in usage endpoint, extract computeQuotaReset helper, ARIA value formatting, manual refresh button.
+
+### Phase 4: Execution (6 tasks, 2 gates)
+
+**Task 1: D1 migration + quotas module** [data-minion, GATED]
+Migration adds `tier` column. `src/quotas.js` exports `TIER_QUOTAS`, `checkQuota` (db.batch for single round-trip), `getEffectiveQuota`, `computeQuotaReset`. Config validation for quota overrides in `setTenantConfig`. 21+16 = 37 new tests.
+
+**Task 2: Quota check in capture pipeline** [api-design-minion, GATED]
+`checkQuota` wired into `handleCreateCapture` and `handleBatchCapture` after rate limit, before body parse. `buildQuotaHeaders` helper for X-Quota-* headers. Legacy auth skipped (consistent with rate limit). 14 new integration tests.
+
+**Task 3: GET /v1/account/usage endpoint** [api-design-minion]
+Session-gated endpoint reusing `checkQuota(db, tenantId, 0)` with fallback for over-limit edge cases. Returns `tierDisplay`, captures/storage metrics with remaining, `resetsAt`. 23 new tests.
+
+**Task 4: Web UI usage dashboard** [frontend-minion]
+Usage card in settings with progress bars, three-state thresholds (normal at <80%, warning at 80-94%, critical at 95-100%). `formatBytes` (SI units), `formatPeriod`, manual refresh button. Quota-specific 429 handling in submit form. 58 new tests.
+
+**Task 5: OpenAPI spec updates** [api-spec-minion]
+Added `QuotaDetail`, `UsageMetric`, `AccountUsageResponse` schemas. X-Quota-* header components. Updated 429 with quota example. New `GET /v1/account/usage` path. 86 net new lines.
+
+**Task 6: Docs site content** [software-docs-minion]
+Created `site/content/limits.md` (171 lines) — consolidated rate limits + quotas guide. Updated batch.md, nav, and index with cross-references.
+
+## Verification
+
+Verification: code review passed (1 finding auto-fixed: formatBytes MB ternary), all 991 tests pass across 37 files.
+
+Code review findings:
+- [FIXED] formatBytes MB ternary had identical branches (0 vs 0) — corrected to (0 vs 1)
+- [ADVISE] JSON.parse without try-catch in quotas.js — defense-in-depth gap, acceptable given setTenantConfig validates
+- [NIT] Usage endpoint fallback duplicates query from checkQuota
+- [NIT] Hardcoded key limit in UI
+- [NIT] No index on tier column (acceptable at current scale)
+
+## Agent Contributions
+
+### Planning Agents
+
+| Agent | Role | Key Recommendation |
+|-------|------|--------------------|
+| data-minion | Schema design | Tier as column, quotas in code, overrides in config JSON, db.batch for check |
+| api-design-minion | API contract | RFC 9457 + limitType discriminator, after rate limit, batch full-rejection |
+| iac-minion | Infrastructure | Single D1 read sufficient, no KV cache, piggyback on existing flow |
+| frontend-minion | UI architecture | Settings section (not new route), dedicated usage endpoint, vanilla CSS bars |
+| security-minion | Threat model | Per-tenant quotas sound, dual-check recommended (overruled), validate overrides |
+| ux-strategy-minion | User journey | Warning at 80%, no quota on submit form, "Starter" not "Free", current period only |
+| software-docs-minion | Documentation | Extend ProblemDetail schema, consolidate rate limit/quota docs |
+
+### Architecture Reviewers
+
+| Reviewer | Verdict | Key Finding |
+|----------|---------|-------------|
+| security-minion | ADVISE | Catch block fix for quotas validation; setTenantTier unreachable |
+| test-minion | ADVISE | Date-brittle resetsAt; test both null and zero usage paths |
+| ux-strategy-minion | ADVISE | 429 dead-end needs action hint; binary/SI unit mismatch |
+| lucy | ADVISE | Wrong file path; reuse checkQuota in Task 3; CSS token verification |
+| margo | ADVISE | Extract computeQuotaReset and buildQuotaHeaders helpers |
+| accessibility-minion | ADVISE | ARIA value units for storage; formatBytes in aria-label |
+
+## Session Resources
+
+<details>
+<summary>Skills Invoked</summary>
+
+- `/nefario` — orchestration workflow
+
+</details>
+
+<details>
+<summary>Working Files</summary>
+
+Companion directory: `docs/history/nefario-reports/2026-03-23-030747-tenant-quotas/`
+
+Files: phase1-metaplan.md, phase1-metaplan-rerun.md, phase2-*.md (7 specialists), phase3-synthesis.md, phase3.5-*.md (6 reviewers), phase5-code-review-minion.md, prompt.md
+
+</details>
+
+Compaction events: 0

--- a/docs/history/nefario-reports/2026-03-23-030747-tenant-quotas/phase1-metaplan-prompt.md
+++ b/docs/history/nefario-reports/2026-03-23-030747-tenant-quotas/phase1-metaplan-prompt.md
@@ -1,0 +1,48 @@
+MODE: META-PLAN
+
+You are creating a meta-plan -- a plan for who should help plan.
+
+## Task
+
+<github-issue>
+**Outcome**: Tenants are subject to usage quotas (captures/month, storage GB) based on their tier. Quota checks happen before expensive operations (browser launch), and tenants can see their usage in the web UI.
+
+**Success criteria**:
+- Default quotas defined per tier: free (e.g., 100 captures/month, 1 GB storage), pro (e.g., 5000 captures/month, 50 GB)
+- Quota check runs before browser session creation in the capture pipeline
+- Exceeding quota returns 429 with `{ "error": "quota_exceeded", "detail": "monthly capture limit reached", "limit": N, "used": N }`
+- Per-tenant quota overrides stored in D1 (operator can grant custom limits)
+- Web UI usage dashboard shows current period usage vs. quota with a progress bar per metric
+- Usage dashboard updates on page load (not real-time; reads from D1 usage counters)
+- Quota enforcement is best-effort (eventual consistency of usage counters means slight overages are acceptable)
+- Tier assignment is stored per tenant in D1 and defaults to "free" on auto-provisioning
+
+**Scope**:
+- In: Tier-based default quotas, pre-capture quota check, 429 quota_exceeded response, per-tenant D1 overrides, web UI usage dashboard, tier field on tenant record
+- Out: Automatic tier upgrades (manual or via billing), storage cleanup/eviction on quota breach, per-endpoint API call quotas (only captures and storage for now), quota alerts/notifications
+
+**Constraints**:
+- Depends on R25 (usage metering) for counter data and R21 (per-tenant rate limiting) for the rate limit infrastructure
+- Quota check must not add >10ms latency to the capture request (single D1 read, cached if possible)
+- Must handle race conditions gracefully -- two concurrent captures from the same tenant near quota limit may both proceed; slight overages are acceptable
+</github-issue>
+
+## Working Directory
+/Users/ben/github/benpeter/web-resource-ledger/.claude/worktrees/validated-wondering-avalanche
+
+## External Skill Discovery
+Before analyzing the task, scan for project-local skills. If skills are discovered, include an "External Skill Integration" section in your meta-plan.
+
+## Instructions
+1. Read relevant files to understand the codebase context
+2. Discover external skills:
+   a. Scan .claude/skills/ and .skills/ in the working directory for SKILL.md files
+   b. Read frontmatter (name, description) for each discovered skill
+   c. For skills whose description matches the task domain, classify as ORCHESTRATION or LEAF
+   d. Check the project's CLAUDE.md for explicit skill preferences
+   e. Include discovered skills in your meta-plan output
+3. Analyze the task against your delegation table
+4. Identify which specialists should be CONSULTED FOR PLANNING (not execution -- planning). These are agents whose domain expertise is needed to create a good plan.
+5. For each specialist, write a specific planning question that draws on their unique expertise.
+6. Return the meta-plan in the structured format.
+7. Write your complete meta-plan to /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-b9rn1q/tenant-quotas/phase1-metaplan.md

--- a/docs/history/nefario-reports/2026-03-23-030747-tenant-quotas/phase1-metaplan-rerun-prompt.md
+++ b/docs/history/nefario-reports/2026-03-23-030747-tenant-quotas/phase1-metaplan-rerun-prompt.md
@@ -1,0 +1,54 @@
+MODE: META-PLAN
+
+You are creating a revised meta-plan after a team adjustment.
+
+## Task
+
+<github-issue>
+**Outcome**: Tenants are subject to usage quotas (captures/month, storage GB) based on their tier. Quota checks happen before expensive operations (browser launch), and tenants can see their usage in the web UI.
+
+**Success criteria**:
+- Default quotas defined per tier: free (e.g., 100 captures/month, 1 GB storage), pro (e.g., 5000 captures/month, 50 GB)
+- Quota check runs before browser session creation in the capture pipeline
+- Exceeding quota returns 429 with `{ "error": "quota_exceeded", "detail": "monthly capture limit reached", "limit": N, "used": N }`
+- Per-tenant quota overrides stored in D1 (operator can grant custom limits)
+- Web UI usage dashboard shows current period usage vs. quota with a progress bar per metric
+- Usage dashboard updates on page load (not real-time; reads from D1 usage counters)
+- Quota enforcement is best-effort (eventual consistency of usage counters means slight overages are acceptable)
+- Tier assignment is stored per tenant in D1 and defaults to "free" on auto-provisioning
+
+**Scope**:
+- In: Tier-based default quotas, pre-capture quota check, 429 quota_exceeded response, per-tenant D1 overrides, web UI usage dashboard, tier field on tenant record
+- Out: Automatic tier upgrades (manual or via billing), storage cleanup/eviction on quota breach, per-endpoint API call quotas (only captures and storage for now), quota alerts/notifications
+
+**Constraints**:
+- Depends on R25 (usage metering) for counter data and R21 (per-tenant rate limiting) for the rate limit infrastructure
+- Quota check must not add >10ms latency to the capture request (single D1 read, cached if possible)
+- Must handle race conditions gracefully -- two concurrent captures from the same tenant near quota limit may both proceed; slight overages are acceptable
+</github-issue>
+
+## Original Meta-Plan
+Read the original meta-plan from: /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-b9rn1q/tenant-quotas/phase1-metaplan.md
+
+The original meta-plan was produced for the original team. Use it as context for the revised plan, not as a template to minimally edit.
+
+## Team Adjustment
+Added: ux-strategy-minion, software-docs-minion. Removed: none.
+
+Revised team: data-minion, api-design-minion, iac-minion, frontend-minion, security-minion, ux-strategy-minion, software-docs-minion
+
+## Constraints
+- Keep the same scope and task description
+- Preserve external skill integration decisions unless the team change removes all agents relevant to a skill's domain
+- Generate planning consultations for ALL agents in the revised team
+- Re-evaluate the cross-cutting checklist against the new team
+- Produce output at the same depth and format as the original
+- Do NOT change the fundamental scope of the task
+- Do NOT add agents the user did not request (beyond cross-cutting requirements)
+- Design planning questions as a coherent set -- each question should address aspects that no other agent on the team covers, and questions should reference cross-cutting boundaries where relevant
+
+## Working Directory
+/Users/ben/github/benpeter/web-resource-ledger/.claude/worktrees/validated-wondering-avalanche
+
+## Instructions
+Write your complete revised meta-plan to /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-b9rn1q/tenant-quotas/phase1-metaplan-rerun.md

--- a/docs/history/nefario-reports/2026-03-23-030747-tenant-quotas/phase1-metaplan-rerun.md
+++ b/docs/history/nefario-reports/2026-03-23-030747-tenant-quotas/phase1-metaplan-rerun.md
@@ -1,0 +1,131 @@
+# Meta-Plan: Tenant Quotas (R26)
+
+## Planning Consultations
+
+### Consultation 1: Data Model for Tiers and Quota Overrides
+
+- **Agent**: data-minion
+- **Planning question**: The `tenants` table currently has an `id`, `config` (JSON), `created_at`, `updated_at`, and `updated_by`. The `usage_counters` table already tracks `capture_count` and `storage_bytes` per tenant per period. How should tier assignment and per-tenant quota overrides be modeled? Specifically: (a) Should `tier` be a new column on the `tenants` table or a field inside the existing `config` JSON? (b) Should default quota limits per tier live in code (a constant map) or in D1? (c) How should per-tenant quota overrides be stored -- as fields in the existing `config` JSON column, or as a separate table? (d) The quota check must read current usage + tier limits in a single D1 call to stay under 10ms -- what query pattern achieves this (JOIN usage_counters with tenant tier in one statement, or batch two statements)?
+- **Context to provide**: `migrations/0001_initial_schema.sql` (tenants table), `migrations/0002_usage_counters.sql` (usage_counters table), `src/db.js` (existing `getTenantConfig`, `setTenantConfig`, `getUsage`, `incrementUsage`), the constraint that D1 is edge SQLite with batch support
+- **Why this agent**: Database schema design is foundational -- the tier/quota data model determines the shape of every other task. Getting this wrong means rework across the migration, DAL, API, and UI.
+
+### Consultation 2: Quota Check Placement and API Contract
+
+- **Agent**: api-design-minion
+- **Planning question**: The capture pipeline currently has auth (step 2), rate limit (step 3), URL validation (step 6), and then D1 write + queue enqueue (steps 8-10). Where exactly should the quota check be inserted, and what should the 429 response look like? The issue specifies `{ "error": "quota_exceeded", "detail": "monthly capture limit reached", "limit": N, "used": N }` but the existing error format uses RFC 7807 problem responses (`{ "status": 429, "title": "...", "detail": "..." }`) via the `problemResponse` helper in `src/responses.js`, which supports an `extra` object for additional fields. Should we extend the problem response with `limit` and `used` as extra fields, or use a separate response shape for quota errors? Also: should the batch capture endpoint (`POST /v1/captures/batch`) check quotas upfront for the whole batch, or per-item? Consider that the API spec changes (OpenAPI updates) should reflect whichever response shape is chosen -- the api-design-minion's recommendation here feeds directly into the software-docs-minion's documentation planning.
+- **Context to provide**: `src/index.js` (handleCreateCapture steps 1-10, handleBatchCapture), `src/responses.js` (problemResponse helper with `extra` param), existing rate limit 429 pattern, `openapi.yaml`
+- **Why this agent**: API contract decisions (response shape, header conventions, batch semantics) affect every API consumer. The tension between RFC 7807 and the issue's requested format needs resolution before implementation.
+
+### Consultation 3: Quota Enforcement Strategy and Latency Budget
+
+- **Agent**: iac-minion
+- **Planning question**: The quota check has a 10ms latency budget. Options include: (a) single D1 read per request (read usage_counters + tenant tier, compare in application code), (b) cached tier/quota data in KV with short TTL (avoids D1 read on every request but introduces staleness), (c) Cloudflare rate limiter binding with dynamic limits (but limits can't be changed per-request). Given that D1 is edge-colocated SQLite with sub-5ms read latency for simple queries, is option (a) sufficient? Or should we plan for caching in KV? Also: the existing per-tenant rate limit already does a KV read (`getTenantConfig`) for rate limit overrides -- can we piggyback the quota check on that same config read to avoid an additional round-trip?
+- **Context to provide**: `wrangler.toml` (D1 binding, KV binding, rate limiter bindings), `src/rate-limits.js` (getEffectiveLimit with tenantConfig), `src/kv.js` (rateLimitCounter), `src/index.js` (checkCaptureRateLimit flow), the 10ms latency constraint
+- **Why this agent**: Infrastructure-level decisions about caching strategy and D1 read patterns affect the latency budget and determine whether the implementation is a simple D1 read or requires a caching layer.
+
+### Consultation 4: Web UI Usage Dashboard Design
+
+- **Agent**: frontend-minion
+- **Planning question**: The existing web UI is vanilla JS with no framework (inline in ui-shell.js as string constants). It has hash-based routing with views: `#/captures`, `#/captures/:id`, and `#/settings`. The usage dashboard needs to show current period usage vs. quota with progress bars for captures and storage. Design questions: (a) Should usage be a new view (`#/usage`) or a section within the existing settings view? (b) The data source is the existing `GET /v1/admin/usage` endpoint -- but this is admin-only. Should we add a session-gated `GET /v1/account/usage` endpoint, or should the session endpoint `/auth/session` return usage data inline? (c) What's the minimal viable progress bar implementation in vanilla CSS (no framework)? Note: the ux-strategy-minion will separately advise on journey design (when/where to surface quota info), so focus your recommendation on the technical implementation within the existing vanilla JS architecture.
+- **Context to provide**: `src/ui/ui-shell.js` (hash router, view structure), `src/ui/ui-settings.js` (existing settings view with account info and key management), `src/ui/ui-css.js` (existing CSS), `src/design-system.css` (design tokens), `src/oauth.js` (handleAuthSession response shape)
+- **Why this agent**: The UI implementation must fit within the existing vanilla JS architecture and maintain consistent UX patterns. The routing decision (new view vs. settings section) and data source question affect both backend and frontend work.
+
+### Consultation 5: Security Review of Quota Bypass Vectors
+
+- **Agent**: security-minion
+- **Planning question**: The quota system introduces new attack surfaces: (a) Can a tenant bypass quotas by creating multiple API keys? (The answer should be no -- quotas are per-tenant, not per-key -- but confirm the data model supports this.) (b) The issue says "slight overages are acceptable" due to eventual consistency. What's the maximum realistic overage given that captures are queued (one concurrent consumer per tenant due to rate limiting, but up to 10 concurrent globally)? Is there a risk of intentional overage exploitation? (c) The per-tenant quota override in D1 means an admin can grant custom limits. Should this require the admin key, or should it be protected differently? (d) Should the usage dashboard expose absolute numbers (capture count, storage bytes) or only relative (percentage of quota)? (e) What are the security implications of surfacing tier information in user-facing endpoints -- could a tenant infer other tenants' tier assignments or usage patterns?
+- **Context to provide**: `src/auth.js` (verifyApiKey binds to tenantId), `src/index.js` (queue consumer with tenantId from message), `src/db.js` (incrementUsage with UPSERT), `wrangler.toml` (max_concurrency = 10 for capture queue)
+- **Why this agent**: Quota systems are authorization mechanisms. Bypass vectors, overage exploitation, and information disclosure in the usage dashboard are security concerns that should shape the design.
+
+### Consultation 6: User Journey and Quota Awareness Strategy
+
+- **Agent**: ux-strategy-minion
+- **Planning question**: The usage dashboard will show captures/month and storage used vs. quota limits. From a user journey perspective: (a) When should users encounter quota information -- only on a dedicated page/section, or proactively surfaced as contextual warnings when approaching limits (e.g., banner on the captures list, inline warning on the submit form)? (b) What cognitive load does quota awareness add to the capture submission flow -- should the submit form show remaining quota, or does that add unnecessary friction for users well under their limits? (c) Should the 429 quota_exceeded API response include a human-readable hint about next steps (even though auto-upgrade is out of scope)? (d) For the progress bar, what thresholds should trigger visual warning states (yellow at 80%? red at 95%?)? (e) Should the dashboard show historical usage (past months) or only current period? (f) How should the system communicate tier identity to users -- is "free" a useful label or does it carry negative connotations (consider alternatives like "starter")? Note: the frontend-minion will handle technical implementation; your focus is on WHAT quota information to surface and WHERE in the user journey.
+- **Context to provide**: Existing UI views (captures list, capture detail, submit form, settings), the session response shape from `/auth/session`, the quota error response shape (TBD from api-design-minion)
+- **Why this agent**: Every plan needs journey coherence review and cognitive load assessment. Quota information is a cross-cutting UX concern -- it touches the submit flow, the captures list, the settings page, and API error responses. Deciding where to surface it (and where NOT to) requires user journey analysis, not just UI implementation.
+
+### Consultation 7: Documentation Impact Assessment
+
+- **Agent**: software-docs-minion
+- **Planning question**: This feature introduces several documentation surfaces. Assess and recommend: (a) The OpenAPI spec (`openapi.yaml`) needs updates for the 429 quota_exceeded response on `POST /v1/captures` and `POST /v1/captures/batch`, any new `GET /v1/account/usage` endpoint, and tier/quota fields on tenant config admin endpoints -- should these be documented as inline response schemas or referenced components? (b) The existing docs site may have an "API Rate Limits" guide -- should it be updated to distinguish rate limits (per-minute, via Cloudflare rate limiter) from quotas (per-month, via D1 usage counters), or does this warrant a separate "Usage Quotas" guide? (c) Should the architecture documentation capture the quota check flow as a distinct pipeline stage (it sits between rate limiting and capture execution)? (d) Are there documentation implications for the tenant admin API (`PUT /v1/admin/tenants/:id/config`) when it gains quota override fields?
+- **Context to provide**: `openapi.yaml` (current API spec), existing API documentation structure, `src/responses.js` (problemResponse format with extra fields), the current tenant config admin endpoints
+- **Why this agent**: API documentation is a critical contract with consumers. The distinction between rate limits and quotas is subtle enough to cause confusion if not documented clearly. The OpenAPI spec updates need to align with whichever response format the api-design-minion recommends.
+
+---
+
+### Cross-Cutting Checklist
+
+- **Testing**: Include test-minion for planning? **No** -- test strategy for this feature is straightforward (unit tests for quota check logic, integration tests for the 429 response, UI tests for dashboard rendering). The patterns are well-established from R25 usage metering (20 unit + 16 integration tests). Test-minion will participate in Phase 3.5 architecture review and Phase 6 test execution.
+- **Security**: Include security-minion for planning? **Yes** -- included as Consultation 5 above. Quota bypass vectors and overage exploitation need pre-implementation analysis.
+- **Usability -- Strategy**: ALWAYS include. **Yes** -- included as Consultation 6 above. Quota information touches multiple points in the user journey (submit, captures list, settings, API errors). Journey coherence and cognitive load assessment are needed before implementation.
+- **Usability -- Design**: Include ux-design-minion / accessibility-minion? **No** -- the progress bar is a simple visual element within an established design system. No new interaction patterns are introduced. The accessibility-minion review in Phase 3.5 will cover WCAG for the progress bar (color contrast, ARIA attributes for progress indicators, screen reader announcement of quota status).
+- **Documentation**: ALWAYS include. **Yes** -- included as Consultation 7 above. OpenAPI spec updates, rate limit vs. quota documentation distinction, and architecture documentation of the quota check flow all need pre-implementation assessment.
+- **Observability**: Include observability-minion / sitespeed-minion? **No** -- the quota check will use the existing structured logging infrastructure (log events like `quota.exceeded`, `quota.check` via the existing `log()` helper in `src/log.js`). No new observability patterns are needed. The existing Coralogix alerting pipeline can be extended later if quota events need alerting. sitespeed-minion is not relevant -- the dashboard is a simple page load with a single API call, not a performance-critical rendering concern.
+
+---
+
+### Notable Exclusions
+
+- **oauth-minion**: The OAuth/session infrastructure is already built and tested. The usage dashboard will reuse existing session auth (`verifySession` in `src/session.js`). No new auth flows are needed -- just a new session-gated endpoint that follows the same pattern as existing `/v1/account/*` routes.
+- **mcp-minion**: The MCP server tools (capture_url, list_captures, etc.) will naturally return 429 quota errors without any MCP-specific changes. The error propagation is transparent -- the MCP handler calls the same pipeline that produces the 429.
+- **edge-minion**: No CDN, caching, or edge worker changes. D1 reads are edge-colocated by default. KV caching (if needed) is an infrastructure concern being evaluated by iac-minion in Consultation 3, not an edge delivery concern.
+
+---
+
+### Anticipated Approval Gates
+
+1. **Data model and migration** (MUST gate): The D1 schema for tier assignment and quota overrides is hard to reverse once migrated to production. This determines the shape of the quota check query, the admin API, the session response, and the UI data source. High blast radius (blocks all downstream tasks).
+
+2. **API contract for quota error response** (MUST gate): Whether to extend RFC 7807 problem responses with `limit`/`used` extra fields or use the issue's custom shape affects all API consumers and the OpenAPI spec. The batch endpoint behavior (upfront vs. per-item quota check) is also a contract decision. Hard to change after consumers adopt it.
+
+---
+
+### Rationale
+
+This feature has seven distinct planning perspectives needed:
+
+1. **Data modeling** (data-minion) -- the tier/quota schema is the foundation. The tenants table needs a tier field, and the quota check needs an efficient query pattern against usage_counters. This is the highest-risk decision because schema changes are hard to reverse.
+
+2. **API design** (api-design-minion) -- the 429 response shape and batch behavior are API contracts. The tension between RFC 7807 and the issue's requested format needs explicit resolution. The response format feeds directly into both the frontend implementation and the documentation.
+
+3. **Infrastructure** (iac-minion) -- the 10ms latency constraint requires understanding D1 read performance and whether caching is needed. This intersects with the existing rate limit infrastructure.
+
+4. **Frontend** (frontend-minion) -- the usage dashboard is a new UI surface within an established vanilla JS architecture. Routing and data source decisions need to align with backend design.
+
+5. **Security** (security-minion) -- quota systems are authorization mechanisms with bypass risks. Pre-implementation security analysis prevents architectural vulnerabilities.
+
+6. **User journey** (ux-strategy-minion) -- quota information is a cross-cutting UX concern that touches multiple views and flows. Deciding where to surface quota awareness (and where NOT to) shapes both the frontend and API work. Without journey analysis, the implementation risks either under-informing users (they hit 429 with no warning) or over-informing them (quota noise on every interaction).
+
+7. **Documentation** (software-docs-minion) -- the API contract changes need OpenAPI spec updates, and the distinction between rate limits and quotas is subtle enough to cause consumer confusion. Early documentation planning ensures the spec and guides align with the chosen response format.
+
+The cross-cutting agents for usability strategy and documentation have been promoted from checklist items to full planning consultations because this feature introduces a new user-facing concept (tiers and quotas) that requires coherent presentation across the API, UI, and documentation surfaces.
+
+---
+
+### Scope
+
+**What this task achieves**: Adds tier-based usage quotas to WRL. Tenants are assigned tiers (free/pro) with default capture and storage limits. The capture pipeline checks quotas before accepting work. A web UI dashboard shows usage vs. limits. Operators can override quotas per-tenant via admin API.
+
+**In scope**:
+- `tier` field on tenant records (defaults to "free" on auto-provisioning)
+- Default quota map per tier (free: 100 captures/month, 1 GB storage; pro: 5000 captures/month, 50 GB)
+- Pre-capture quota check in the HTTP handler (before queue enqueue)
+- 429 `quota_exceeded` response with usage details
+- Per-tenant quota overrides in D1 (admin-configurable)
+- Web UI usage dashboard with progress bars (reads from D1 on page load)
+- D1 migration for tier field and any new schema
+- OpenAPI spec updates
+- Unit and integration tests
+
+**Out of scope**:
+- Automatic tier upgrades or billing integration
+- Storage cleanup/eviction on quota breach
+- Per-endpoint API call quotas (only captures and storage)
+- Quota alerts or notifications
+- Real-time usage updates (dashboard reads on page load only)
+
+---
+
+### External Skill Integration
+
+No external skills detected in project. No `.claude/skills/` or `.skills/` directories found in the working directory.

--- a/docs/history/nefario-reports/2026-03-23-030747-tenant-quotas/phase1-metaplan.md
+++ b/docs/history/nefario-reports/2026-03-23-030747-tenant-quotas/phase1-metaplan.md
@@ -1,0 +1,113 @@
+# Meta-Plan: Tenant Quotas (R26)
+
+## Planning Consultations
+
+### Consultation 1: Data Model for Tiers and Quota Overrides
+
+- **Agent**: data-minion
+- **Planning question**: The `tenants` table currently has an `id`, `config` (JSON), `created_at`, `updated_at`, and `updated_by`. The `usage_counters` table already tracks `capture_count` and `storage_bytes` per tenant per period. How should tier assignment and per-tenant quota overrides be modeled? Specifically: (a) Should `tier` be a new column on the `tenants` table or a field inside the existing `config` JSON? (b) Should default quota limits per tier live in code (a constant map) or in D1? (c) How should per-tenant quota overrides be stored -- as fields in the existing `config` JSON column, or as a separate table? (d) The quota check must read current usage + tier limits in a single D1 call to stay under 10ms -- what query pattern achieves this (JOIN usage_counters with tenant tier in one statement, or batch two statements)?
+- **Context to provide**: `migrations/0001_initial_schema.sql` (tenants table), `migrations/0002_usage_counters.sql` (usage_counters table), `src/db.js` (existing `getTenantConfig`, `setTenantConfig`, `getUsage`, `incrementUsage`), the constraint that D1 is edge SQLite with batch support
+- **Why this agent**: Database schema design is foundational -- the tier/quota data model determines the shape of every other task. Getting this wrong means rework across the migration, DAL, API, and UI.
+
+### Consultation 2: Quota Check Placement and API Contract
+
+- **Agent**: api-design-minion
+- **Planning question**: The capture pipeline currently has auth (step 2), rate limit (step 3), URL validation (step 6), and then D1 write + queue enqueue (steps 8-10). Where exactly should the quota check be inserted, and what should the 429 response look like? The issue specifies `{ "error": "quota_exceeded", "detail": "monthly capture limit reached", "limit": N, "used": N }` but the existing error format uses RFC 7807 problem responses (`{ "status": 429, "title": "...", "detail": "..." }`). Should we extend the problem response format with `limit` and `used` fields, or use a separate response shape for quota errors? Also: should the batch capture endpoint (`POST /v1/captures/batch`) check quotas upfront for the whole batch, or per-item?
+- **Context to provide**: `src/index.js` (handleCreateCapture steps 1-10, handleBatchCapture), `src/responses.js` (problemResponse helper), existing rate limit 429 pattern, `openapi.yaml`
+- **Why this agent**: API contract decisions (response shape, header conventions, batch semantics) affect every API consumer. The tension between RFC 7807 and the issue's requested format needs resolution before implementation.
+
+### Consultation 3: Quota Enforcement Strategy and Latency Budget
+
+- **Agent**: iac-minion
+- **Planning question**: The quota check has a 10ms latency budget. Options include: (a) single D1 read per request (read usage_counters + tenant tier, compare in application code), (b) cached tier/quota data in KV with short TTL (avoids D1 read on every request but introduces staleness), (c) Cloudflare rate limiter binding with dynamic limits (but limits can't be changed per-request). Given that D1 is edge-colocated SQLite with sub-5ms read latency for simple queries, is option (a) sufficient? Or should we plan for caching in KV? Also: the existing per-tenant rate limit already does a KV read (`getTenantConfig`) for rate limit overrides -- can we piggyback the quota check on that same config read to avoid an additional round-trip?
+- **Context to provide**: `wrangler.toml` (D1 binding, KV binding, rate limiter bindings), `src/rate-limits.js` (getEffectiveLimit with tenantConfig), `src/kv.js` (rateLimitCounter), `src/index.js` (checkCaptureRateLimit flow), the 10ms latency constraint
+- **Why this agent**: Infrastructure-level decisions about caching strategy and D1 read patterns affect the latency budget and determine whether the implementation is a simple D1 read or requires a caching layer.
+
+### Consultation 4: Web UI Usage Dashboard Design
+
+- **Agent**: frontend-minion
+- **Planning question**: The existing web UI is vanilla JS with no framework (inline in ui-shell.js as string constants). It has three views: captures list, capture detail, and settings. The usage dashboard needs to show current period usage vs. quota with progress bars for captures and storage. Design questions: (a) Should usage be a new view (#/usage) or a section within the existing settings view? (b) The data source is the existing `GET /v1/admin/usage` endpoint -- but this is admin-only. Should we add a session-gated `GET /v1/account/usage` endpoint, or should the session endpoint `/auth/session` return usage data inline? (c) What's the minimal viable progress bar implementation in vanilla CSS (no framework)?
+- **Context to provide**: `src/ui/ui-shell.js` (hash router, view structure), `src/ui/ui-settings.js` (existing settings view with account info and key management), `src/ui/ui-css.js` (existing CSS), `src/design-system.css` (design tokens), `src/oauth.js` (handleAuthSession response shape)
+- **Why this agent**: The UI implementation must fit within the existing vanilla JS architecture and maintain consistent UX patterns. The routing decision (new view vs. settings section) and data source question affect both backend and frontend work.
+
+### Consultation 5: Security Review of Quota Bypass Vectors
+
+- **Agent**: security-minion
+- **Planning question**: The quota system introduces new attack surfaces: (a) Can a tenant bypass quotas by creating multiple API keys? (The answer should be no -- quotas are per-tenant, not per-key -- but confirm the data model supports this.) (b) The issue says "slight overages are acceptable" due to eventual consistency. What's the maximum realistic overage given that captures are queued (one concurrent consumer per tenant due to rate limiting, but up to 10 concurrent globally)? Is there a risk of intentional overage exploitation? (c) The per-tenant quota override in D1 means an admin can grant custom limits. Should this require the admin key, or should it be protected differently? (d) Should the usage dashboard expose absolute numbers (capture count, storage bytes) or only relative (percentage of quota)?
+- **Context to provide**: `src/auth.js` (verifyApiKey binds to tenantId), `src/index.js` (queue consumer with tenantId from message), `src/db.js` (incrementUsage with UPSERT), `wrangler.toml` (max_concurrency = 10 for capture queue)
+- **Why this agent**: Quota systems are authorization mechanisms. Bypass vectors, overage exploitation, and information disclosure in the usage dashboard are security concerns that should shape the design.
+
+---
+
+### Cross-Cutting Checklist
+
+- **Testing**: Include test-minion for planning? **No** -- test strategy for this feature is straightforward (unit tests for quota check logic, integration tests for the 429 response, UI tests for dashboard rendering). The patterns are well-established from R25 usage metering (20 unit + 16 integration tests). Test-minion will participate in Phase 3.5 architecture review.
+- **Security**: Include security-minion for planning? **Yes** -- included as Consultation 5 above. Quota bypass vectors and overage exploitation need pre-implementation analysis.
+- **Usability -- Strategy**: ALWAYS include. **Planning question for ux-strategy-minion**: The usage dashboard will show captures/month and storage used vs. quota limits. From a user journey perspective: (a) When should users see quota information -- only on a dedicated page, or surfaced as a warning when approaching limits (e.g., banner on the captures list)? (b) Should the 429 quota_exceeded API response include a link or hint about how to upgrade (even though auto-upgrade is out of scope)? (c) For the progress bar, what thresholds should trigger visual warning states (yellow at 80%? red at 95%?)? (d) Should the dashboard show historical usage (past months) or only current period?
+- **Usability -- Design**: Include ux-design-minion? **No** -- the progress bar is a simple visual element within an established design system. No new interaction patterns are introduced. The accessibility-minion review in Phase 3.5 will cover WCAG for the progress bar (color contrast, ARIA attributes).
+- **Documentation**: ALWAYS include. **Planning question for software-docs-minion**: The OpenAPI spec needs updates for: (a) the 429 quota_exceeded response on POST /v1/captures and POST /v1/captures/batch, (b) any new account usage endpoint, (c) tier and quota fields on tenant config admin endpoints. Also: should the docs site guide on "API Rate Limits" be updated to distinguish rate limits (per-minute) from quotas (per-month), or is a separate "Usage Quotas" guide warranted?
+- **Observability**: Include observability-minion? **No** -- the quota check will use the existing structured logging infrastructure (log events like `quota.exceeded`, `quota.check`). No new observability patterns are needed. The existing Coralogix alerting pipeline can be extended later if quota events need alerting.
+
+---
+
+### Notable Exclusions
+
+- **oauth-minion**: The OAuth/session infrastructure is already built and tested. The usage dashboard will reuse existing session auth -- no new auth flows needed.
+- **mcp-minion**: The MCP server tools (capture_url, list_captures, etc.) will naturally return 429 quota errors without any MCP-specific changes. The error propagation is transparent.
+- **edge-minion**: No CDN, caching, or edge worker changes. D1 reads are edge-colocated by default. KV caching is being evaluated by iac-minion in Consultation 3, but this is an infrastructure concern, not an edge delivery concern.
+
+---
+
+### Anticipated Approval Gates
+
+1. **Data model and migration** (MUST gate): The D1 schema for tier assignment and quota overrides is hard to reverse once migrated to production. This determines the shape of the quota check query, the admin API, and the UI data source. High blast radius (blocks all downstream tasks).
+
+2. **API contract for quota error response** (MUST gate): Whether to extend RFC 7807 problem responses or use the issue's custom shape affects all API consumers. The batch endpoint behavior (upfront vs. per-item quota check) is also a contract decision. Hard to change after consumers adopt it.
+
+---
+
+### Rationale
+
+This feature has five distinct domains that need planning input:
+
+1. **Data modeling** (data-minion) -- the tier/quota schema is the foundation. The tenants table needs a tier field, and the quota check needs an efficient query pattern against usage_counters. This is the highest-risk decision because schema changes are hard to reverse.
+
+2. **API design** (api-design-minion) -- the 429 response shape and batch behavior are API contracts. The tension between RFC 7807 and the issue's requested format needs explicit resolution.
+
+3. **Infrastructure** (iac-minion) -- the 10ms latency constraint requires understanding D1 read performance and whether caching is needed. This intersects with the existing rate limit infrastructure.
+
+4. **Frontend** (frontend-minion) -- the usage dashboard is a new UI surface within an established vanilla JS architecture. Routing and data source decisions need to align with backend design.
+
+5. **Security** (security-minion) -- quota systems are authorization mechanisms with bypass risks. Pre-implementation security analysis prevents architectural vulnerabilities.
+
+The cross-cutting agents (ux-strategy-minion for journey design, software-docs-minion for API documentation) bring complementary perspective without requiring deep domain analysis.
+
+---
+
+### Scope
+
+**What this task achieves**: Adds tier-based usage quotas to WRL. Tenants are assigned tiers (free/pro) with default capture and storage limits. The capture pipeline checks quotas before accepting work. A web UI dashboard shows usage vs. limits. Operators can override quotas per-tenant via admin API.
+
+**In scope**:
+- `tier` field on tenant records (defaults to "free" on auto-provisioning)
+- Default quota map per tier (free: 100 captures/month, 1 GB storage; pro: 5000 captures/month, 50 GB)
+- Pre-capture quota check in the HTTP handler (before queue enqueue)
+- 429 `quota_exceeded` response with usage details
+- Per-tenant quota overrides in D1 (admin-configurable)
+- Web UI usage dashboard with progress bars (reads from D1 on page load)
+- D1 migration for tier field and any new schema
+- OpenAPI spec updates
+- Unit and integration tests
+
+**Out of scope**:
+- Automatic tier upgrades or billing integration
+- Storage cleanup/eviction on quota breach
+- Per-endpoint API call quotas (only captures and storage)
+- Quota alerts or notifications
+- Real-time usage updates (dashboard reads on page load only)
+
+---
+
+### External Skill Integration
+
+No external skills detected in project. No `.claude/skills/` or `.skills/` directories found in the working directory.

--- a/docs/history/nefario-reports/2026-03-23-030747-tenant-quotas/phase2-api-design-minion.md
+++ b/docs/history/nefario-reports/2026-03-23-030747-tenant-quotas/phase2-api-design-minion.md
@@ -1,0 +1,287 @@
+## Domain Plan Contribution: api-design-minion
+
+### Recommendations
+
+#### 1. Use the existing `problemResponse` with `extra` fields -- do NOT invent a new response shape
+
+The issue description suggests a flat `{ "error": "quota_exceeded", "detail": "...", "limit": N, "used": N }` shape, but the codebase already has a well-established RFC 9457 Problem Details pattern via `problemResponse(status, detail, headers, extra)`. The `extra` parameter spreads additional fields into the response body. This is already used for rate limiting -- see `{ limitType: 'tenant' }` on line 573 of `src/index.js`.
+
+The quota-exceeded response should be:
+
+```json
+{
+  "type": "about:blank",
+  "status": 429,
+  "title": "Too Many Requests",
+  "detail": "Monthly capture quota reached (100/100). Resets 2026-04-01T00:00:00Z.",
+  "limitType": "quota",
+  "quota": {
+    "limit": 100,
+    "used": 100,
+    "resource": "captures",
+    "resetsAt": "2026-04-01T00:00:00Z"
+  }
+}
+```
+
+**Rationale:**
+
+- **Consistency with existing 429 responses.** Rate limit 429s already use `problemResponse(429, ..., headers, { limitType: 'tenant' })`. Adding `limitType: 'quota'` lets SDK clients distinguish rate-limit-exceeded from quota-exceeded by switching on `limitType` without needing a new error shape. This is the discriminator pattern -- one response schema, one field that tells you which kind of 429 you hit.
+- **RFC 9457 permits extension members.** The `quota` object with `limit`, `used`, `resource`, and `resetsAt` is fully compliant. Clients that understand quota can use it; clients that don't just see a standard problem response.
+- **The `detail` message is human-readable and actionable.** It includes the counts AND the reset date so operators can diagnose without parsing the structured fields. This follows the existing convention documented in `src/responses.js` lines 1-5.
+- **`resetsAt` instead of `Retry-After`.** Rate limits use `Retry-After` because the wait is seconds. Quotas reset at calendar boundaries (first of next month). Include `Retry-After` header too (seconds until reset), but the ISO 8601 timestamp in the body is more useful for UI display and logging.
+
+#### 2. Pipeline insertion point: after rate limit (step 3), before body parsing (step 4)
+
+In `handleCreateCapture`, the current flow is:
+
+```
+Step 1: Content-Type check
+Step 2: Auth check (verifyApiKey) → yields tenantId
+Step 3: Per-tenant rate limit (checkCaptureRateLimit)
+   --> NEW: Step 3b: Quota check (monthly capture limit)
+Step 4: Parse JSON body
+Step 5: Validate url field
+Step 6: URL validation (SSRF)
+Step 7: Generate capture ID
+Step 8: Write D1 record
+Step 9: Log
+Step 10: Queue dispatch
+Step 11: Return 202
+```
+
+**Why after rate limit but before body parsing:**
+
+- **Quota check needs `tenantId`**, which comes from step 2 (auth). So it must be after step 2.
+- **Quota check should be before any expensive work.** The issue explicitly says "before browser session creation," but in the HTTP handler the expensive work is D1 write + queue dispatch (steps 8-10). Checking quota before body parsing (step 4) saves the JSON parse cost on quota-exceeded requests.
+- **Rate limiting and quota enforcement are orthogonal.** Rate limits protect against burst abuse (requests per minute). Quotas protect against cumulative overage (captures per month). Rate limit fires first because it is cheaper (KV counter check vs D1 query). If a tenant is rate-limited, no need to check quota.
+- **Do NOT check quota inside the queue consumer.** The queue consumer (`handleCaptureMessage`) runs asynchronously after the 202 has already been returned. Checking quota there would mean accepting the capture, telling the user it is pending, then silently failing it. That violates the principle of failing loudly and early.
+
+#### 3. Batch endpoint: upfront quota check for the whole batch
+
+For `handleBatchCapture`, check quota upfront for `body.urls.length` items, same as the existing rate limit pattern (line 732: `checkCaptureRateLimit(env, auth, clientIp, 'capture', body.urls.length)`).
+
+The batch endpoint already parses the body before rate limiting (step 3 is parse, step 5 is rate limit) because it needs the batch size. Add the quota check immediately after the rate limit check at step 5, before the per-URL processing loop (step 7).
+
+**Do NOT check quota per-item in the loop.** Reasons:
+
+- **Partial acceptance is confusing for quota.** If a batch of 10 URLs has 3 remaining in quota, accepting 3 and rejecting 7 with `quota_exceeded` is a poor developer experience. The tenant should know upfront that they cannot afford the batch.
+- **Consistency with rate limiting.** The existing KV-auth batch rate limit is an upfront check for the whole batch. Quota should follow the same pattern.
+- **Atomicity.** Quota is a monthly budget. Partial batch acceptance makes accounting harder and forces the client to figure out which items succeeded.
+
+If the batch would exceed quota, return the whole-request 429 (not a 207 with per-item errors):
+
+```json
+{
+  "type": "about:blank",
+  "status": 429,
+  "title": "Too Many Requests",
+  "detail": "Batch of 10 captures would exceed monthly quota (95/100). Resets 2026-04-01T00:00:00Z.",
+  "limitType": "quota",
+  "quota": {
+    "limit": 100,
+    "used": 95,
+    "requested": 10,
+    "resource": "captures",
+    "resetsAt": "2026-04-01T00:00:00Z"
+  }
+}
+```
+
+The `requested` field is added only for batch responses so clients know how many items triggered the rejection.
+
+#### 4. `limitType` as the discriminator field for 429 responses
+
+The existing 429 responses use `limitType: 'tenant'` (for rate limits) or omit `limitType` (for IP-based rate limits). Formalize this into a documented discriminator:
+
+| `limitType` value | Meaning | Recovery |
+|---|---|---|
+| (absent) | IP-based rate limit | Wait `Retry-After` seconds |
+| `"tenant"` | Per-tenant rate limit | Wait `Retry-After` seconds |
+| `"quota"` | Monthly quota exceeded | Wait until `quota.resetsAt` or upgrade tier |
+
+This should be reflected in the OpenAPI spec. The existing `ProblemDetail` schema has no `additionalProperties: false` constraint (and should not get one -- RFC 9457 explicitly allows extension members). Define a new `QuotaExceededProblem` schema that extends `ProblemDetail` with the `limitType` and `quota` fields, and reference it from the 429 response using `oneOf` with the discriminator.
+
+#### 5. Quota headers on successful responses
+
+Follow the same pattern as rate limit headers. On successful capture requests (202), include quota usage headers so clients can monitor their budget proactively:
+
+```
+X-Quota-Limit: 100
+X-Quota-Used: 42
+X-Quota-Resource: captures
+X-Quota-Resets-At: 2026-04-01T00:00:00Z
+```
+
+These are custom headers (no RFC standard for quota headers exists yet). The `X-` prefix is technically deprecated by RFC 6648, but the pragmatic convention for quota headers is not yet standardized. An alternative is to use `RateLimit` headers from the draft RFC 9110 successor, but that conflates rate limits and quotas. Custom `X-Quota-*` headers are clearer.
+
+Include these on ALL capture-related responses (202, 207, 429) so clients always know their quota position.
+
+#### 6. Usage dashboard endpoint: `GET /v1/account/usage`
+
+The issue mentions a "web UI usage dashboard with progress bars." The UI needs an endpoint to fetch quota and usage data. Design:
+
+```
+GET /v1/account/usage
+Authorization: Bearer <session-cookie or API key>
+```
+
+Response:
+
+```json
+{
+  "tenantId": "gh-12345",
+  "period": "2026-03",
+  "tier": "free",
+  "quotas": {
+    "captures": {
+      "limit": 100,
+      "used": 42,
+      "remaining": 58,
+      "resetsAt": "2026-04-01T00:00:00Z"
+    },
+    "storageBytes": {
+      "limit": 1073741824,
+      "used": 524288000,
+      "remaining": 549453824,
+      "resetsAt": "2026-04-01T00:00:00Z"
+    }
+  }
+}
+```
+
+**Design notes:**
+
+- Place under `/v1/account/` because this is tenant-scoped self-serve data, consistent with the existing `/v1/account/keys`, `/v1/account/tos` pattern.
+- `operationId: getAccountUsage` -- follows the existing `list*`, `get*`, `create*` convention.
+- `tier` field tells the UI which tier label and limits to display.
+- `remaining` is computed server-side (avoids client math and races).
+- Storage quota uses bytes, not GB -- consistent with the existing `storageBytes` field in `usage_counters` and `getUsage()`.
+- The admin endpoint `GET /v1/admin/usage` already exists for admin-scoped usage queries. The account endpoint is the self-serve equivalent.
+
+#### 7. Default quota tiers as application constants
+
+Define defaults alongside the existing `RATE_LIMITS` pattern in a new `src/quotas.js` module:
+
+```js
+export const TIER_QUOTAS = {
+  free: {
+    captures: 100,         // per month
+    storageBytes: 1073741824, // 1 GB
+  },
+  pro: {
+    captures: 5000,        // per month
+    storageBytes: 53687091200, // 50 GB
+  },
+};
+
+export const DEFAULT_TIER = 'free';
+```
+
+Per-tenant overrides stored in the `tenants.config` JSON column (same as rate limit overrides). The config shape adds a `quota` key:
+
+```json
+{
+  "rateLimit": { "capture": { "limit": 20, "period": 60 } },
+  "quota": { "captures": 500, "storageBytes": 5368709120 },
+  "tier": "pro"
+}
+```
+
+Effective quota resolution: `tenantConfig.quota.captures ?? TIER_QUOTAS[tier].captures ?? TIER_QUOTAS[DEFAULT_TIER].captures`. Per-tenant overrides beat tier defaults, tier defaults beat free-tier defaults.
+
+#### 8. Tenant tier storage
+
+The `tenants` table currently has no `tier` column. Two options:
+
+**Option A: Add `tier` column to `tenants` table (recommended).** New migration `0005_tenant_quotas.sql`:
+
+```sql
+ALTER TABLE tenants ADD COLUMN tier TEXT NOT NULL DEFAULT 'free'
+  CHECK (tier IN ('free', 'pro'));
+```
+
+**Option B: Store tier inside the `config` JSON blob.** No migration needed, but tier cannot be queried or indexed efficiently.
+
+Recommend Option A. Tier is a first-class billing concept that may need indexing for admin queries ("how many pro tenants?"). It should not be buried in a JSON blob.
+
+#### 9. `Retry-After` header semantics for quota responses
+
+For rate limit 429s, `Retry-After` is seconds until the rate limit window resets (typically 10-60 seconds). For quota 429s, the reset is the first of the next month, which could be days away.
+
+Use `Retry-After` with the HTTP-date format (RFC 9110 section 10.2.3) instead of seconds for quota responses:
+
+```
+Retry-After: Wed, 01 Apr 2026 00:00:00 GMT
+```
+
+This avoids absurdly large second counts (e.g., `Retry-After: 691200` for 8 days) and is more meaningful. The `Retry-After` header spec explicitly supports HTTP-date format.
+
+
+### Proposed Tasks
+
+#### Task 1: Define quota constants and resolution logic
+**What to do:** Create `src/quotas.js` with `TIER_QUOTAS`, `DEFAULT_TIER`, and a `getEffectiveQuota(tenantConfig, resource)` function that resolves per-tenant overrides against tier defaults (mirroring the `getEffectiveLimit` pattern in `src/rate-limits.js`).
+**Deliverables:** `src/quotas.js` module with exported constants and resolution function.
+**Dependencies:** None.
+
+#### Task 2: Add `tier` column to tenants table
+**What to do:** Write migration `0005_tenant_quotas.sql` adding `tier TEXT NOT NULL DEFAULT 'free' CHECK (tier IN ('free', 'pro'))` to the `tenants` table.
+**Deliverables:** Migration SQL file.
+**Dependencies:** None.
+
+#### Task 3: Implement quota check function
+**What to do:** Create a `checkQuota(db, tenantId, resource, count)` function in `src/db.js` (or `src/quotas.js`) that reads the current period's `usage_counters` row and compares against the effective quota. Returns `{ exceeded: boolean, limit: number, used: number, resetsAt: string }`.
+**Deliverables:** Function with unit tests.
+**Dependencies:** Task 1 (quota constants), Task 2 (tier column).
+
+#### Task 4: Insert quota check into `handleCreateCapture`
+**What to do:** After the rate limit check (step 3) and before body parsing (step 4), add the quota check. On exceeded, return `problemResponse(429, ...)` with `limitType: 'quota'` and `quota` extra fields. Include `Retry-After` header with HTTP-date format. Also add `X-Quota-*` headers to the successful 202 response.
+**Deliverables:** Updated `handleCreateCapture` in `src/index.js`.
+**Dependencies:** Task 3 (quota check function).
+
+#### Task 5: Insert quota check into `handleBatchCapture`
+**What to do:** After the batch rate limit check (step 5) and before the per-URL loop (step 7), add an upfront quota check for `body.urls.length` items. Reject the entire batch with a 429 if the batch would exceed quota. Include `requested` in the quota extra fields. Also add `X-Quota-*` headers to the successful 207 response.
+**Deliverables:** Updated `handleBatchCapture` in `src/index.js`.
+**Dependencies:** Task 3 (quota check function), Task 4 (for consistency review).
+
+#### Task 6: Add `GET /v1/account/usage` endpoint
+**What to do:** Implement a new endpoint that returns the tenant's current-period usage against their effective quotas. Session-gated (same auth as `/v1/account/keys`). Supports API key auth as well.
+**Deliverables:** Handler function, route registration in `src/index.js`.
+**Dependencies:** Task 1 (quota constants), Task 2 (tier column), Task 3 (quota resolution).
+
+#### Task 7: Update `setTenantConfig` validation for quota overrides
+**What to do:** Extend the admin `PUT /v1/admin/tenants/{id}/config` validation to accept and validate `quota` and `tier` fields in the config body. `quota.captures` must be a positive integer. `quota.storageBytes` must be a non-negative integer. `tier` must be one of the valid tier names.
+**Deliverables:** Updated validation in `setTenantConfig` or `handlePutTenantConfig`.
+**Dependencies:** Task 1 (tier names), Task 2 (tier column).
+
+#### Task 8: Update OpenAPI spec for quota responses
+**What to do:**
+- Add `QuotaExceededProblem` schema extending `ProblemDetail` with `limitType` and `quota` fields.
+- Add `X-Quota-*` header definitions to `components/headers`.
+- Add quota-exceeded example to the 429 response of `POST /v1/captures` and `POST /v1/captures/batch`.
+- Add `GET /v1/account/usage` path with request/response schemas.
+- Add `AccountUsage` and `QuotaDetail` schemas to `components/schemas`.
+- Update the `Problem429` response component to document the `limitType` discriminator.
+**Deliverables:** Updated `openapi.yaml`.
+**Dependencies:** Tasks 4-6 (implementation shapes the spec).
+
+
+### Risks and Concerns
+
+1. **D1 read latency on the quota check hot path.** The quota check requires reading `usage_counters` from D1 on every capture request. The rate limit check already reads `tenantConfig` from D1 (line 495: `getTenantConfig(env.DB, auth.tenantId)`), so this is one additional D1 query. If latency becomes a concern, both queries could be combined into a single D1 batch call. However, this is a measured optimization -- do not prematurely optimize.
+
+2. **Race condition: concurrent requests may exceed quota.** Two requests arriving simultaneously could both read `used: 99` (limit 100), both pass the check, and both increment to 101. This is acceptable for several reasons: (a) the `usage_counters` table uses `capture_count + excluded.capture_count` which is atomic per-write, (b) the overshoot is bounded by concurrency (at most a few extra captures), and (c) this is the same tradeoff the existing rate limit KV counters make. Do not add locking or transactions -- the cure is worse than the disease for a soft quota.
+
+3. **Quota check reads stale data.** The `incrementUsage` call in `handleCreateCapture` is fire-and-forget via `ctx.waitUntil`. This means the quota check reads `usage_counters` before the current request's increment has been written. The counter may be 1-2 behind reality under high concurrency. This is fine for a soft quota -- users will see slight overages rather than under-counts.
+
+4. **Storage quota enforcement timing.** Capture storage bytes are only known after the capture completes (in the queue consumer), not at request time. The quota check at request time can only enforce capture count, not storage. Storage quota enforcement must be a separate concern -- either checked in the queue consumer (with graceful degradation if exceeded) or enforced retroactively by disabling new captures when storage is over quota. Recommend: check storage quota at capture request time using *current* storage usage. If already over storage quota, reject new captures. This does not predict the size of the new capture, but prevents runaway usage.
+
+5. **Backward compatibility.** Adding `limitType` and `quota` fields to the 429 response body is an additive change (new optional fields on an existing response). This is backward-compatible. The `X-Quota-*` headers are new headers that existing clients will ignore. No breaking changes.
+
+6. **Batch partial-acceptance vs full-rejection.** The recommendation to reject the entire batch when quota is insufficient is a design decision that differs from the rate limit behavior (which does partial acceptance for legacy auth). Document this clearly -- the batch endpoint returns 429 (not 207) when quota is exceeded, because quota is a budget concept and partial acceptance would create confusing accounting.
+
+
+### Additional Agents Needed
+
+None. The current team is sufficient for the described scope. The api-spec-minion will handle the OpenAPI spec updates based on the conventions described here. The data-minion (if involved) can handle the D1 migration. The frontend work (progress bars in the web UI) is a standard UI task that does not require additional API design input beyond the `GET /v1/account/usage` endpoint defined above.

--- a/docs/history/nefario-reports/2026-03-23-030747-tenant-quotas/phase2-data-minion.md
+++ b/docs/history/nefario-reports/2026-03-23-030747-tenant-quotas/phase2-data-minion.md
@@ -1,0 +1,223 @@
+## Domain Plan Contribution: data-minion
+
+### Recommendations
+
+#### (a) `tier` should be a new column on the `tenants` table, not inside `config` JSON
+
+**Recommendation: Add a `tier TEXT NOT NULL DEFAULT 'free'` column to the `tenants` table.**
+
+Rationale:
+
+1. **Query performance.** The quota check is on the hot path (before every capture). It needs to JOIN `tenants.tier` with `usage_counters` in a single statement. If `tier` lives inside the `config` JSON blob, you must use `json_extract(config, '$.tier')` in the WHERE/JOIN clause. SQLite's `json_extract` works but cannot be indexed, and it adds parsing overhead on every call. A real column with a CHECK constraint is both faster and indexable if needed later.
+
+2. **Schema contract.** `tier` is not optional configuration -- it is a core business attribute of every tenant. The `config` column is designed for optional, evolving settings (rate limit overrides, future feature flags). Tier determines billing and access rights. It deserves a NOT NULL column with a CHECK constraint (`CHECK (tier IN ('free', 'pro'))`) so the database enforces data integrity.
+
+3. **Consistency with existing patterns.** The tenants table already has structured columns (`id`, `created_at`, `updated_at`, `updated_by`) and delegates only truly flexible data to `config`. Tier is not flexible -- it has a fixed set of valid values.
+
+4. **Auto-provisioning default.** The existing `INSERT OR IGNORE INTO tenants (id) VALUES (?)` pattern (used in `createCapture`, `createApiKeyRecord`, `createWebhook`, `createGitHubUser`) auto-creates tenants with default values. Adding `tier TEXT NOT NULL DEFAULT 'free'` means every auto-provisioned tenant gets `free` tier automatically with zero code changes to the four existing INSERT OR IGNORE call sites.
+
+Migration (0005):
+```sql
+ALTER TABLE tenants ADD COLUMN tier TEXT NOT NULL DEFAULT 'free'
+  CHECK (tier IN ('free', 'pro'));
+```
+
+Note: SQLite (and D1) does not support adding CHECK constraints in ALTER TABLE ADD COLUMN. The CHECK must be enforced at the application layer, with the column added as:
+```sql
+ALTER TABLE tenants ADD COLUMN tier TEXT NOT NULL DEFAULT 'free';
+```
+Application-layer validation in `setTenantConfig` / a new `setTenantTier` function enforces the allowed values.
+
+#### (b) Default quota limits per tier should live in code, not D1
+
+**Recommendation: A constant map in a `src/quotas.js` module.**
+
+```js
+export const TIER_QUOTAS = {
+  free: { capturesPerMonth: 100, storageBytes: 1 * 1024 * 1024 * 1024 },
+  pro:  { capturesPerMonth: 5000, storageBytes: 50 * 1024 * 1024 * 1024 },
+};
+```
+
+Rationale:
+
+1. **Zero-latency access.** Tier defaults are read on every capture request. Fetching them from D1 adds a round-trip that provides no value -- these values change with code releases, not at runtime.
+
+2. **Consistency with existing pattern.** `RATE_LIMITS` in `src/rate-limits.js` already follows this exact pattern: a constant map of defaults in code, with per-tenant overrides in D1 config. Quota limits are the same class of setting.
+
+3. **Deployment atomicity.** When you change tier limits, you want the new limits and any code that depends on them to deploy together. A code constant guarantees this. A D1 value requires a separate migration step that can get out of sync with the deployment.
+
+4. **Simplicity.** Two tiers with two numbers each. A database table for this is over-engineering. When a third tier is added, it is a one-line code change plus a migration to add the CHECK value.
+
+5. **Testability.** Tests can import the constant directly without needing a database fixture.
+
+#### (c) Per-tenant quota overrides should be fields inside the existing `config` JSON column
+
+**Recommendation: Store overrides as `config.quotas.capturesPerMonth` and `config.quotas.storageBytes` inside the existing `config` JSON column.**
+
+Example config with quota overrides:
+```json
+{
+  "rateLimit": { "capture": { "limit": 20, "period": 60 } },
+  "quotas": { "capturesPerMonth": 500, "storageBytes": 5368709120 }
+}
+```
+
+Rationale:
+
+1. **Established pattern.** Per-tenant rate limit overrides already live in `config.rateLimit`. Quota overrides are the same concept: a per-tenant exception to a tier default. Putting them in `config.quotas` is natural and consistent.
+
+2. **No migration needed.** The `config` column is already nullable JSON. Adding new keys requires zero schema changes.
+
+3. **Admin API reuse.** The existing `PUT /v1/admin/tenants/:id/config` endpoint (backed by `setTenantConfig`) already handles config updates with validation. Adding quota override validation to `setTenantConfig` (similar to the existing `rateLimit` validation) is a small change.
+
+4. **A separate `quota_overrides` table would be wasteful.** Overrides are rare (most tenants use tier defaults), tightly coupled to the tenant, and always read alongside other tenant config. A separate table means an extra JOIN on the hot path for data that is almost always absent.
+
+5. **Effective-limit pattern.** Mirror the existing `getEffectiveLimit(tenantConfig, group)` with a `getEffectiveQuota(tier, tenantConfig)` function that returns tier defaults merged with any config overrides.
+
+```js
+export function getEffectiveQuota(tier, tenantConfig) {
+  const defaults = TIER_QUOTAS[tier] || TIER_QUOTAS.free;
+  if (!tenantConfig?.quotas) return { ...defaults };
+  return {
+    capturesPerMonth: tenantConfig.quotas.capturesPerMonth ?? defaults.capturesPerMonth,
+    storageBytes: tenantConfig.quotas.storageBytes ?? defaults.storageBytes,
+  };
+}
+```
+
+#### (d) Quota check query pattern: single `db.batch()` with two prepared statements
+
+**Recommendation: Use `db.batch()` with two SELECTs -- one for tenant tier + config, one for current period usage -- then compute the check in application code.**
+
+This is superior to a JOIN for several reasons:
+
+1. **D1 batch is a single round-trip.** `db.batch([stmt1, stmt2])` sends both statements to the D1 edge in one HTTP call. The latency is effectively the same as a single query. The codebase already uses this pattern extensively (see `listCaptures` which batches a data query + count query).
+
+2. **Simpler queries, better SQLite query plans.** Two simple PK lookups are faster than a JOIN, especially in SQLite which uses nested-loop joins. Each statement hits an exact-match primary key:
+   - `SELECT tier, config FROM tenants WHERE id = ?` (PK lookup)
+   - `SELECT capture_count, storage_bytes FROM usage_counters WHERE tenant_id = ? AND period = ?` (composite PK lookup)
+   Both are O(log n) B-tree seeks with zero scanning.
+
+3. **Graceful handling of missing rows.** If the `usage_counters` row does not exist (tenant has zero usage this period), a LEFT JOIN would return NULLs that need COALESCE. With separate statements, you simply default to zero in application code -- exactly as `getUsage` already does.
+
+4. **Application-level merge is trivial.** After the batch returns, compute the decision in JS:
+
+```js
+export async function checkQuota(db, tenantId) {
+  const period = computePeriod();
+  const [tenantResult, usageResult] = await db.batch([
+    db.prepare('SELECT tier, config FROM tenants WHERE id = ?').bind(tenantId),
+    db.prepare(
+      'SELECT capture_count, storage_bytes FROM usage_counters WHERE tenant_id = ? AND period = ?'
+    ).bind(tenantId, period),
+  ]);
+
+  const tenant = tenantResult.results?.[0];
+  if (!tenant) return { allowed: false, reason: 'tenant_not_found' };
+
+  const tier = tenant.tier || 'free';
+  const config = tenant.config ? JSON.parse(tenant.config) : null;
+  const quota = getEffectiveQuota(tier, config);
+
+  const usage = usageResult.results?.[0];
+  const captureCount = usage?.capture_count ?? 0;
+  const storageBytes = usage?.storage_bytes ?? 0;
+
+  if (captureCount >= quota.capturesPerMonth) {
+    return {
+      allowed: false,
+      reason: 'capture_limit',
+      limit: quota.capturesPerMonth,
+      used: captureCount,
+      period,
+    };
+  }
+
+  if (storageBytes >= quota.storageBytes) {
+    return {
+      allowed: false,
+      reason: 'storage_limit',
+      limit: quota.storageBytes,
+      used: storageBytes,
+      period,
+    };
+  }
+
+  return { allowed: true, quota, captureCount, storageBytes, period };
+}
+```
+
+**Performance estimate:** Two PK lookups in D1 edge SQLite should complete in 1-3ms. The `db.batch()` overhead is a single Cloudflare internal RPC. Well under the 10ms budget.
+
+**Why not a single JOIN query?** A JOIN would work:
+```sql
+SELECT t.tier, t.config, COALESCE(u.capture_count, 0) AS capture_count,
+       COALESCE(u.storage_bytes, 0) AS storage_bytes
+FROM tenants t
+LEFT JOIN usage_counters u ON u.tenant_id = t.id AND u.period = ?
+WHERE t.id = ?
+```
+This is also valid and would be a single statement. Either approach meets the 10ms requirement. I recommend the batch approach because:
+- It is consistent with how the codebase already structures multi-statement reads (see `listCaptures`)
+- Individual statements are easier to test and reuse independently
+- No COALESCE / NULL-handling complexity in SQL
+
+Both approaches are acceptable. If the team prefers fewer statements, the JOIN is fine too.
+
+
+### Proposed Tasks
+
+#### Task 1: Migration 0005 -- Add `tier` column to tenants table
+- **What:** Create `migrations/0005_tenant_tiers.sql` adding `tier TEXT NOT NULL DEFAULT 'free'` to tenants
+- **Deliverables:** Migration file, tested against existing data
+- **Dependencies:** None (must be applied before any code that reads `tier`)
+
+#### Task 2: `src/quotas.js` -- Tier defaults and quota logic
+- **What:** Create module with `TIER_QUOTAS` constant map, `getEffectiveQuota(tier, tenantConfig)` function, and `checkQuota(db, tenantId)` function
+- **Deliverables:** `src/quotas.js`, unit tests in `test/quotas.test.js`
+- **Dependencies:** Task 1 (migration must exist for schema awareness)
+
+#### Task 3: Quota validation in `setTenantConfig`
+- **What:** Add validation for `config.quotas` fields in `setTenantConfig` (same pattern as existing `rateLimit` validation). Ensure `capturesPerMonth` and `storageBytes` are positive integers when present.
+- **Deliverables:** Updated `src/db.js` `setTenantConfig`, updated tests
+- **Dependencies:** Task 2 (quota constants needed for ceiling validation)
+
+#### Task 4: Tier management in `src/db.js`
+- **What:** Add `setTenantTier(db, tenantId, tier, updatedBy)` function with application-layer validation of allowed tier values. Update `createGitHubUser` batch to ensure newly auto-provisioned tenants get `free` tier (already handled by DEFAULT, but explicit is better for clarity).
+- **Deliverables:** Updated `src/db.js`, tests
+- **Dependencies:** Task 1
+
+#### Task 5: Wire quota check into capture pipeline
+- **What:** In `handleCapture` (and `handleBatchCapture`) in `src/index.js`, call `checkQuota` after auth but before `createCapture`. Return 429 with `quota_exceeded` error body on failure. Place the check after rate limiting but before URL validation (fail fast -- quota check is cheaper than URL validation).
+- **Deliverables:** Updated `src/index.js`, integration tests
+- **Dependencies:** Task 2
+- **Insertion point:** Between Step 3 (rate limiting, ~line 580) and Step 4 (parse JSON body, ~line 594). Or between Step 6 (URL validation) and Step 7 (generate capture ID) if the team prefers to validate the URL first. The former is better because it avoids unnecessary work on a request that will be rejected anyway.
+
+#### Task 6: Admin API for tier management
+- **What:** Add `PUT /v1/admin/tenants/:id/tier` endpoint. Accepts `{ "tier": "pro" }`. Only admin key authenticated. Returns updated tenant record.
+- **Deliverables:** Route handler, tests
+- **Dependencies:** Task 4
+
+#### Task 7: Usage dashboard API endpoint
+- **What:** Add `GET /v1/tenants/:id/usage` (authenticated, tenant-scoped) returning current period usage, effective quotas, and percentage used. This is the data source for the web UI progress bars.
+- **Deliverables:** Route handler returning `{ period, captures: { used, limit, percent }, storage: { used, limit, percent }, tier }`
+- **Dependencies:** Task 2
+
+### Risks and Concerns
+
+1. **Race condition on quota check.** The quota check reads usage counters, but `incrementUsage` happens asynchronously via `ctx.waitUntil()` after capture completion. This means the usage counter can lag behind actual captures in flight. Two rapid requests could both pass the quota check before either increments the counter. This is acceptable for a soft quota (100 captures/month -- a few extra captures at the boundary is not harmful), but it should be documented. If exact enforcement is needed later, the check-and-increment would need to be atomic (a single UPDATE ... WHERE capture_count < limit RETURNING statement), but that is over-engineering for the current requirements.
+
+2. **Storage bytes is cumulative, not current.** The `storage_bytes` counter in `usage_counters` is incremented on each capture but never decremented when artifacts are deleted (if deletion is ever supported). For storage quota purposes, the counter represents "bytes ever stored this period" not "bytes currently stored." The success criteria says "storage GB" which implies current storage. If the intent is current storage, you would need to SUM artifact sizes from the `captures` table or maintain a separate running total. Clarify whether storage quota means "monthly ingestion volume" or "total stored data." The counter-based approach maps naturally to monthly ingestion volume.
+
+3. **Existing auto-provisioning `INSERT OR IGNORE` does not set tier explicitly.** This is actually fine -- the `DEFAULT 'free'` on the column handles it. But if additional per-tier setup is ever needed at provisioning time (e.g., creating a usage counter row, sending a welcome webhook), the four existing `INSERT OR IGNORE` call sites are scattered across the codebase. Consider centralizing tenant creation into a single `ensureTenant(db, tenantId)` function that all paths call, to avoid future divergence.
+
+4. **D1 ALTER TABLE limitations.** D1 uses SQLite, which does not support ALTER TABLE ADD COLUMN with CHECK constraints. The CHECK must be enforced in application code. This is not a problem -- the existing `config` JSON validation already follows this pattern -- but the migration file should document why the CHECK is absent.
+
+5. **Period boundary edge case.** A tenant at 99/100 captures on January 31 23:59 UTC submits a capture. By the time `incrementUsage` runs (asynchronously, after browser rendering which takes seconds), it may be February 1. The counter increments in the new period. The quota check used the old period's count. This is harmless (they get one extra capture) but worth noting.
+
+6. **Batch capture endpoint.** `handleBatchCapture` accepts up to 10 URLs. The quota check should either (a) check once for the entire batch count (`captureCount + batch.length <= limit`) or (b) check per-item. Option (a) is simpler and more correct -- a batch of 5 where only 3 quota slots remain should be rejected entirely, not partially processed then rejected mid-batch. The check should be: `captureCount + requestedCount > quota.capturesPerMonth`.
+
+### Additional Agents Needed
+
+None. The current team is sufficient for this scope. The data modeling questions are addressed above; implementation (wiring into the capture pipeline, admin endpoints, UI dashboard) falls to the implementation agents. If the web UI usage dashboard involves significant frontend work (progress bars, real-time updates), a frontend specialist may be useful but is likely already part of the team.

--- a/docs/history/nefario-reports/2026-03-23-030747-tenant-quotas/phase2-frontend-minion.md
+++ b/docs/history/nefario-reports/2026-03-23-030747-tenant-quotas/phase2-frontend-minion.md
@@ -1,0 +1,176 @@
+## Domain Plan Contribution: frontend-minion
+
+### Recommendations
+
+#### (a) New view (`#/usage`) vs. section within settings
+
+**Recommendation: New section within the existing `#/settings` view.**
+
+Rationale:
+- The settings view already follows a card-per-section pattern (Account info card, API Keys card). Usage/quota fits naturally as a third card section between Account and API Keys.
+- Adding a new top-level route (`#/usage`) for what amounts to a read-only summary would fragment the UI. A tenant's account page is the natural home for "what's my plan, how much have I used."
+- The nav bar is already tight (Captures, Settings). Adding a third link for a secondary info display isn't justified.
+- The settings view already fetches data on mount (`mountSettings` calls `apiFetch` for keys). Adding one more parallel fetch for usage follows the same pattern with minimal code change.
+- The UX-strategy minion may separately recommend surfacing a quota warning on the captures view (e.g., a banner when >80% used). That's a separate concern from the dashboard location.
+
+#### (b) Data source: new `GET /v1/account/usage` vs. inline in `/auth/session`
+
+**Recommendation: New `GET /v1/account/usage` endpoint, NOT inline in `/auth/session`.**
+
+Rationale:
+1. **Separation of concerns.** `/auth/session` fires on every page load (boot check). It should remain lightweight -- a single D1 lookup returning auth state. Adding usage counters, quota limits, and tier info bloats the boot payload and adds a D1 join/read that runs even when the user isn't visiting settings.
+
+2. **Follows existing patterns.** The `/v1/account/*` namespace already has session-gated endpoints (keys, tos). Adding `/v1/account/usage` is one route tuple in `index.js` and one handler in `account.js`. The session auth gate, CSRF exemption (GET is exempt), ToS enforcement, and rate limiting are already wired for any `/v1/account/*` route.
+
+3. **Cacheability.** A dedicated usage endpoint can return `Cache-Control: private, max-age=60` so the browser doesn't re-fetch on every settings navigation within a minute. Embedding in `/auth/session` (which returns `no-store` for security) prevents this.
+
+4. **Response shape.** The endpoint should return the same fields as the admin endpoint plus quota limits:
+   ```json
+   {
+     "tenantId": "gh-12345",
+     "period": "2026-03",
+     "tier": "free",
+     "captures": { "used": 42, "limit": 100 },
+     "storageBytes": { "used": 524288000, "limit": 1073741824 },
+     "updatedAt": "2026-03-23T10:15:00.000Z"
+   }
+   ```
+   This shape gives the frontend everything it needs in one call: current usage and the quota ceiling, without needing to know tier-to-limit mappings client-side.
+
+5. **The existing admin endpoint (`GET /v1/admin/usage`) cannot be reused** -- it requires the ADMIN_KEY auth, not session auth, and its response shape lacks quota limits. A separate session-gated endpoint is the clean path.
+
+#### (c) Minimal viable progress bar in vanilla CSS
+
+The progress bar should be implemented as a pair of nested `<div>` elements with ARIA attributes. No framework, no `<progress>` element (which has inconsistent cross-browser styling), no JavaScript animation.
+
+**HTML structure** (built with `document.createElement`, matching the existing DOM-construction pattern):
+
+```html
+<div class="usage-bar" role="progressbar"
+     aria-valuenow="42" aria-valuemin="0" aria-valuemax="100"
+     aria-label="42 of 100 captures used">
+  <div class="usage-bar-fill" style="width: 42%"></div>
+</div>
+```
+
+**CSS** (uses existing design tokens only):
+
+```css
+.usage-bar {
+  height: 8px;
+  background: var(--color-surface-muted);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  border: 1px solid var(--color-border-subtle);
+}
+
+.usage-bar-fill {
+  height: 100%;
+  background: var(--color-accent);
+  border-radius: var(--radius-sm);
+  transition: width 0.2s ease;
+  min-width: 0;
+}
+
+/* Warning threshold: >80% */
+.usage-bar-fill--warning {
+  background: var(--color-warning);
+}
+
+/* Critical threshold: >95% */
+.usage-bar-fill--critical {
+  background: var(--color-error);
+}
+```
+
+**Key implementation details:**
+
+- Width is set via inline `style` attribute (percentage clamped 0-100 in JS). This avoids creating CSS classes for every possible width value.
+- Color thresholds: `<=80%` uses `--color-accent` (blue-teal), `>80%` uses `--color-warning` (amber), `>95%` uses `--color-error` (red). The threshold class is applied to the fill element.
+- The `role="progressbar"` with `aria-valuenow`, `aria-valuemin`, `aria-valuemax` provides screen reader semantics. The `aria-label` provides the human-readable usage string (e.g., "42 of 100 captures used").
+- `transition: width 0.2s ease` provides a smooth fill animation on first paint. The `prefers-reduced-motion` media query already in `ui-css.js` will reduce this to 0.01ms.
+- Storage bytes should be formatted as human-readable (e.g., "524 MB of 1 GB"). A simple `formatBytes(n)` helper is needed.
+
+**Usage section layout within settings:**
+
+```
++-----------------------------------------------+
+| Usage                          March 2026      |
+|                                                |
+| Captures          42 of 100                    |
+| [========------------------------------] 42%   |
+|                                                |
+| Storage           524 MB of 1 GB               |
+| [============================---------] 51%    |
+|                                                |
+| Plan: Free                                     |
++-----------------------------------------------+
+```
+
+The section follows the existing settings card pattern: a `<section>` with `class="settings-section card"`, a heading `<h2>`, and content below. Each metric gets a label row (metric name + value text) and a progress bar row. Tier is shown as a simple text line at the bottom.
+
+
+### Proposed Tasks
+
+**Task 1: Add `GET /v1/account/usage` endpoint**
+- **What:** Create a handler in `src/account.js` that reads from the session (`env._session.tenantId`), calls `getUsage(db, tenantId, computePeriod())`, looks up the tenant's tier and quota limits, and returns the response shape described above.
+- **Deliverables:** Handler function, route tuple in `index.js`, tests.
+- **Dependencies:** Tier + quota data model must be defined first (data-minion concern: where are tier defaults and per-tenant overrides stored?). The `getUsage` DAL function already exists.
+- **Note:** This task is primarily API work. The frontend-minion should collaborate with the api-design-minion on the response shape, but the handler implementation follows the existing `account.js` patterns closely enough that it could be handled by either specialist.
+
+**Task 2: Add usage section to settings view**
+- **What:** In `src/ui/ui-settings.js`, modify `mountSettings()` to fire a parallel `apiFetch('/v1/account/usage')` alongside the existing keys fetch. In `buildSettingsContent()`, add a new "Usage" card section (inserted before the API Keys section) containing:
+  - Period label (e.g., "March 2026")
+  - Two progress bar rows: Captures and Storage
+  - Each row: metric label, "N of M" text, progress bar with threshold coloring
+  - Tier label at the bottom of the card
+- **Deliverables:** Modified `ui-settings.js`, new CSS classes in `ui-css.js`.
+- **Dependencies:** Task 1 (the endpoint must exist to fetch from). The response shape must be agreed upon before the frontend is built.
+
+**Task 3: Add usage bar CSS to design system / ui-css.js**
+- **What:** Add `.usage-bar`, `.usage-bar-fill`, `.usage-bar-fill--warning`, `.usage-bar-fill--critical` classes and the `formatBytes` helper function. Also add mobile responsive rules (on small screens, the label and value should stack vertically above the bar).
+- **Deliverables:** CSS additions in `ui-css.js`. The progress bar itself is simple enough that it does not warrant a design-system.css addition -- it's application-level CSS.
+- **Dependencies:** None (CSS-only). Can be done in parallel with Task 1.
+
+**Task 4: Handle error and loading states**
+- **What:** The usage section must handle:
+  - **Loading:** Show "Loading usage..." placeholder text (same pattern as `settings-loading`).
+  - **Error:** If the usage fetch fails, show an inline error alert within the usage card ("Could not load usage data") -- do not block the rest of settings from rendering.
+  - **Zero usage:** If `captureCount` and `storageBytes` are both 0, still show the bars at 0% with "0 of N" text. Do not hide the section.
+  - **No quota (unlimited):** If the API returns `null` for a limit (e.g., internal tenants with no cap), show usage without a progress bar -- just the count/size.
+- **Deliverables:** Error handling code within the settings mount function.
+- **Dependencies:** Task 2.
+
+**Task 5: Accessibility verification**
+- **What:** Verify the usage bars are announced correctly by screen readers:
+  - `role="progressbar"` with `aria-valuenow`, `aria-valuemin`, `aria-valuemax`
+  - `aria-label` with human-readable text (e.g., "42 of 100 captures used this month")
+  - The `aria-live` region already in settings (`#settings-live`) should announce when usage data loads: "Usage data loaded."
+  - Keyboard users can tab to the usage section heading (already works via heading semantics)
+- **Deliverables:** ARIA attributes on progress bar elements, live region announcement.
+- **Dependencies:** Task 2.
+
+
+### Risks and Concerns
+
+1. **`_wrlUser.createdAt` is already broken.** The settings view references `_wrlUser.createdAt` (line 92 of `ui-settings.js`) but `/auth/session` does not include `createdAt` in its response (see `oauth.js` lines 508-517). This means "Member since" always shows "--". This is a pre-existing bug, not introduced by this feature, but it's worth noting since we're modifying the same view. Recommend fixing it as a drive-by if the session response shape is being touched.
+
+2. **Quota limits not yet in the data model.** The current D1 schema has no `tier` column on the `tenants` table, and no quota configuration table. The R26 spec calls for "tier field on tenant record" and "per-tenant quota overrides stored in D1." The data-minion needs to define this schema before the API endpoint can return quota limits. The frontend cannot proceed with Task 2 until the response shape is finalized.
+
+3. **Parallel fetch ordering in `mountSettings`.** The current `mountSettings` does a single fetch (keys). Adding a second parallel fetch (usage) means `buildSettingsContent` should wait for both to resolve. Options:
+   - Use `Promise.all([keysFetch, usageFetch])` and build everything at once. This is cleanest but means the whole settings page waits for the slower of the two fetches.
+   - Render the skeleton immediately and fill in each section as its fetch resolves. This is more code but better perceived performance.
+   - **Recommendation:** Use `Promise.all` for simplicity. Both fetches hit the same D1 database via the same worker; they should complete within ~50ms of each other. The added complexity of progressive rendering isn't justified for two fast fetches.
+
+4. **`formatBytes` edge cases.** Storage bytes from D1 could be very large numbers. The formatter should handle: 0, sub-KB values, exact boundary values (1024, 1048576, etc.), and values exceeding the quota (overages are allowed per spec). Use 1024-based units (KiB/MiB/GiB) or 1000-based (KB/MB/GB) -- recommend SI units (1000-based) for user-facing display since that's what cloud providers typically show.
+
+5. **API-key auth users see no usage.** The settings view is session-only (`_authMethod === 'session'` check in the router). API-key users are redirected to `#/captures` and never see settings. This is correct per the current architecture -- API-key users don't have a tenant context in the same way. No action needed, but worth documenting.
+
+6. **Period rollover display.** On the 1st of a new month, the usage counters reset but the tenant sees "0 of 100 captures" for the new period. This is correct behavior but may be confusing without context. Consider adding a small help text: "Resets on [first of next month]" -- though this is a UX-strategy decision.
+
+
+### Additional Agents Needed
+
+- **data-minion**: Required to define the D1 schema changes for tier assignment and quota overrides (new `tier` column on `tenants`, default quota lookup table or constants, per-tenant override table). The frontend cannot finalize its response shape expectations without this.
+- **api-design-minion**: Required to finalize the `GET /v1/account/usage` response shape, including how tier defaults and per-tenant overrides are resolved and what the response looks like for unlimited quotas. The frontend plan above proposes a shape but the API designer should validate it against the broader API conventions.
+- **test-minion**: Required for integration tests of the new endpoint and component tests verifying the usage section renders correctly with various data states (zero usage, near-limit, over-limit, error, unlimited quota).

--- a/docs/history/nefario-reports/2026-03-23-030747-tenant-quotas/phase2-iac-minion.md
+++ b/docs/history/nefario-reports/2026-03-23-030747-tenant-quotas/phase2-iac-minion.md
@@ -1,0 +1,161 @@
+# Domain Plan Contribution: iac-minion
+
+## Recommendations
+
+### Option (a) -- Single D1 Read -- Is Sufficient. No KV Cache Needed.
+
+After reading the codebase, the answer is clear: **option (a) is sufficient, and the quota check should piggyback on the existing `getTenantConfig` D1 read** rather than introducing a second read or a KV caching layer.
+
+Here is the reasoning:
+
+**1. D1 read latency is well within budget.**
+
+D1 is edge-colocated SQLite. A single `SELECT` by primary key is sub-2ms in practice. Even a two-statement batch (tenant tier + usage counter) via D1's `db.batch()` completes in under 5ms. The 10ms budget has generous headroom for a single D1 read path.
+
+**2. The existing `checkCaptureRateLimit` already does a D1 read.**
+
+At line 495 of `src/index.js`, `checkCaptureRateLimit` calls `getTenantConfig(env.DB, auth.tenantId)` -- this is a D1 `SELECT config FROM tenants WHERE id = ?` by primary key. The quota check needs the same tenant record (to read the tier) plus the current period's usage counter. This can be done as a `db.batch()` of two prepared statements in a single D1 round-trip, returning both results. The latency cost is negligible vs. the single read that already exists.
+
+**3. KV caching would add complexity with no meaningful latency benefit.**
+
+KV reads are ~5ms from within Workers (edge-local). D1 reads by primary key are ~2ms. Adding a KV cache for tier data would actually increase P50 latency (KV read + occasional D1 read on cache miss) while introducing staleness. The only scenario where KV caching helps is if D1 is under write contention -- but `usage_counters` writes happen via `ctx.waitUntil()` (non-blocking), so they do not contend with the quota check read path.
+
+**4. Cloudflare rate limiter bindings (option c) are not viable for monthly quotas.**
+
+The rate limiter binding (`unsafe.bindings` with `type = "ratelimit"`) supports only fixed `limit` and `period` values set in `wrangler.toml`. They cannot accept dynamic per-tenant limits, per-tier limits, or monthly rolling windows. They are designed for per-minute/per-second rate limiting, not monthly quota enforcement.
+
+### Piggyback on Existing Flow -- Merge Quota Check into `checkCaptureRateLimit`
+
+The current capture pipeline order is:
+1. Auth (`verifyApiKey`)
+2. Usage increment (`incrementUsage` via `ctx.waitUntil()`)
+3. Rate limit (`checkCaptureRateLimit` -- calls `getTenantConfig` from D1, then `rateLimitCounter` from KV)
+4. URL validation
+5. D1 write + queue enqueue
+
+The quota check should be integrated into step 3. The `checkCaptureRateLimit` function already fetches `tenantConfig` from D1. The modified flow:
+
+1. **Batch-read tenant config + usage counter in one D1 round-trip** using `db.batch()`:
+   - Statement 1: `SELECT config, tier FROM tenants WHERE id = ?` (add `tier` column -- see data-minion for schema)
+   - Statement 2: `SELECT capture_count, storage_bytes FROM usage_counters WHERE tenant_id = ? AND period = ?`
+2. **Check monthly quota first** (cheaper rejection -- reject before KV read):
+   - Look up tier's default limits from a code-level constant map
+   - Apply per-tenant overrides from config JSON if present
+   - Compare current `capture_count` against limit
+   - If exceeded, return immediately with `quota_exceeded` (no KV read, no rate limiter call)
+3. **Then proceed with existing rate limit checks** (KV counter, IP guard)
+
+This means the quota check adds zero additional network round-trips when it passes (the D1 read was already happening, now it just reads one more row in the same batch). When the quota is exceeded, it actually saves a round-trip by short-circuiting before the KV read.
+
+### No New Bindings or Infrastructure Changes Needed
+
+The existing infrastructure is sufficient:
+
+- **D1 binding `DB`**: Already used for `getTenantConfig` and `incrementUsage`. The quota check query uses the same binding.
+- **KV binding `KV`**: Unchanged. Rate limit counters continue to use KV. Monthly quotas do NOT use KV.
+- **Rate limiter bindings**: Unchanged. The per-minute rate limiters remain as hard backstops. Monthly quotas are a separate concern enforced in application code.
+- **Queues**: Unchanged. The queue consumer calls `incrementUsage` after capture completion -- this is the write side of the counter. The quota check is the read side, and both use D1.
+
+No changes to `wrangler.toml` are required for quota enforcement.
+
+### Race Condition Analysis
+
+The constraint says "slight overages are acceptable." Here is the analysis:
+
+**Write path** (`incrementUsage`): Runs in `ctx.waitUntil()` after the capture is enqueued. This means the D1 counter is incremented asynchronously, after the HTTP response is sent. Two concurrent requests from the same tenant could both read `capture_count = 99` (limit 100) and both pass the quota check before either write lands.
+
+**Maximum realistic overage**: Bounded by the per-tenant rate limit. The `CAPTURE_RATE_LIMITER` binding hard-caps any tenant at 100 requests/60 seconds. Combined with the KV-based per-tenant counter (default 10/60s), the maximum concurrent in-flight requests that could slip past the quota check is equal to the rate limit window (at most 10 concurrent for default tenants, up to 100 for overridden tenants). In practice, the D1 `ctx.waitUntil()` write completes in <10ms, so the actual race window is tiny.
+
+**Mitigation needed?** No. The constraint explicitly accepts slight overages. The overage is bounded at `rate_limit_per_minute` captures at most, which is a rounding error on monthly quotas of 100-5000 captures. No additional locking, atomic compare-and-set, or pessimistic check is needed.
+
+**Storage quota** is harder to enforce pre-capture because the final storage size is unknown until after the browser renders the page. The quota check should compare the pre-capture `storage_bytes` counter against the limit, but cannot account for the in-progress capture's eventual size. This means storage overage could be up to `max_single_capture_size` bytes beyond the limit. This is acceptable for the same reason -- the limit is soft, not a hard billing boundary.
+
+### Migration Considerations
+
+The only infrastructure-adjacent schema change is adding a `tier` column to the `tenants` table (data-minion owns the exact schema design). From an infrastructure perspective:
+
+- **D1 migration**: A new `0005_tenant_quotas.sql` migration adds the `tier` column with a default value (e.g., `'free'`). This is a safe ALTER TABLE -- SQLite adds columns with defaults without rewriting the table.
+- **Deployment order**: Migration must run before the new Worker code deploys. Since `wrangler deploy` does not auto-run D1 migrations, the deployment process must call `wrangler d1 migrations apply` first. This is the same pattern used for all prior migrations.
+- **Rollback**: If the new code is rolled back, the `tier` column is harmless -- old code ignores it (it reads `config` only). No backward-incompatible schema change.
+
+## Proposed Tasks
+
+### Task 1: Extend `getTenantConfig` to Batch-Read Tier + Usage Counter
+
+**What**: Modify the D1 access layer to support a single `db.batch()` call that retrieves both the tenant record (with tier) and the current period's usage counter row. This replaces the current single-statement `getTenantConfig` read in the rate limit path.
+
+**Deliverables**:
+- New function in `src/db.js` (e.g., `getTenantQuotaContext(db, tenantId)`) that returns `{ tier, config, usage: { captureCount, storageBytes } }` in one D1 round-trip
+- Unit tests verifying batch read returns correct data for existing tenant, tenant with no usage row, and non-existent tenant
+
+**Dependencies**: Depends on data-minion's schema design for the `tier` column and migration.
+
+### Task 2: Define Tier Quota Constants in Application Code
+
+**What**: Create a constant map of tier defaults (captures/month, storage bytes) in a new module or within `src/rate-limits.js`. This keeps tier definitions in code rather than D1 -- they change infrequently and should be deployed with the application.
+
+**Deliverables**:
+- Constant map, e.g.:
+  ```js
+  export const TIER_QUOTAS = {
+    free: { capturesPerMonth: 100, storageBytesMax: 1_073_741_824 },
+    pro:  { capturesPerMonth: 5000, storageBytesMax: 53_687_091_200 },
+  };
+  ```
+- Function `getEffectiveQuota(tier, configOverrides)` that merges tier defaults with per-tenant overrides from config JSON
+- Unit tests for default resolution and override merging
+
+**Dependencies**: None (code-only, no infrastructure changes).
+
+### Task 3: Integrate Quota Check into `checkCaptureRateLimit`
+
+**What**: Modify `checkCaptureRateLimit` in `src/index.js` to call the batch D1 read (Task 1), check monthly quotas before proceeding to KV rate limit checks. Quota failure short-circuits with a distinct return shape (e.g., `{ exceeded: true, type: 'quota', ... }`).
+
+**Deliverables**:
+- Modified `checkCaptureRateLimit` that checks quota first, then existing rate limits
+- The function's return type gains `type: 'quota'` as a possible value, with `limit`, `used`, and `remaining` fields
+- The caller in `handleCreateCapture` and `handleBatchCapture` maps `type: 'quota'` to the 429 quota_exceeded response (using whatever format api-design-minion recommends)
+- Integration tests: request at quota boundary passes, request over quota returns 429 with correct response shape
+
+**Dependencies**: Task 1, Task 2, api-design-minion's response format decision.
+
+### Task 4: Verify No `wrangler.toml` Changes Required
+
+**What**: Confirm that no new bindings, rate limiters, or configuration changes are needed in `wrangler.toml` or `wrangler.toml` staging environment. Document this as a non-change in the evolution log.
+
+**Deliverables**:
+- Explicit confirmation that the existing D1 (`DB`), KV (`KV`), and rate limiter bindings are sufficient
+- No changes to `wrangler.toml`
+- Note in evolution `decisions.md` explaining why infrastructure-level enforcement was not needed
+
+**Dependencies**: None.
+
+## Risks and Concerns
+
+### Risk 1: D1 Batch Latency Under Load
+
+**Concern**: While single D1 reads are sub-2ms, a `db.batch()` with two statements could have higher tail latency under heavy write contention on `usage_counters` (concurrent `incrementUsage` writes from multiple captures completing simultaneously).
+
+**Mitigation**: SQLite's WAL mode (used by D1) allows concurrent readers even during writes. The read-side query hits the `usage_counters` primary key index directly. Monitor P99 latency of the quota check path after deployment. If tail latency exceeds 10ms, the fallback is to cache the usage counter value in KV with a 60-second TTL as a read-through cache -- but this should not be built preemptively. YAGNI.
+
+### Risk 2: Storage Quota Cannot Be Enforced Pre-Capture
+
+**Concern**: The capture's final storage size is unknown at request time. The quota check can only compare the cumulative `storage_bytes` counter against the limit, not account for the in-progress capture's eventual size. A tenant at 990 MB of a 1 GB limit could submit a capture that produces 50 MB, exceeding the limit.
+
+**Mitigation**: Accept this as a design constraint. The storage quota is a soft limit. If strict enforcement is needed later, the queue consumer could check storage quota post-render and fail the capture before uploading to R2 -- but this is out of scope for R26 and should be a backlog item if the soft limit proves insufficient.
+
+### Risk 3: Tier Column Migration on Existing Tenants
+
+**Concern**: Existing tenants created via GitHub OAuth auto-provisioning have no tier. The migration must set a default tier for all existing rows.
+
+**Mitigation**: The migration `DEFAULT 'free'` on the new column handles this. All existing tenants become `free` tier. No manual data fixup needed. This is a standard SQLite ALTER TABLE ADD COLUMN with a default value.
+
+### Risk 4: Quota Check Adds Latency to Already-Blocked Requests
+
+**Concern**: The quota check runs after auth but before rate limiting. If a tenant is both over quota AND rate-limited, the response now comes from the quota check (which does a D1 read) rather than the rate limiter (which uses the faster CF binding). This could slightly increase P50 latency for abusive tenants.
+
+**Mitigation**: The quota check ordering (quota before rate limit) is correct because quota rejection is cheaper for the system than rate limit rejection followed by eventual queue processing and quota-check-at-consumer. A D1 read is <5ms. The alternative (checking rate limit first) would let over-quota requests consume KV counter tokens unnecessarily.
+
+## Additional Agents Needed
+
+None. The current team (data-minion, api-design-minion, iac-minion, frontend-minion, security-minion, ux-strategy-minion, software-docs-minion) covers all planning dimensions. The observability and test concerns are straightforward enough to handle during implementation without dedicated planning consultation.

--- a/docs/history/nefario-reports/2026-03-23-030747-tenant-quotas/phase2-security-minion.md
+++ b/docs/history/nefario-reports/2026-03-23-030747-tenant-quotas/phase2-security-minion.md
@@ -1,0 +1,362 @@
+## Domain Plan Contribution: security-minion
+
+### Recommendations
+
+#### (a) Can a tenant bypass quotas by creating multiple API keys?
+
+**Answer: No -- the data model correctly prevents this.** API keys are bound to
+tenants via `api_keys.tenant_id` (see `src/db.js:createApiKeyRecord`). The
+`verifyApiKey` function in `src/auth.js` resolves every key to its `tenantId`
+before any operation proceeds. Usage counters in `usage_counters` are keyed on
+`(tenant_id, period)`, not on API key hash. Quotas checked against
+`usage_counters.capture_count` will aggregate all activity for a tenant
+regardless of which key was used.
+
+**However, there are two bypass vectors to address:**
+
+1. **Self-serve tenant re-registration**: A GitHub user could create a second
+   GitHub account and sign up again, getting a fresh `gh-{id}` tenant with a
+   fresh quota. This is an inherent limitation of self-serve signup and is
+   acceptable at the free tier. Mitigation is out of scope per the spec
+   ("automatic tier upgrades" are out), but the system should log tenant
+   creation events so operators can spot abuse patterns.
+
+2. **Legacy auth bypass**: The legacy `CAPTURE_API_KEY` fallback in
+   `verifyApiKey` (line 212-236) always returns `tenantId: 'default'`. If the
+   `default` tenant has a different quota tier than the caller's actual
+   tenant, this could be exploited. **Recommendation: ensure legacy auth is
+   either removed before quota enforcement ships, or the `default` tenant
+   inherits the most restrictive (free) tier quotas.**
+
+#### (b) Maximum realistic overage and intentional exploitation
+
+**Architecture analysis:**
+
+The capture flow is two-phase:
+1. **HTTP handler** (`handleCreateCapture`): auth, rate limit, create D1
+   record, enqueue to `CAPTURE_QUEUE`, return 202.
+2. **Queue consumer** (`handleCaptureMessage`): dequeue, run browser capture,
+   `incrementUsage` via `ctx.waitUntil()`.
+
+Usage counters are incremented **after** capture completion (line 163 of
+`index.js`), not at enqueue time. This is the TOCTOU gap.
+
+**Quota check placement matters critically.** Per the spec, the quota check
+runs "before browser session creation." Two options:
+
+- **Check at HTTP handler (before enqueue)**: The counter lags because
+  `incrementUsage` fires post-completion. Captures already in-flight or
+  queued are invisible to the check.
+
+- **Check at queue consumer (before browser launch)**: Tighter enforcement
+  because fewer captures are "in flight" between check and increment. But
+  the tenant already received a 202 -- they believe the capture was accepted.
+
+**Recommended: check at both points.** Primary enforcement at the HTTP
+handler (to fail fast with 429 before creating a D1 record and queue
+message). Secondary defense-in-depth at the queue consumer (to catch
+captures that slipped through the race window -- fail them with a
+`quota_exceeded` error instead of launching a browser).
+
+**Maximum realistic overage calculation:**
+
+- `max_concurrency = 10` globally across all tenants. Per-tenant rate limit
+  is 10/60s (or custom override, max 100/60s via binding ceiling).
+- Worst case: a tenant submits a burst of captures right at quota boundary.
+  Due to rate limiting (10/60s default), at most 10 captures could be
+  accepted in a single rate limit window before the counter updates.
+- With `max_concurrency = 10`, at most 10 captures could be simultaneously
+  processing in the queue consumer. But since captures take 5-30 seconds,
+  only a fraction of those would complete between the quota check and the
+  next check.
+- **Realistic maximum overage: ~10 captures** (one rate limit window's worth
+  of burst, all accepted before the first `incrementUsage` writes back).
+  With the secondary queue-consumer check, this drops to ~1-2 (only those
+  that passed the consumer check simultaneously before any increment landed).
+
+**Intentional exploitation risk:**
+
+A malicious tenant could deliberately time burst requests to maximize the
+TOCTOU gap. This is bounded by the rate limiter (10/60s default, 100/60s
+ceiling). With the dual-check approach, exploitation is limited to the number
+of concurrent in-flight captures for that tenant, which is at most
+`max_concurrency = 10` (shared globally, so typically fewer per tenant).
+
+**Assessment: acceptable.** The spec explicitly allows "slight overages."
+10 captures over a 100/month free tier is 10% overage in the worst case.
+For the pro tier (5000/month), it is negligible (0.2%). The dual-check
+approach brings this to 1-2 captures of overage in practice.
+
+#### (c) Admin key protection for per-tenant quota overrides
+
+The quota override will be stored in the `tenants.config` JSON column, set via
+`PUT /v1/admin/tenants/:tenantId/config`. This endpoint is already gated by
+`verifyAdminKey` (infrastructure secret), not tenant API keys. This is the
+correct protection level.
+
+**Recommendation: admin key is sufficient.** Reasons:
+
+1. Quota overrides are an operational setting, same category as rate limit
+   overrides which already live in tenant config and use the same admin key.
+2. Adding a separate auth mechanism would increase complexity with no
+   meaningful security benefit -- anyone with the admin key already has full
+   infrastructure access.
+3. The admin key is rate-limited (5 req/60s per IP via `ADMIN_RATE_LIMITER`)
+   and timing-safe compared.
+
+**Additional safeguards:**
+
+- **Input validation**: Quota override values must be validated on write.
+  Enforce minimum 0 (or 1), maximum sane upper bounds (e.g., 1M
+  captures/month, 10 TB storage). Reject negative values, non-integers for
+  capture counts, and non-positive values for storage.
+- **Audit logging**: The existing `admin.tenant_config_updated` log event
+  (index.js:1131) covers this. Ensure the log includes the old and new quota
+  values for diff-ability.
+- **No tenant self-service for quota changes**: The `/v1/account/*` routes
+  must NOT expose quota override writes. The session-gated account routes
+  should only expose read access to quota/usage data.
+
+#### (d) Absolute numbers vs. relative (percentage of quota) in usage dashboard
+
+**Recommendation: expose both, with deliberate choices about what goes where.**
+
+- **Usage dashboard (authenticated, session-gated)**: Show absolute numbers
+  AND percentage. The tenant needs absolute numbers to understand their
+  consumption, and percentages to understand proximity to limits. The session
+  is already tenant-scoped, so there is no cross-tenant information leakage.
+
+- **429 quota_exceeded response body**: The spec already defines
+  `{ "limit": N, "used": N }`. This is fine -- a tenant calling the API with
+  their own key already knows their own identity. The response should NOT
+  include tier name, only the numeric limits. Reason: tier names are
+  internal business categories; exposing them gives tenants information about
+  your pricing model that could be used to negotiate or reverse-engineer
+  other tenants' arrangements.
+
+- **GET /auth/session response**: Currently returns `githubId`,
+  `githubLogin`, `tenantId`, `tosAcceptedAt`, `tosVersion`. **Do NOT add
+  tier or quota information here.** This endpoint fires on every page load
+  and should remain minimal. Create a separate `/v1/account/usage` endpoint
+  for the dashboard to call.
+
+#### (e) Security implications of surfacing tier information
+
+**Risk: tenant inference of other tenants' tiers is LOW but not zero.**
+
+Attack scenario: A tenant could probe the system's behavior under different
+conditions to infer tier information about other tenants. Specific vectors:
+
+1. **Rate limit headers**: Already exposed via `X-RateLimit-Limit`. Custom
+   rate limit overrides are visible in these headers. A tenant can see their
+   own limits but not others'. Low risk.
+
+2. **Quota limits in 429 response**: The `{ "limit": N }` field reveals the
+   tenant's own quota. If default tier quotas are public (e.g., on a pricing
+   page), this tells the tenant nothing new. If a tenant has a custom
+   override, the 429 response reveals their specific limit. This is
+   acceptable -- they need to know their own limit.
+
+3. **Cross-tenant inference via shared infrastructure**: The
+   `GLOBAL_CAPTURE_LIMITER` (200/60s) is shared across all tenants. If a
+   tenant gets 503 "Service at capacity," they know the global system is
+   busy, but cannot distinguish which other tenants are consuming capacity.
+   Low risk.
+
+4. **Timing side-channels**: If the quota check adds measurably different
+   latency for different tiers, an attacker could infer information. However,
+   the spec requires <10ms for the quota check (single D1 read). Since all
+   tiers use the same code path with the same D1 query, timing differences
+   will be below measurement noise. No risk.
+
+**Recommendation:**
+
+- Do NOT expose tier name/label in API responses or user-facing endpoints.
+  Expose only numeric limits (captureLimit, storageLimitBytes).
+- Do NOT expose other tenants' usage or limits in any endpoint. All usage
+  endpoints must be tenant-scoped.
+- The admin usage endpoint (`GET /v1/admin/usage`) already correctly requires
+  the admin key, so cross-tenant visibility is admin-only.
+- If a public pricing page exists, the default tier quotas are public anyway.
+  Custom overrides should remain private to the tenant + admin.
+
+### Proposed Tasks
+
+#### Task 1: Quota enforcement at HTTP handler (pre-enqueue check)
+
+**What**: Add a quota check in `handleCreateCapture` and `handleBatchCapture`
+after auth and rate limit checks, before creating the D1 capture record.
+Read `usage_counters` for the current period and compare against the
+tenant's tier default or custom override from `tenants.config`.
+
+**Deliverables**:
+- `checkQuota(db, tenantId, metric)` function in `src/db.js` (or new
+  `src/quota.js`) that returns `{ allowed: true }` or
+  `{ allowed: false, limit, used }`.
+- Default tier definitions (free: 100 captures/month, 1 GB storage; pro:
+  5000 captures/month, 50 GB storage) as constants.
+- 429 response with `quota_exceeded` error shape per spec.
+- Batch capture handler must check quota against batch size (remaining
+  capacity vs. items in batch), not just single-item.
+
+**Dependencies**: Tier field on tenant record (migration task), usage counter
+data (R25, already implemented).
+
+**Security requirements**:
+- Quota check must read from D1, not a cached value (stale caches could allow
+  bypass). The spec allows <10ms latency -- a single D1 read is well within
+  this.
+- Reject the entire batch if remaining quota is less than batch size, OR
+  accept a partial batch up to the remaining quota. Decision for design, but
+  either way the check must happen BEFORE any D1 writes or queue dispatches.
+
+#### Task 2: Defense-in-depth quota check at queue consumer
+
+**What**: Add a secondary quota check in `handleCaptureMessage` before calling
+`performCapture`. If the tenant is now over quota (due to captures that
+completed after the HTTP handler check), fail the capture with
+`status: 'failed'`, `error: 'quota_exceeded'`, `retryable: false`, and
+ack the message (do not retry -- the quota won't un-exceed).
+
+**Deliverables**:
+- Quota check call in `handleCaptureMessage`, after idempotency guard (line
+  124) and before `performCapture` call (line 143).
+- Log event: `capture.quota_exceeded_dequeue` with tenantId, captureId,
+  used, limit.
+
+**Dependencies**: Task 1 (shared `checkQuota` function).
+
+**Security requirements**:
+- Must NOT retry quota-exceeded captures. Retrying would waste queue
+  throughput and never succeed within the billing period.
+- Must ack the message after failing it, to prevent DLQ accumulation.
+
+#### Task 3: Tier field migration and default assignment
+
+**What**: Add a `tier` column to the `tenants` table. New migration
+(`0005_tenant_tiers.sql`) with `ALTER TABLE tenants ADD COLUMN tier TEXT NOT
+NULL DEFAULT 'free'`. Existing tenants (including `default`) get `'free'`.
+
+**Deliverables**:
+- Migration file.
+- `getTenantTier(db, tenantId)` function or extend `getTenantConfig` to
+  include tier.
+- Validation: tier values must come from an allowlist (`free`, `pro`). No
+  freeform strings.
+
+**Security requirements**:
+- Tier assignment can only be changed via admin API (`PUT /v1/admin/tenants/
+  :tenantId/config` or a new dedicated endpoint). Never via session-gated
+  account routes.
+- The `createGitHubUser` flow (self-serve signup) must always assign
+  `'free'` tier. The tier value must not be controllable by the OAuth
+  callback or any user-supplied data.
+- Input validation: reject unknown tier values with 400, not silently
+  default. Fail closed.
+
+#### Task 4: Tenant-scoped usage endpoint for the dashboard
+
+**What**: New `GET /v1/account/usage` endpoint, session-gated (same auth as
+other `/v1/account/*` routes). Returns usage for the authenticated tenant's
+current billing period, plus their quota limits.
+
+**Deliverables**:
+- Handler returning `{ period, captureCount, captureLimit, storageBytes,
+  storageLimitBytes, percentUsed: { captures, storage } }`.
+- No tier name in the response -- only numeric limits.
+
+**Security requirements**:
+- Must be scoped to the authenticated tenant (from session's `tenantId`).
+  No `?tenant=` parameter.
+- Must NOT expose other tenants' data.
+- Must NOT expose tier name (internal business category).
+- Cache-Control: `private, no-store` (usage data is sensitive and
+  tenant-specific).
+- Rate-limited per the account group limits.
+
+#### Task 5: Quota override validation in tenant config
+
+**What**: Extend `setTenantConfig` validation (currently only validates
+`rateLimit` overrides) to also validate quota overrides.
+
+**Deliverables**:
+- Validation for `config.quota.captureLimit` (positive integer, max 1000000)
+  and `config.quota.storageLimitBytes` (positive integer, max 10TB in bytes).
+- Reject `config.tier` if set via config (tier should be a top-level column,
+  not embedded in JSON config, to prevent confusion and ensure schema
+  enforcement).
+- Log old vs. new quota values in the `admin.tenant_config_updated` event.
+
+**Dependencies**: Task 3 (tier column).
+
+#### Task 6: Legacy auth quota alignment
+
+**What**: Ensure the `default` tenant (used by legacy `CAPTURE_API_KEY` auth)
+is subject to free-tier quotas, preventing legacy auth as a quota bypass.
+
+**Deliverables**:
+- Verify `default` tenant exists in D1 with `tier = 'free'`.
+- If legacy auth is slated for removal, document the timeline. If not,
+  ensure quota checks apply identically to `tenantId: 'default'`.
+
+**Dependencies**: Task 1, Task 3.
+
+### Risks and Concerns
+
+1. **TOCTOU race window in usage counters (MEDIUM)**: Usage is incremented
+   post-capture via `ctx.waitUntil()`. Between the HTTP handler quota check
+   and the increment, captures are invisible to the quota. The dual-check
+   approach (Tasks 1 + 2) mitigates this to 1-2 captures of overage. This
+   is explicitly accepted by the spec ("slight overages are acceptable").
+
+2. **`ctx.waitUntil` increment failures (MEDIUM)**: If `incrementUsage`
+   fails (D1 transient error), the counter underreports, and the tenant
+   effectively gets free captures. The current code logs this as a warning
+   (`wrl:usage_increment_fail`) but does not retry. For quota enforcement,
+   this means a tenant could accumulate uncounted captures. **Mitigation**:
+   consider moving `incrementUsage` out of `ctx.waitUntil()` and into the
+   synchronous path for the queue consumer -- the capture is already
+   complete, so a few ms of D1 write latency is acceptable. Alternatively,
+   add a periodic reconciliation job that counts D1 `captures` rows per
+   tenant per period and corrects `usage_counters`.
+
+3. **Storage quota enforcement gap (HIGH in implementation complexity)**:
+   Capture count quotas are straightforward -- increment by 1 per capture.
+   Storage quotas depend on `result.storedBytes`, which is only known after
+   the capture completes. A tenant at 999 MB of a 1 GB limit could submit
+   a capture that produces 500 MB of artifacts, pushing them to 1.5 GB.
+   **Pre-capture storage estimation is unreliable.** Recommendation: enforce
+   storage quotas at the queue consumer AFTER the capture completes but
+   BEFORE incrementing the counter. If over storage quota, the artifacts are
+   already stored (can't un-upload mid-capture). Options: (a) accept the
+   overage and block the next capture, (b) delete the artifacts and fail the
+   capture. Option (a) is simpler and consistent with "slight overages are
+   acceptable."
+
+4. **Batch capture quota exhaustion (MEDIUM)**: A batch of 10 URLs where the
+   tenant has 3 captures remaining. Decision needed: reject the entire batch
+   (simpler, but poor UX) or accept partial (up to remaining quota, reject
+   the rest with 429). The current batch handler has precedent for partial
+   success (rate limit mid-batch returns per-item errors). Partial acceptance
+   is consistent with existing behavior.
+
+5. **Tier escalation via config manipulation (LOW)**: The `PUT /v1/admin/
+   tenants/:tenantId/config` endpoint currently accepts arbitrary JSON in the
+   config body (only `rateLimit` is validated). If tier is stored in config
+   JSON rather than as a dedicated column, a future developer could
+   accidentally allow tier changes via config updates. **Mitigation**: store
+   tier as a dedicated column (Task 3), and explicitly reject `tier` in
+   config JSON (Task 5).
+
+6. **Information disclosure in error responses (LOW)**: The quota_exceeded
+   response includes `limit` and `used` values. For the tenant's own
+   request, this is expected. Ensure these values are not cached by
+   intermediaries (enforce `Cache-Control: private, no-store` on 429
+   responses).
+
+### Additional Agents Needed
+
+None -- the current team is sufficient. The security concerns are
+addressable within the existing architecture. The key security decisions
+(dual-check placement, tier column vs. config JSON, response shape) are
+documented above for the synthesis phase.

--- a/docs/history/nefario-reports/2026-03-23-030747-tenant-quotas/phase2-software-docs-minion.md
+++ b/docs/history/nefario-reports/2026-03-23-030747-tenant-quotas/phase2-software-docs-minion.md
@@ -1,0 +1,160 @@
+## Domain Plan Contribution: software-docs-minion
+
+### Recommendations
+
+#### (a) OpenAPI schema strategy: referenced components, not inline
+
+The existing `openapi.yaml` already follows a consistent pattern: all error responses are defined as `$ref` components (`Problem400`, `Problem401`, `Problem429`, `Problem503`), and reusable data shapes are defined under `components/schemas` (`ProblemDetail`, `UsageResponse`, etc.). The quota feature must extend this pattern, not break it.
+
+**Specific recommendation:**
+
+1. **Do NOT replace `Problem429` wholesale.** The existing `Problem429` response component describes rate limiting. Quota exhaustion is a semantically different 429 (monthly limit vs. per-minute limit). The spec should distinguish them by adding a **new `Problem429Quota` response component** alongside the existing `Problem429`. The two responses share the same HTTP status code but differ in:
+   - The `detail` message (quota-specific: "Monthly capture limit reached")
+   - Additional extension fields (`limit`, `used`, `resetsAt`) per the success criteria
+   - The `Retry-After` semantics (rate limit: seconds; quota: potentially days until month reset)
+
+   The `POST /v1/captures` and `POST /v1/captures/batch` endpoints should list both `Problem429` (rate limit) and `Problem429Quota` (quota exceeded) as possible 429 responses using `oneOf` in the response schema, or (more pragmatically, since OpenAPI 3.1 doesn't natively support multiple descriptions for the same status code) combine them under the existing `429` response with a description that covers both cases and examples for each.
+
+   **Pragmatic approach (recommended):** Extend the existing `Problem429` response to cover both cases. Add a second example (`quotaExceeded`) alongside the existing `rateLimited` example. Extend the `ProblemDetail` schema documentation to note that quota responses include additional fields. The `extra` spread parameter in `problemResponse()` already supports arbitrary additional fields -- the spec should document this extension pattern.
+
+2. **Create new referenced schemas for quota-specific types:**
+   - `QuotaStatus` schema (used in `GET /v1/account/usage` response and potentially in the extended `Problem429` response) with fields like `limit`, `used`, `remaining`, `resetsAt`.
+   - `TenantQuotaConfig` schema (used in admin tenant config endpoints) with fields for tier, per-metric limits, and override flags.
+
+3. **New endpoint `GET /v1/account/usage`** should follow the existing `account.js` pattern (session-gated, `Cache-Control: private, no-store`). Schema should be a referenced `components/schemas/AccountUsageResponse` -- similar to the existing `UsageResponse` but augmented with quota limits and remaining counts. This is tenant-facing, distinct from the admin `GET /v1/admin/usage` which exists today.
+
+4. **Admin endpoint additions:** If `PUT /v1/admin/tenants/:id/config` is being added (or an existing admin endpoint gains quota override fields), the request/response schema should reference a `TenantConfig` component that includes `tier`, `quotaOverrides`, and any other tenant-level configuration. This keeps the admin API spec DRY if the same shape appears in GET and PUT.
+
+#### (b) Docs site: update existing content, add one new guide
+
+There is currently **no dedicated rate limits guide** on the docs site. Rate limit information is scattered:
+- `batch.md` mentions per-URL rate limit tokens and 429 handling
+- `index.md` references the API Reference for rate limits
+- `openapi.yaml` documents rate limits per-endpoint inline
+- `README.md` mentions "10 per minute per IP" and "60 per minute per IP"
+
+**Recommendation:** Create a single **"Limits & Quotas"** guide on the docs site that covers both concepts in one place. Separating them into two guides would fragment information that developers need to understand together (both can produce 429 responses, both affect capture submission). The guide should:
+
+1. **Distinguish the two systems clearly** with a comparison table:
+   - Rate limits: per-minute, per-IP, enforced by KV counters, `Retry-After` in seconds, affects all endpoints
+   - Quotas: per-month, per-tenant, enforced by D1 usage counters, resets at month boundary, affects capture endpoints only
+2. **Document the 429 response disambiguation** -- how clients tell whether a 429 is rate-limit or quota (the `detail` field, plus the presence/absence of `limit`/`used` extension fields)
+3. **Document the `GET /v1/account/usage` endpoint** for self-serve usage checking
+4. **Cross-reference** from the existing `batch.md` rate limits section and `authentication.md` (where scopes are listed)
+
+**Do NOT create a standalone "API Rate Limits" guide** -- it would immediately need to reference quotas, and vice versa. One guide covering both is cleaner and avoids single-source-of-truth violations.
+
+#### (c) Architecture documentation: yes, document the quota check as a pipeline stage
+
+The capture request flow currently has these implicit stages: rate limit check -> auth check -> URL validation -> queue enqueue -> (async) browser launch -> capture -> store. Inserting a quota check between auth and queue enqueue is architecturally significant because:
+
+1. It introduces a **new failure mode before expensive work** (the whole point of the feature)
+2. It creates a **dependency on D1 in the synchronous request path** (previously D1 was only hit for auth and completion)
+3. It has **different consistency semantics** from rate limiting (eventual consistency, slight overages acceptable)
+
+**Recommendation:** Add a Mermaid sequence diagram to the evolution log (`docs/evolution/0056-tenant-quotas/decisions.md`) showing the capture request pipeline stages with the quota check inserted. This does NOT warrant a standalone architecture document -- it fits naturally in the evolution log decisions file. If a higher-level architecture diagram exists (I did not find one), the quota check should be annotated there too.
+
+The pipeline stage ordering should be explicitly documented as:
+
+```
+Rate Limit (KV, per-IP) -> Auth (D1 key lookup) -> Quota Check (D1 usage counters) -> URL Validation -> Queue Enqueue
+```
+
+This ordering matters: rate limiting is cheapest (KV read), then auth (D1 read), then quota (D1 read), then validation (CPU), then enqueue (Queue write). Document why quota check sits after auth: you need the tenantId from auth to look up quota.
+
+#### (d) Admin API documentation for quota overrides
+
+Yes, there are documentation implications. The admin tenant config endpoint needs:
+
+1. **OpenAPI spec additions:** The `PUT /v1/admin/tenants/:id/config` endpoint (if new) or the extended response for existing admin endpoints needs a schema showing:
+   - `tier` field (enum: `free`, `pro`, or whatever tiers are defined)
+   - `quotaOverrides` object (optional per-metric overrides that supersede tier defaults)
+   - Clear documentation that overrides take precedence over tier defaults
+
+2. **Admin docs in `authentication.md`:** The "Managing API Keys (Operators)" section should mention that quota overrides are managed per-tenant through the admin API. A sentence and a link to the API Reference is sufficient -- no need for a full walkthrough.
+
+3. **README.md:** Does NOT need updates for quota overrides specifically. The README already links to OPERATIONS.md and the docs site for operator workflows. Adding quota configuration to the README would bloat it beyond its purpose.
+
+4. **OPERATIONS.md:** Should get a brief section on quota override management as part of tenant onboarding, since the existing onboarding flow in CLAUDE.md already covers creating tenant keys and 1Password items.
+
+### Proposed Tasks
+
+#### Task 1: Extend OpenAPI spec with quota-related schemas and responses
+**What:** Update `openapi.yaml` with:
+- Extended `Problem429` response adding `quotaExceeded` example with `limit`, `used`, `resetsAt` extension fields
+- New `AccountUsageResponse` schema under `components/schemas`
+- New `GET /v1/account/usage` endpoint definition (session-gated, under a new `account` tag)
+- New `TenantConfig` / `TenantQuotaConfig` schemas for admin endpoints
+- Updated `POST /v1/captures` and `POST /v1/captures/batch` descriptions noting quota enforcement
+- New `PUT /v1/admin/tenants/:id/config` endpoint definition (if this is a new endpoint)
+
+**Deliverables:** Updated `openapi.yaml` with all quota-related additions
+**Dependencies:** Requires finalized API design from api-design-minion (endpoint paths, field names, tier definitions). Must happen AFTER API design decisions but BEFORE implementation.
+
+#### Task 2: Create "Limits & Quotas" docs site guide
+**What:** Create `site/content/limits.md` covering:
+- Rate limits vs. quotas comparison table
+- 429 response disambiguation (how to tell which kind)
+- Quota tiers and default limits
+- `GET /v1/account/usage` endpoint usage examples
+- Handling quota exceeded errors (client retry strategy: wait until month resets, or request tier upgrade)
+- Cross-references to batch.md and authentication.md
+
+**Deliverables:** New `site/content/limits.md`, updated navigation/index to include it, updated cross-references in `batch.md`
+**Dependencies:** Finalized quota tiers and limits. Depends on Task 1 (spec must be settled first).
+
+#### Task 3: Update docs site navigation and cross-references
+**What:**
+- Add "Limits & Quotas" to the docs site navigation (in `site/content/index.md` guides list)
+- Update `batch.md` rate limits section to cross-reference the new guide
+- Update `authentication.md` endpoint scope table to include `GET /v1/account/usage`
+- Update `api-reference.njk` tag list if a new `account` tag is added to the spec
+
+**Deliverables:** Updated `index.md`, `batch.md`, `authentication.md`
+**Dependencies:** Task 2 completed.
+
+#### Task 4: Document quota check pipeline in evolution log
+**What:** Include a Mermaid sequence diagram in `docs/evolution/0056-tenant-quotas/decisions.md` showing:
+- The capture request pipeline stages with quota check inserted
+- The ordering rationale (cheapest checks first)
+- The eventual consistency trade-off (best-effort enforcement, slight overages accepted)
+
+**Deliverables:** Content in `decisions.md` (created as part of the standard evolution log workflow)
+**Dependencies:** None -- this is part of the standard evolution log requirement and should be written during the implementation phase.
+
+#### Task 5: Update OPERATIONS.md with quota override management
+**What:** Add a section to OPERATIONS.md covering:
+- How to check a tenant's current quota/tier (admin usage endpoint)
+- How to override default quotas for a specific tenant (admin config endpoint)
+- How to change a tenant's tier
+
+**Deliverables:** Updated `OPERATIONS.md`
+**Dependencies:** Task 1 (needs finalized admin API shape).
+
+#### Task 6: Update README.md rate limit mention
+**What:** The README currently says "Captures are rate-limited to 10 per minute per IP." This needs a brief addition noting that captures are also subject to monthly quotas based on tenant tier. One sentence, linking to the docs site for details. Do not expand the README significantly.
+
+**Deliverables:** Updated `README.md` (one sentence addition)
+**Dependencies:** Task 2 (so the link target exists).
+
+### Risks and Concerns
+
+1. **429 ambiguity is the biggest documentation risk.** Both rate limiting and quota exhaustion return HTTP 429. If the response bodies are not clearly distinguishable, clients cannot programmatically differentiate between "wait 60 seconds and retry" (rate limit) and "you're done for the month" (quota). The OpenAPI spec MUST document the distinguishing fields. The `problemResponse()` `extra` parameter supports this, but the spec must formalize which extension fields appear in which case. Recommend the api-design-minion specifies a `reason` field (e.g., `"rate_limit"` vs `"quota_exceeded"`) or a `type` URI that differs from `about:blank` for quota responses.
+
+2. **Docs site is generated from the OpenAPI spec.** The API Reference page (`api-reference.njk`) auto-renders from `openapi.yaml`. Any schema additions must be valid OpenAPI 3.1 or the docs site build will break. The CI pipeline should catch this, but it's worth noting as a dependency.
+
+3. **Two usage endpoints with different audiences.** The existing `GET /v1/admin/usage` (admin-only) and the proposed `GET /v1/account/usage` (tenant self-serve) show similar data but with different authorization and potentially different response shapes (tenant sees their own quotas and usage; admin sees raw counters). The documentation must be clear about which is which and avoid confusion. Naming them differently helps (`admin/usage` vs `account/usage` follows the existing `admin/keys` vs `account/keys` pattern).
+
+4. **Tier definitions need to be documented somewhere authoritative.** The prompt mentions "free" and "pro" tiers with specific limits. These defaults need a single source of truth -- either in the OpenAPI spec as enum documentation, in a constants file in the codebase, or in the docs site guide. If they're only in code, the docs will drift. Recommend defining tier defaults in the OpenAPI spec description AND in the "Limits & Quotas" guide, with the code being the actual enforcement point.
+
+5. **Web UI usage dashboard documentation.** The success criteria mention "Web UI usage dashboard shows current period usage vs. quota with a progress bar per metric." This is a UI feature, not an API documentation feature. I flag it but do NOT own it -- the frontend implementation is separate from the API documentation. However, the `GET /v1/account/usage` endpoint that feeds this dashboard IS in my scope.
+
+### Additional Agents Needed
+
+**None for the documentation tasks specifically.** However, the documentation work has a hard dependency on the api-design-minion finalizing:
+- The exact endpoint paths (`GET /v1/account/usage` vs alternatives)
+- The response schema shape (especially the 429 disambiguation strategy)
+- The tenant config admin endpoint path and schema
+- The tier names and default limits
+
+The api-design-minion's output is the input to all documentation tasks. If api-design-minion has not yet been consulted for this feature, it is a blocker for Tasks 1-3 and 5-6.

--- a/docs/history/nefario-reports/2026-03-23-030747-tenant-quotas/phase2-ux-strategy-minion.md
+++ b/docs/history/nefario-reports/2026-03-23-030747-tenant-quotas/phase2-ux-strategy-minion.md
@@ -1,0 +1,183 @@
+# Domain Plan Contribution: ux-strategy-minion
+
+## Recommendations
+
+### (a) Where quota information should appear in the user journey
+
+**Primary location: a "Usage" section inside the existing Settings view (`#/settings`).**
+
+The Settings view (`ui-settings.js`) already follows a clear card-based section pattern (Account info card, API Keys card). Usage fits naturally as a third card section. This is the logical place users will look for account-level information -- it maps to the mental model of "my account, my limits." There is no need for a separate `#/usage` route; that would fragment account information across two views and add a nav item for something most users check infrequently.
+
+**Secondary location: contextual inline warning on the captures list view, but ONLY when the tenant is above 80% of their captures/month quota.**
+
+This follows progressive disclosure: don't surface quota information in the core workflow until it becomes relevant. Below 80%, quota awareness adds pure cognitive overhead to what should be a frictionless "paste URL, click Capture" flow. Above 80%, the user's mental context shifts from "I'm doing my work" to "I need to manage a resource" -- that's the right moment to surface it.
+
+The warning should appear as a dismissible banner between the submit form and the captures list (similar to the existing `showGlobalError` pattern but using `alert--warning` styling). Content: "You've used {N} of {limit} captures this month." No link to upgrade (out of scope), but include a "View usage" link that navigates to `#/settings`.
+
+**Not on the submit form itself.** See (b) below.
+
+### (b) Cognitive load of quota awareness during capture submission
+
+**The submit form should NOT show remaining quota.** Here is the reasoning:
+
+1. **Satisficing behavior (Krug):** Users submitting a capture are focused on one job -- "capture this URL." Showing remaining quota ("142 of 500 remaining") forces them to context-switch into resource management mode on every single submission. This is extraneous cognitive load for users well under their limits (the vast majority, most of the time).
+
+2. **The captures list view already shows the inline warning at 80%.** If a user is on the captures page (which contains the submit form), they will see the banner. The banner IS the contextual warning for the submission flow. Adding a second indicator on the form itself is redundant and contributes to information density without adding signal.
+
+3. **Error handling covers the edge case.** When a user actually exceeds their quota, the 429 response from the API will display in the existing `formErrorEl` (the same error slot used for invalid URLs, network errors, etc.). This is the correct moment for the system to communicate "you can't do this" -- at the point of failure, not preemptively on every interaction.
+
+**Exception:** If the tenant has exactly 0 remaining captures (quota fully exhausted), the submit button should be disabled with a clear explanation. This prevents the user from filling in a URL, clicking submit, and waiting for a failure -- that's wasted effort. A disabled state with text like "Monthly capture limit reached" is a constraint (Norman) that prevents the error entirely.
+
+### (c) Human-readable 429 response for quota_exceeded
+
+**Yes, absolutely.** The 429 response body should include a clear, actionable message. Current 429 responses say "Per-tenant rate limit exceeded" or "Rate limit exceeded. Try again later." -- these are generic rate-limit messages, not quota messages. A quota exhaustion is fundamentally different from a rate limit: rate limits reset in seconds/minutes, quotas reset at the end of the billing period.
+
+The quota-specific 429 should be distinguishable from rate-limit 429s and include:
+
+- **What happened:** "Monthly capture quota reached."
+- **When it resets:** "Your quota resets on {first day of next month}." (This is the most important piece of information -- it answers the user's immediate question: "When can I use this again?")
+- **What to do (without promising auto-upgrade):** "Contact the site operator to discuss your usage needs." (Neutral phrasing that works whether upgrade paths exist or not.)
+
+Technical detail: Add a `quotaType` or `limitType: 'quota'` field in the Problem Details JSON extension so the UI can differentiate quota exhaustion from rate limiting and show appropriate messaging. The existing `limitType: 'tenant'` pattern in the codebase is the right model to follow.
+
+### (d) Progress bar thresholds
+
+**Three visual states:**
+
+| Range | Visual state | Rationale |
+|-------|-------------|-----------|
+| 0-79% | Default/neutral (the bar's accent color against a muted track) | Normal operation. No emotional signal needed. |
+| 80-94% | Warning (amber/yellow treatment) | Early warning. The 80% threshold is well-established in systems design (disk usage warnings, data plan alerts). It gives users enough runway to adjust behavior -- 20% remaining is meaningful enough to plan around. |
+| 95-100% | Critical (red treatment) | Urgent. At 95%, the user is essentially at the boundary. For a 50-capture free tier, 95% means 2-3 captures left. This is the "you're about to hit a wall" signal. |
+
+**Do not animate the bar or use pulsing/flashing for the warning states.** Color change alone is sufficient and respects calm technology principles. The bar should also show the numeric ratio as text (e.g., "42 / 50 captures") -- never rely on the visual bar alone (accessibility, and some users prefer numbers over spatial representations).
+
+For storage (GB), the same thresholds apply proportionally. Show storage in human-readable units (e.g., "1.2 GB / 5 GB") rather than raw bytes.
+
+### (e) Historical usage vs. current period only
+
+**Current period only for MVP.** Here is why:
+
+1. **JTBD analysis:** The job users hire a usage dashboard for is "understand whether I'm about to hit my limit." Historical data serves a different job -- "understand my usage trends over time" -- which is a billing/optimization concern, not an operational one. The operational job is what matters for quota enforcement.
+
+2. **Cognitive load:** Adding a historical dimension (month selector, trend charts, comparison views) significantly increases the interface complexity. The current D1 schema stores per-period rows, so historical data CAN be surfaced later, but this is a textbook case for progressive disclosure -- build the simple version, see if anyone asks for history.
+
+3. **Data availability:** New self-serve tenants (from Phase 0055) will have zero or one months of data. Showing an empty chart or a single data point is worse than showing nothing -- it signals incompleteness rather than intentional design.
+
+**Recommendation:** Show current-period usage only, with the period label displayed as "March 2026" (human-readable month name, not "2026-03"). If the quota resets monthly, showing the period label implicitly communicates the reset cadence without requiring a separate explanation.
+
+### (f) Tier naming and identity
+
+**Use "Starter" instead of "Free."**
+
+"Free" has three UX problems:
+
+1. **Negative connotation:** "Free tier" implies "the limited version" or "the one you're supposed to upgrade from." It frames the product relationship as transactional before monetization even exists.
+
+2. **Anchoring effect:** Showing "Free" to users anchors their perception of the product's value at zero. If WRL ever introduces paid tiers, users anchored on "free" will resist paying more strongly than users anchored on "starter."
+
+3. **No functional information:** "Free" tells the user nothing about what they get. "Starter" at least implies "this is where you begin" -- it's a stage, not a price.
+
+**How to display tier identity:**
+
+- In the Settings/Usage section, show the tier name once in a definition list row: "Plan: Starter". Keep it factual and unadorned. No badge, no upsell CTA (there's nothing to upsell to yet).
+- Do NOT show tier name in the nav bar, in the captures list, or on the submit form. Tier identity is account-level context, not per-interaction context.
+- In the 429 quota-exceeded error message, do NOT mention the tier name. "Monthly capture quota reached" is sufficient. Mentioning "Starter plan" in an error message feels like shaming the user for not paying.
+
+---
+
+## Proposed Tasks
+
+### Task 1: Define quota information architecture
+
+**What:** Document the exact quota data points to surface, where each appears, and the display rules (thresholds, conditional visibility, disabled states).
+
+**Deliverables:**
+- Information architecture specification covering: Settings/Usage card content, captures-list warning banner trigger rules, submit-button disabled state rules, 429 error message copy
+- Quota threshold table (0-79%, 80-94%, 95-100%) with visual state descriptions
+- Copy for all user-facing quota messages (banner text, error messages, disabled-state labels)
+
+**Dependencies:** Tier definitions with actual quota numbers (captures/month, storage GB per tier) -- these must be decided before UI copy can be finalized.
+
+### Task 2: Extend /auth/session response with quota data
+
+**What:** The UI boots from `/auth/session` (see `handleAuthSession` in `oauth.js`). The response already includes `user: { githubId, githubLogin, tenantId, tosAcceptedAt, tosVersion }`. This should be extended to include `tier` and optionally a summary usage snapshot, so the captures-list view can show/hide the warning banner without a separate API call.
+
+**Deliverables:**
+- Updated `/auth/session` response shape with `tier` field
+- New endpoint or extended session response that includes current-period usage summary (captureCount, captureLimit, storageBytes, storageLimit)
+- The captures-list banner needs this data at render time; if it requires a separate fetch, the UX degrades (flash of content, layout shift)
+
+**Dependencies:** Tier-to-limits mapping must be defined in the backend. Usage metering (R25) is already done.
+
+### Task 3: Design Usage section for Settings view
+
+**What:** Add a "Usage" card section to the Settings view, following the existing card-based pattern (Account card, API Keys card). Shows current-period usage with progress bars per metric, tier identity, and period label.
+
+**Deliverables:**
+- Usage card with: tier name row ("Plan: Starter"), period label ("March 2026"), captures progress bar with numeric label, storage progress bar with numeric label
+- Progress bars with three visual states per the threshold table
+- Accessible markup: progress bars should use `role="progressbar"` with `aria-valuenow`, `aria-valuemin`, `aria-valuemax`, and `aria-label`
+
+**Dependencies:** Task 2 (API endpoint for usage data), Task 1 (copy and thresholds)
+
+### Task 4: Implement contextual quota warning on captures list
+
+**What:** When usage exceeds 80% of captures/month quota, show a dismissible warning banner between the submit form and the captures list. Banner should not reappear after dismissal within the same session (use a module-level flag, not localStorage -- dismissal should not persist across reloads since the situation may change).
+
+**Deliverables:**
+- Warning banner element with close button
+- Conditional rendering based on usage data from boot (Task 2)
+- "View usage" link navigating to `#/settings`
+- At 100%: submit button disabled with "Monthly capture limit reached" label
+
+**Dependencies:** Task 2 (usage data available at boot), Task 1 (copy)
+
+### Task 5: Differentiate quota-exceeded 429 from rate-limit 429
+
+**What:** Ensure the API returns a distinguishable 429 response when the rejection reason is quota exhaustion rather than rate limiting. The UI already handles 429 responses generically in `apiFetch` (shows "Too many requests. Please wait N seconds..."). Quota exhaustion needs different copy because the wait isn't seconds -- it's until the next billing period.
+
+**Deliverables:**
+- Problem Details response with `limitType: 'quota'` (or similar) and human-readable `detail` including reset date
+- UI-side differentiation in `apiFetch` or in the submit form's error handler to show quota-specific messaging instead of rate-limit messaging
+- Copy: "Monthly capture limit reached. Your quota resets on {date}."
+
+**Dependencies:** Backend quota enforcement logic (not this minion's scope), Task 1 (error message copy)
+
+---
+
+## Risks and Concerns
+
+### Risk 1: Quota data staleness during a session
+
+The success criteria say "updates on page load (not real-time)." This is fine for the Settings/Usage dashboard, but introduces a subtle problem for the captures-list warning banner. If the user submits several captures after page load, the banner's threshold calculation becomes stale. The user might cross 80% without the banner appearing (low severity -- the 429 will still catch them) or the banner might show when they're no longer approaching the limit (very unlikely in the captures-up direction).
+
+**Mitigation:** On each successful capture submission (the `prependPendingItem` path), locally decrement the remaining quota count. This keeps the banner state approximately correct without requiring a re-fetch.
+
+### Risk 2: API-key auth users don't have session data
+
+The dual-auth model means API-key users (`_authMethod === 'apikey'`) don't have `_wrlUser` data and don't see the Settings view. They won't see the Usage dashboard or the captures-list warning banner. This is acceptable for MVP -- API-key users are the legacy path and can check usage via the admin API -- but it should be explicitly documented as a known gap.
+
+### Risk 3: Tier naming may need to change when monetization arrives
+
+"Starter" is a good default name, but when paid tiers are introduced, the naming taxonomy needs to be coherent (Starter / Pro / Business, or Starter / Growth / Enterprise, etc.). The tier name should come from the backend (the `tier` field in the API response), not be hardcoded in the UI, so it can evolve without frontend changes.
+
+### Risk 4: Progress bar accessibility
+
+Progress bars are notoriously difficult to make accessible. The bar must work for screen readers (ARIA progressbar role), for users who can't distinguish colors (numeric labels alongside the bar), and for users with low vision (sufficient contrast in all three visual states). The frontend-minion should validate against WCAG AA contrast ratios for all three bar states against both light backgrounds and potential dark mode.
+
+### Risk 5: "Starter" tier and zero-quota edge case
+
+If the system needs to support a "paused" or "suspended" state where quotas are zero, the UI must handle 0/0 gracefully. A progress bar at 0/0 is meaningless. In this case, show a text-only state ("Account paused" or similar) rather than a degenerate progress bar.
+
+---
+
+## Additional Agents Needed
+
+None. The current team composition (assuming backend, frontend, and testing specialists) is sufficient. The tasks above are split cleanly between:
+
+- **Backend/API:** Task 2 (session response), Task 5 (quota-specific 429)
+- **Frontend:** Task 3 (Usage card), Task 4 (warning banner)
+- **UX strategy (this contribution):** Task 1 (information architecture, copy, thresholds)
+
+One note: if the project has a **copy/content specialist**, the quota-related copy (error messages, banner text, tier labels) would benefit from a review pass. The copy I've suggested above is functional but hasn't been tested for tone consistency with the rest of the product. If no content specialist exists, the copy in Task 1 deliverables is ready to use.

--- a/docs/history/nefario-reports/2026-03-23-030747-tenant-quotas/phase3-synthesis.md
+++ b/docs/history/nefario-reports/2026-03-23-030747-tenant-quotas/phase3-synthesis.md
@@ -1,0 +1,1165 @@
+## Delegation Plan
+
+**Team name**: tenant-quotas
+**Description**: Implement per-tenant usage quotas (captures/month, storage GB) based on tier, with pre-capture enforcement, a self-serve usage dashboard in the web UI, and OpenAPI spec updates.
+
+### Task 1: D1 migration + quotas module
+- **Agent**: data-minion
+- **Delegation type**: standard
+- **Model**: sonnet
+- **Mode**: bypassPermissions
+- **Blocked by**: none
+- **Approval gate**: yes
+- **Gate reason**: The tier column schema and quota constant definitions are foundational -- every downstream task depends on them. Wrong schema choices are hard to reverse once code is built on top.
+- **Gate rationale**: |
+    Chosen: `tier` as a real column on the `tenants` table with app-layer validation; default quotas as a code constant in `src/quotas.js`; per-tenant overrides in `config.quotas` JSON
+    Over: (1) Tier stored inside `config` JSON blob -- rejected because tier is a core business attribute needing indexed queries, not optional config. (2) Default quotas stored in D1 -- rejected because they change with code releases and should deploy atomically with the code that uses them. (3) Separate `quota_overrides` table -- rejected because overrides are rare and config JSON already follows this pattern for rate limits.
+    Why: Maximizes consistency with existing patterns (rate-limits.js constants, config JSON overrides), avoids unnecessary schema complexity, and keeps the hot-path query simple.
+- **Prompt**: |
+    You are implementing the data layer for tenant quotas in the WRL (Web Resource Ledger) Cloudflare Worker.
+
+    ## Context
+
+    WRL is a Cloudflare Worker that captures web pages. It uses D1 (edge SQLite) for metadata. Tenants are identified by IDs like `gh-12345`. The existing schema has:
+    - `tenants` table with columns: `id TEXT PRIMARY KEY`, `config TEXT` (nullable JSON), `created_at`, `updated_at`, `updated_by`
+    - `usage_counters` table with `(tenant_id, period)` composite PK, columns: `capture_count`, `storage_bytes`, `api_call_count`, `updated_at`
+    - Rate limit overrides stored in `tenants.config` JSON as `{ rateLimit: { capture: { limit: N, period: N } } }`
+    - Default rate limits defined as code constants in `src/rate-limits.js` with `RATE_LIMITS` map and `getEffectiveLimit(tenantConfig, group)` function
+
+    The existing `getTenantConfig()` in `src/db.js` (line 252) reads `SELECT config FROM tenants WHERE id = ?`. The existing `getUsage()` in `src/db.js` (line 701) reads usage counters by `(tenant_id, period)`. The `computePeriod()` function (line 658) returns `'YYYY-MM'` format.
+
+    The existing migration files are in `migrations/` numbered 0001-0004.
+
+    ## What to build
+
+    ### 1. Migration file: `migrations/0005_tenant_tiers.sql`
+
+    ```sql
+    ALTER TABLE tenants ADD COLUMN tier TEXT NOT NULL DEFAULT 'free';
+    ```
+
+    Note: SQLite/D1 does NOT support CHECK constraints in ALTER TABLE ADD COLUMN. Validation of allowed values ('free', 'pro') must happen at the application layer.
+
+    ### 2. New module: `src/quotas.js`
+
+    Create a module following the exact pattern of `src/rate-limits.js`. It should export:
+
+    **Constants:**
+    ```js
+    export const TIER_QUOTAS = {
+      free: { capturesPerMonth: 100, storageBytes: 1 * 1024 * 1024 * 1024 },   // 1 GB
+      pro:  { capturesPerMonth: 5000, storageBytes: 50 * 1024 * 1024 * 1024 },  // 50 GB
+    };
+
+    export const DEFAULT_TIER = 'free';
+
+    // UI display names -- internal code uses 'free'/'pro', UI shows these
+    export const TIER_DISPLAY_NAMES = {
+      free: 'Starter',
+      pro: 'Pro',
+    };
+    ```
+
+    **Functions:**
+
+    `getEffectiveQuota(tier, tenantConfig)` -- returns the effective quota for a tenant by merging tier defaults with any per-tenant overrides from `tenantConfig.quotas`. Pattern mirrors `getEffectiveLimit()` in rate-limits.js.
+
+    ```js
+    export function getEffectiveQuota(tier, tenantConfig) {
+      const defaults = TIER_QUOTAS[tier] || TIER_QUOTAS[DEFAULT_TIER];
+      if (!tenantConfig?.quotas) return { ...defaults };
+      return {
+        capturesPerMonth: tenantConfig.quotas.capturesPerMonth ?? defaults.capturesPerMonth,
+        storageBytes: tenantConfig.quotas.storageBytes ?? defaults.storageBytes,
+      };
+    }
+    ```
+
+    `checkQuota(db, tenantId, count = 1)` -- performs a single D1 batch read (two prepared statements in one round-trip) to get tenant tier+config and current period usage, then checks whether the capture would exceed quota. Returns a result object.
+
+    Implementation:
+    ```js
+    export async function checkQuota(db, tenantId, count = 1) {
+      const period = computePeriod();
+      const [tenantResult, usageResult] = await db.batch([
+        db.prepare('SELECT tier, config FROM tenants WHERE id = ?').bind(tenantId),
+        db.prepare(
+          'SELECT capture_count, storage_bytes FROM usage_counters WHERE tenant_id = ? AND period = ?'
+        ).bind(tenantId, period),
+      ]);
+
+      const tenant = tenantResult.results?.[0];
+      if (!tenant) return { allowed: false, reason: 'tenant_not_found' };
+
+      const tier = tenant.tier || DEFAULT_TIER;
+      const config = tenant.config ? JSON.parse(tenant.config) : null;
+      const quota = getEffectiveQuota(tier, config);
+
+      const usage = usageResult.results?.[0];
+      const captureCount = usage?.capture_count ?? 0;
+      const storageBytes = usage?.storage_bytes ?? 0;
+
+      if (captureCount + count > quota.capturesPerMonth) {
+        // Compute reset date: first of next month
+        const now = new Date();
+        const resetsAt = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1)).toISOString();
+        return {
+          allowed: false,
+          reason: 'capture_limit',
+          limit: quota.capturesPerMonth,
+          used: captureCount,
+          requested: count,
+          resetsAt,
+          period,
+        };
+      }
+
+      if (storageBytes >= quota.storageBytes) {
+        const now = new Date();
+        const resetsAt = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1)).toISOString();
+        return {
+          allowed: false,
+          reason: 'storage_limit',
+          limit: quota.storageBytes,
+          used: storageBytes,
+          resetsAt,
+          period,
+        };
+      }
+
+      return {
+        allowed: true,
+        quota,
+        captureCount,
+        storageBytes,
+        tier,
+        period,
+      };
+    }
+    ```
+
+    Import `computePeriod` from `./db.js`.
+
+    Key design decisions:
+    - Use `db.batch()` with two prepared statements (same pattern as `listCaptures` in db.js) for a single D1 round-trip
+    - For capture count, check `captureCount + count > quota` (not `>=`) to support batch checks where `count` may be > 1
+    - For storage, check `>= quota` (current storage already at/over limit -- we can't predict new capture size)
+    - Gracefully handle missing usage_counters row (default to 0) and missing tenant row
+
+    ### 3. Update `setTenantConfig` in `src/db.js`
+
+    Add validation for `config.quotas` fields, following the existing `config.rateLimit` validation pattern (line 277-286 of db.js):
+
+    ```js
+    // After the existing rateLimit validation block:
+    if (config.quotas) {
+      if (config.quotas.capturesPerMonth !== undefined) {
+        if (typeof config.quotas.capturesPerMonth !== 'number' ||
+            config.quotas.capturesPerMonth < 1 ||
+            !Number.isInteger(config.quotas.capturesPerMonth)) {
+          throw new Error('quotas.capturesPerMonth must be a positive integer');
+        }
+      }
+      if (config.quotas.storageBytes !== undefined) {
+        if (typeof config.quotas.storageBytes !== 'number' ||
+            config.quotas.storageBytes < 1 ||
+            !Number.isInteger(config.quotas.storageBytes)) {
+          throw new Error('quotas.storageBytes must be a positive integer');
+        }
+      }
+    }
+    ```
+
+    ### 4. Add `setTenantTier` function in `src/db.js`
+
+    ```js
+    const VALID_TIERS = ['free', 'pro'];
+
+    export async function setTenantTier(db, tenantId, tier, updatedBy) {
+      if (!TENANT_ID_RE.test(tenantId)) {
+        throw new Error(`Invalid tenantId: ${tenantId}`);
+      }
+      if (!VALID_TIERS.includes(tier)) {
+        throw new Error(`Invalid tier '${tier}'; must be one of: ${VALID_TIERS.join(', ')}`);
+      }
+      const updatedAt = new Date().toISOString();
+      await db.prepare(
+        `UPDATE tenants SET tier = ?, updated_at = ?, updated_by = ? WHERE id = ?`
+      ).bind(tier, updatedAt, updatedBy, tenantId).run();
+    }
+    ```
+
+    Also export `VALID_TIERS` for use by admin handlers.
+
+    ### 5. Update `getTenantConfig` in `src/db.js`
+
+    The existing function reads `SELECT config FROM tenants WHERE id = ?`. It does NOT need to change -- the quota check uses its own batch query that reads `tier, config` together with usage. Keep `getTenantConfig` unchanged to avoid breaking existing rate-limit callers. The quota module handles its own data access.
+
+    ## What NOT to do
+
+    - Do NOT modify `src/index.js` -- the capture pipeline integration is a separate task
+    - Do NOT create admin API endpoints for tier management -- separate task
+    - Do NOT modify the UI -- separate task
+    - Do NOT add KV caching -- YAGNI (D1 PK lookup is sub-2ms, well within 10ms budget)
+    - Do NOT add a CHECK constraint in the migration SQL -- SQLite/D1 ALTER TABLE doesn't support it
+    - Do NOT add a separate `quota_overrides` table -- use config JSON
+
+    ## Files to create/modify
+
+    - CREATE: `migrations/0005_tenant_tiers.sql`
+    - CREATE: `src/quotas.js`
+    - MODIFY: `src/db.js` (add `setTenantTier`, `VALID_TIERS` export; add quotas validation in `setTenantConfig`)
+
+    ## Tests
+
+    Create `test/quotas.test.js` with tests for:
+    - `getEffectiveQuota` returns tier defaults when no config overrides
+    - `getEffectiveQuota` merges per-tenant overrides with tier defaults
+    - `getEffectiveQuota` falls back to free tier for unknown tier names
+    - `checkQuota` returns allowed:true when under limits
+    - `checkQuota` returns allowed:false with capture_limit reason when at/over captures
+    - `checkQuota` returns allowed:false with storage_limit reason when at/over storage
+    - `checkQuota` handles missing usage_counters row (defaults to 0)
+    - `checkQuota` handles missing tenant row (returns tenant_not_found)
+    - `checkQuota` respects count parameter for batch checks (e.g., count=5 when 97/100 used)
+    - `checkQuota` returns correct resetsAt (first of next month)
+
+    Update `test/db.test.js` with tests for:
+    - `setTenantConfig` validates quotas.capturesPerMonth (must be positive integer)
+    - `setTenantConfig` validates quotas.storageBytes (must be positive integer)
+    - `setTenantConfig` accepts valid quota overrides
+    - `setTenantTier` validates tier values (rejects invalid, accepts 'free' and 'pro')
+    - `setTenantTier` updates the tier column
+
+    Follow the existing test patterns in `test/db.test.js` -- use the same miniflare/D1 setup, import `applyMigrations` from `test/apply-migrations.js`.
+
+    Include the `// tva` comment near the top of `src/quotas.js`.
+
+- **Deliverables**: `migrations/0005_tenant_tiers.sql`, `src/quotas.js`, updated `src/db.js`, `test/quotas.test.js`, updated `test/db.test.js`
+- **Success criteria**: Migration applies cleanly; `getEffectiveQuota` resolves tier defaults and overrides; `checkQuota` returns correct allow/deny decisions; `setTenantTier` validates and updates; all new tests pass
+
+### Task 2: Quota check in capture pipeline + 429 response
+- **Agent**: api-design-minion
+- **Delegation type**: standard
+- **Model**: sonnet
+- **Mode**: bypassPermissions
+- **Blocked by**: Task 1
+- **Approval gate**: yes
+- **Gate reason**: This wires the quota check into the critical capture request path. The insertion point, response format, and batch semantics affect every API consumer. Getting the 429 response shape wrong breaks SDK clients.
+- **Gate rationale**: |
+    Chosen: Insert quota check after rate limit (step 3) and before body parsing (step 4) in handleCreateCapture; after rate limit (step 5) and before per-URL loop (step 7) in handleBatchCapture; use existing `problemResponse(429, ..., headers, { limitType: 'quota', quota: {...} })` pattern; reject entire batch when quota insufficient
+    Over: (1) Quota check in queue consumer only -- rejected because user gets 202 then silent failure. (2) Partial batch acceptance on quota -- rejected because quota is a budget concept and partial acceptance creates confusing accounting. (3) Separate 429 response type -- rejected because `limitType` discriminator on existing ProblemDetail is cleaner and backward-compatible.
+    Why: Fail-fast before expensive work (D1 writes, queue dispatch); consistent with existing rate-limit response patterns; batch full-rejection is simpler and matches API design principles.
+- **Prompt**: |
+    You are wiring the quota check into the WRL capture pipeline and defining the 429 quota-exceeded response.
+
+    ## Context
+
+    WRL is a Cloudflare Worker (`src/index.js`). The capture pipeline in `handleCreateCapture` (line 534) follows these steps:
+    1. Content-Type check
+    2. Auth check (`verifyApiKey`) -- yields `tenantId`
+    3. Usage increment (`incrementUsage` via `ctx.waitUntil`)
+    4. Rate limit check (`checkCaptureRateLimit`)
+    5. Global capacity check
+    6. Parse JSON body
+    7. Validate url field
+    8. URL validation (SSRF)
+    9. Generate capture ID
+    10. Write D1 record
+    11. Queue dispatch
+    12. Return 202
+
+    The batch endpoint `handleBatchCapture` (line 684) follows a similar pattern but parses the body first (needs batch size for rate limit check).
+
+    Task 1 created `src/quotas.js` with:
+    - `checkQuota(db, tenantId, count = 1)` returns `{ allowed: true, quota, captureCount, storageBytes, tier, period }` or `{ allowed: false, reason, limit, used, requested, resetsAt, period }`
+    - `TIER_QUOTAS`, `DEFAULT_TIER`, `TIER_DISPLAY_NAMES` constants
+    - `getEffectiveQuota(tier, tenantConfig)` function
+
+    The existing 429 rate-limit response uses `problemResponse(429, detail, headers, { limitType: 'tenant' })` -- see `src/index.js` line 573. The `problemResponse` function (in `src/responses.js`) creates RFC 9457 Problem Detail responses with `...extra` spread.
+
+    ## What to build
+
+    ### 1. Import `checkQuota` in `src/index.js`
+
+    Add to the imports at the top:
+    ```js
+    import { checkQuota } from './quotas.js';
+    ```
+
+    ### 2. Insert quota check in `handleCreateCapture`
+
+    After the rate limit check (after line 577 where `rl.writePromise` is handled and `rlHeaders` are built) and BEFORE the global rate limit check (step 5, line 586), add the quota check:
+
+    ```js
+    // Step 3b: Monthly quota check
+    const quotaCheck = await checkQuota(env.DB, tenantId);
+    if (!quotaCheck.allowed) {
+      ctx.waitUntil(log(env, 4, 'security', {
+        event: 'security.quota_exceeded',
+        tenantId, keyName, keyHashPrefix, authMethod,
+        reason: quotaCheck.reason,
+        limit: quotaCheck.limit,
+        used: quotaCheck.used,
+        responseStatus: 429,
+        cip,
+      }) ?? Promise.resolve());
+
+      const retryAfterDate = new Date(quotaCheck.resetsAt).toUTCString();
+      const quotaHeaders = {
+        'Retry-After': retryAfterDate,
+        ...rlHeaders,
+      };
+      const detail = quotaCheck.reason === 'capture_limit'
+        ? `Monthly capture quota reached (${quotaCheck.used}/${quotaCheck.limit}). Resets ${quotaCheck.resetsAt}.`
+        : `Storage quota reached. Resets ${quotaCheck.resetsAt}.`;
+
+      return problemResponse(429, detail, quotaHeaders, {
+        limitType: 'quota',
+        quota: {
+          limit: quotaCheck.limit,
+          used: quotaCheck.used,
+          resource: quotaCheck.reason === 'capture_limit' ? 'captures' : 'storage',
+          resetsAt: quotaCheck.resetsAt,
+        },
+      });
+    }
+    ```
+
+    Note on `Retry-After`: Use HTTP-date format (RFC 9110) for quota responses, not seconds. Rate limits reset in seconds; quotas reset at calendar boundaries. The HTTP-date format is more meaningful.
+
+    ### 3. Add `X-Quota-*` headers on successful 202 responses
+
+    After the quota check passes, build quota headers. Add them to the 202 response:
+
+    ```js
+    // Build quota info headers for successful responses
+    const quotaHeaders = {};
+    if (quotaCheck.allowed) {
+      quotaHeaders['X-Quota-Limit'] = String(quotaCheck.quota.capturesPerMonth);
+      quotaHeaders['X-Quota-Used'] = String(quotaCheck.captureCount);
+      quotaHeaders['X-Quota-Remaining'] = String(Math.max(0, quotaCheck.quota.capturesPerMonth - quotaCheck.captureCount));
+    }
+    ```
+
+    Then merge `quotaHeaders` into the 202 response headers alongside `rlHeaders`.
+
+    ### 4. Insert quota check in `handleBatchCapture`
+
+    After the rate limit check (step 5, line 732) and after `rlHeaders` are built (line 755), add the quota check with the batch count:
+
+    ```js
+    // Step 5b: Monthly quota check (entire batch)
+    const quotaCheck = await checkQuota(env.DB, tenantId, body.urls.length);
+    if (!quotaCheck.allowed) {
+      ctx.waitUntil(log(env, 4, 'security', {
+        event: 'security.quota_exceeded',
+        tenantId, keyName, keyHashPrefix, authMethod,
+        reason: quotaCheck.reason,
+        limit: quotaCheck.limit,
+        used: quotaCheck.used,
+        requested: body.urls.length,
+        responseStatus: 429,
+        cip,
+      }) ?? Promise.resolve());
+
+      const retryAfterDate = new Date(quotaCheck.resetsAt).toUTCString();
+      const quotaHeaders = {
+        'Retry-After': retryAfterDate,
+        ...rlHeaders,
+      };
+      const detail = quotaCheck.reason === 'capture_limit'
+        ? `Batch of ${body.urls.length} captures would exceed monthly quota (${quotaCheck.used}/${quotaCheck.limit}). Resets ${quotaCheck.resetsAt}.`
+        : `Storage quota reached. Resets ${quotaCheck.resetsAt}.`;
+
+      return problemResponse(429, detail, quotaHeaders, {
+        limitType: 'quota',
+        quota: {
+          limit: quotaCheck.limit,
+          used: quotaCheck.used,
+          requested: body.urls.length,
+          resource: quotaCheck.reason === 'capture_limit' ? 'captures' : 'storage',
+          resetsAt: quotaCheck.resetsAt,
+        },
+      });
+    }
+    ```
+
+    The batch endpoint rejects the ENTIRE batch when quota is insufficient (not partial acceptance). This is consistent with how quota is a budget concept -- partial batch acceptance makes accounting confusing.
+
+    ### 5. Add `X-Quota-*` headers on batch 207 response
+
+    Same pattern as single capture -- merge quota headers into the batch 207 response.
+
+    ## Important implementation notes
+
+    - The quota check placement is: after auth, after rate limit, BEFORE body parsing (single) or BEFORE per-URL loop (batch). This order ensures:
+      - tenantId is available (from auth)
+      - Rate limit fires first (cheaper -- KV check vs D1 query)
+      - Quota check avoids unnecessary work on requests that will be rejected
+    - Do NOT add a quota check to the queue consumer (`handleCaptureMessage`). The spec says "before browser session creation" which means the HTTP handler. The queue consumer already has the 202 accepted -- failing silently there would violate fail-loudly principles.
+    - Do NOT add quota headers to non-capture endpoints (verify, admin, etc.) -- quotas apply only to capture operations
+    - Do NOT modify `src/responses.js` -- the existing `problemResponse` with `extra` spread already supports the response shape
+    - Do NOT modify `src/quotas.js` or `src/db.js` -- those were built in Task 1
+
+    ## Files to modify
+
+    - MODIFY: `src/index.js` (import checkQuota; add quota check to handleCreateCapture and handleBatchCapture; add X-Quota-* headers to successful responses)
+
+    ## Tests
+
+    Update `test/capture-integration.test.js` (or the most relevant capture test file) with:
+    - Capture request at quota returns 429 with `limitType: 'quota'` and `quota` object
+    - Capture request under quota returns 202 with `X-Quota-*` headers
+    - Batch capture where batch size exceeds remaining quota returns 429 (whole-batch rejection)
+    - Batch capture under quota returns 207 with `X-Quota-*` headers
+    - Quota check runs after rate limit (verify ordering by testing a request that's both rate-limited and over-quota -- should get rate limit 429, not quota 429)
+    - Storage quota exceeded returns 429 with `resource: 'storage'`
+
+    Follow existing test patterns. The test fixtures in `test/fixtures.js` can be extended if needed.
+
+- **Deliverables**: Updated `src/index.js` with quota checks in both capture handlers; tests for pipeline integration
+- **Success criteria**: Captures at/over quota return 429 with correct response shape; captures under quota return 202 with X-Quota headers; batch captures check quota upfront for the entire batch; quota check adds <10ms latency (single D1 batch)
+
+### Task 3: GET /v1/account/usage endpoint
+- **Agent**: api-design-minion
+- **Delegation type**: standard
+- **Model**: sonnet
+- **Mode**: bypassPermissions
+- **Blocked by**: Task 1
+- **Approval gate**: no
+- **Prompt**: |
+    You are implementing the `GET /v1/account/usage` endpoint for tenant self-serve usage checking.
+
+    ## Context
+
+    WRL is a Cloudflare Worker. The `/v1/account/*` namespace is session-gated (authenticated via `__Host-wrl_session` cookie). The router in `src/index.js` (line 170-220) verifies the session and attaches it to `env._session` before calling account handlers.
+
+    Existing account handlers live in `src/account.js`. They follow a consistent pattern:
+    - Read `tenantId` from `env._session.tenantId`
+    - Set `Cache-Control: private, no-store` via the `ACCOUNT_CACHE` constant
+    - Log events with `ctx.waitUntil(log(...))`
+    - Return `jsonResponse(body, status, ACCOUNT_CACHE)`
+
+    The `getUsage()` function in `src/db.js` (line 701) reads `usage_counters` by `(tenant_id, period)` and returns `{ tenantId, period, captureCount, storageBytes, apiCallCount, updatedAt }`.
+
+    The `computePeriod()` function in `src/db.js` (line 658) returns the current `'YYYY-MM'` period string.
+
+    Task 1 created `src/quotas.js` with:
+    - `TIER_QUOTAS` -- map of tier defaults `{ free: { capturesPerMonth, storageBytes }, pro: {...} }`
+    - `TIER_DISPLAY_NAMES` -- map of `{ free: 'Starter', pro: 'Pro' }`
+    - `getEffectiveQuota(tier, tenantConfig)` -- resolves effective quota from tier + config overrides
+    - `DEFAULT_TIER` -- 'free'
+
+    The `getTenantConfig()` function in `src/db.js` reads `SELECT config FROM tenants WHERE id = ?`.
+
+    ## What to build
+
+    ### 1. Add `handleAccountGetUsage` in `src/account.js`
+
+    ```js
+    export async function handleAccountGetUsage(request, env, ctx, _match) {
+      const clientIp = request.headers.get('CF-Connecting-IP') || 'unknown';
+      const cip = await computeCip(env, clientIp);
+      const { tenantId } = env._session;
+
+      const period = computePeriod();
+
+      // Batch read: tenant row (for tier + config) and usage counters
+      const [tenantResult, usageResult] = await env.DB.batch([
+        env.DB.prepare('SELECT tier, config FROM tenants WHERE id = ?').bind(tenantId),
+        env.DB.prepare(
+          'SELECT capture_count, storage_bytes FROM usage_counters WHERE tenant_id = ? AND period = ?'
+        ).bind(tenantId, period),
+      ]);
+
+      const tenantRow = tenantResult.results?.[0];
+      const tier = tenantRow?.tier || DEFAULT_TIER;
+      const config = tenantRow?.config ? JSON.parse(tenantRow.config) : null;
+      const quota = getEffectiveQuota(tier, config);
+
+      const usage = usageResult.results?.[0];
+      const captureCount = usage?.capture_count ?? 0;
+      const storageBytes = usage?.storage_bytes ?? 0;
+
+      // Compute reset date: first of next month
+      const now = new Date();
+      const resetsAt = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1)).toISOString();
+
+      ctx.waitUntil(log(env, 3, 'oauth', {
+        event: 'oauth.usage_view',
+        cip,
+        tenantId,
+        authMethod: 'session',
+        responseStatus: 200,
+      }) ?? Promise.resolve());
+
+      return jsonResponse({
+        tenantId,
+        period,
+        tierDisplay: TIER_DISPLAY_NAMES[tier] || TIER_DISPLAY_NAMES[DEFAULT_TIER],
+        captures: {
+          used: captureCount,
+          limit: quota.capturesPerMonth,
+          remaining: Math.max(0, quota.capturesPerMonth - captureCount),
+        },
+        storageBytes: {
+          used: storageBytes,
+          limit: quota.storageBytes,
+          remaining: Math.max(0, quota.storageBytes - storageBytes),
+        },
+        resetsAt,
+      }, 200, ACCOUNT_CACHE);
+    }
+    ```
+
+    Import `computePeriod` from `./db.js` and `getEffectiveQuota, TIER_DISPLAY_NAMES, DEFAULT_TIER` from `./quotas.js`.
+
+    Key decisions:
+    - Response includes `tierDisplay` (e.g., "Starter") -- NOT the internal tier name. The UI shows the display name; the internal value stays hidden.
+    - `remaining` is computed server-side to avoid client math errors
+    - `resetsAt` is an ISO 8601 timestamp for the first day of the next month
+    - Uses a D1 batch (same pattern as checkQuota) for single round-trip
+    - Cache-Control: `private, no-store` (usage data is tenant-specific, should not be cached by intermediaries)
+
+    ### 2. Register the route in `src/index.js`
+
+    Add the route tuple to the `routes` array, in the account routes section (after line 63):
+    ```js
+    ['GET',    /^\/v1\/account\/usage$/, handleAccountGetUsage],
+    ```
+
+    Add to the import from `./account.js`:
+    ```js
+    import { handleAccountListKeys, handleAccountCreateKey, handleAccountRevokeKey, handleAccountAcceptTos, handleAccountGetUsage } from './account.js';
+    ```
+
+    ### 3. Support API key auth for usage endpoint
+
+    The account routes currently require session auth. However, API key users should also be able to check their own usage. Check how the session gate works in the router (around line 170-220 of index.js). If the route is session-only, that's fine for MVP -- API key users can use `GET /v1/admin/usage` with the admin key. But note this in a comment.
+
+    Actually, looking at the router: account routes are gated by `verifySession`. API key auth goes through `verifyApiKey`. These are separate auth paths. For MVP, the usage endpoint should be session-only (consistent with all other `/v1/account/*` routes). Do NOT add API key auth to this endpoint -- it would break the security invariant that account routes are session-scoped.
+
+    ## What NOT to do
+
+    - Do NOT expose the internal tier name ('free', 'pro') in the response -- use `tierDisplay` with the display name ('Starter', 'Pro')
+    - Do NOT modify `src/quotas.js` or `src/db.js` -- Task 1 owns those
+    - Do NOT add historical usage (multi-period) -- current period only for MVP
+    - Do NOT add this to the `/auth/session` response -- keep the boot payload lightweight
+    - Do NOT add a `?tenant=` parameter -- always scoped to the authenticated tenant
+
+    ## Files to modify
+
+    - MODIFY: `src/account.js` (add `handleAccountGetUsage` handler, add imports)
+    - MODIFY: `src/index.js` (add route tuple, add import)
+
+    ## Tests
+
+    Add tests for the new endpoint. Can go in a new `test/account-usage.test.js` or extend an existing account test file:
+    - Authenticated session returns 200 with correct response shape
+    - Response includes `tierDisplay`, `captures`, `storageBytes`, `resetsAt`
+    - `remaining` is correctly computed (limit - used, minimum 0)
+    - Tenant with zero usage returns 0 for all used fields
+    - Unauthenticated request returns 401
+
+- **Deliverables**: `handleAccountGetUsage` handler in `src/account.js`, route registration in `src/index.js`, tests
+- **Success criteria**: `GET /v1/account/usage` returns current period usage with effective quota limits; response includes `tierDisplay`, `captures`, `storageBytes`, and `resetsAt`; session-gated with correct cache headers
+
+### Task 4: Web UI usage dashboard
+- **Agent**: frontend-minion
+- **Delegation type**: standard
+- **Model**: sonnet
+- **Mode**: bypassPermissions
+- **Blocked by**: Task 3
+- **Approval gate**: no
+- **Prompt**: |
+    You are adding a Usage section to the WRL web UI settings view.
+
+    ## Context
+
+    WRL has a single-page web UI served as an inline HTML document. The UI is built with vanilla JS -- no frameworks. All JS is stored as template literal string constants in `src/ui/ui-*.js` files, embedded into the HTML shell.
+
+    The settings view is in `src/ui/ui-settings.js`. It follows a card-based section pattern:
+    - Account info card (GitHub username, Tenant ID, Member since)
+    - API Keys card (list + create form)
+
+    The mount flow:
+    1. `renderSettings()` creates the skeleton (heading + loading placeholder)
+    2. `mountSettings()` fetches data and calls `buildSettingsContent(view, accountData, keysData)`
+    3. `buildSettingsContent` builds the Account section and API Keys section
+
+    CSS is in `src/ui/ui-css.js` as a string constant `UI_CSS`. Design tokens (CSS custom properties) are in `src/ui/design-system.css`.
+
+    The user object `_wrlUser` is populated at boot from `/auth/session`. It has `{ githubId, githubLogin, tenantId, tosAcceptedAt, tosVersion }` -- note: `createdAt` is referenced in code but NOT present in the session response (pre-existing bug, not your concern).
+
+    Task 3 created `GET /v1/account/usage` which returns:
+    ```json
+    {
+      "tenantId": "gh-12345",
+      "period": "2026-03",
+      "tierDisplay": "Starter",
+      "captures": { "used": 42, "limit": 100, "remaining": 58 },
+      "storageBytes": { "used": 524288000, "limit": 1073741824, "remaining": 549453824 },
+      "resetsAt": "2026-04-01T00:00:00.000Z"
+    }
+    ```
+
+    The `apiFetch` function is globally available and handles auth redirects.
+
+    ## What to build
+
+    ### 1. Modify `mountSettings()` to fetch usage data
+
+    Change `mountSettings()` to make TWO parallel fetches:
+    ```js
+    Promise.all([
+      apiFetch('/v1/account/keys', { credentials: 'same-origin' }),
+      apiFetch('/v1/account/usage', { credentials: 'same-origin' })
+    ]).then(function(responses) {
+      var keysRes = responses[0];
+      var usageRes = responses[1];
+      // ... handle both responses
+    })
+    ```
+
+    If the usage fetch fails, still render settings (keys section) -- usage failure should not block the entire view. Show an inline error in the usage card: "Could not load usage data."
+
+    ### 2. Add Usage section to `buildSettingsContent`
+
+    Insert a new "Usage" card section BETWEEN the Account section and the API Keys section. The card layout:
+
+    ```
+    +-----------------------------------------------+
+    | Usage                          March 2026      |
+    |                                                |
+    | Captures          42 of 100                    |
+    | [========------------------------------] 42%   |
+    |                                                |
+    | Storage           524 MB of 1 GB               |
+    | [============================---------] 51%    |
+    |                                                |
+    | Plan: Starter       Resets Apr 1, 2026         |
+    +-----------------------------------------------+
+    ```
+
+    Implementation:
+    - Create a `<section class="settings-section card">` with heading "Usage"
+    - Show period label as human-readable month (e.g., "March 2026") -- format from the `period` field ("2026-03")
+    - For each metric (captures, storage), render:
+      - A label row with metric name and "N of M" text
+      - A progress bar using `role="progressbar"` with ARIA attributes
+    - Progress bar is two nested divs: `.usage-bar` (track) and `.usage-bar-fill` (fill)
+    - Fill width set via inline style `width: NN%` (clamped 0-100)
+    - Three visual states based on percentage:
+      - 0-79%: default (uses `--color-accent`)
+      - 80-94%: warning class `.usage-bar-fill--warning` (uses `--color-warning`)
+      - 95-100%: critical class `.usage-bar-fill--critical` (uses `--color-error`)
+    - Show tier display name and reset date at the bottom
+    - Storage bytes formatted as human-readable: implement a `formatBytes(n)` helper using SI units (1000-based: KB, MB, GB)
+
+    ### 3. Progress bar HTML structure
+
+    For each metric:
+    ```html
+    <div class="usage-metric">
+      <div class="usage-metric-header">
+        <span class="usage-metric-label">Captures</span>
+        <span class="usage-metric-value">42 of 100</span>
+      </div>
+      <div class="usage-bar" role="progressbar"
+           aria-valuenow="42" aria-valuemin="0" aria-valuemax="100"
+           aria-label="42 of 100 captures used this month">
+        <div class="usage-bar-fill" style="width: 42%"></div>
+      </div>
+    </div>
+    ```
+
+    Note: Build all DOM elements with `document.createElement()` -- this is the project convention. Do NOT use `innerHTML` for content that includes any data from the API.
+
+    ### 4. ARIA and accessibility
+
+    - Each progress bar must have `role="progressbar"` with `aria-valuenow`, `aria-valuemin`, `aria-valuemax`
+    - `aria-label` with human-readable text: "42 of 100 captures used this month" / "524 MB of 1 GB storage used this month"
+    - When usage data loads, announce via the existing settings live region: `settingsAnnounce('Usage data loaded.')`
+    - The threshold color change alone is not sufficient -- the numeric "N of M" text beside the bar provides the same information non-visually
+
+    ### 5. Add CSS to `src/ui/ui-css.js`
+
+    Add these styles to the `UI_CSS` string:
+
+    ```css
+    /* Usage section */
+    .usage-metric { margin-bottom: var(--space-4); }
+    .usage-metric:last-child { margin-bottom: 0; }
+    .usage-metric-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: baseline;
+      margin-bottom: var(--space-1);
+    }
+    .usage-metric-label {
+      font-size: var(--text-sm);
+      font-weight: 500;
+      color: var(--color-text-muted);
+    }
+    .usage-metric-value {
+      font-size: var(--text-sm);
+      font-variant-numeric: tabular-nums;
+      color: var(--color-text);
+    }
+    .usage-bar {
+      height: 8px;
+      background: var(--color-surface-muted);
+      border-radius: var(--radius-sm);
+      overflow: hidden;
+      border: 1px solid var(--color-border-subtle);
+    }
+    .usage-bar-fill {
+      height: 100%;
+      background: var(--color-accent);
+      border-radius: var(--radius-sm);
+      transition: width 0.2s ease;
+      min-width: 0;
+    }
+    .usage-bar-fill--warning { background: var(--color-warning); }
+    .usage-bar-fill--critical { background: var(--color-error); }
+    .usage-footer {
+      display: flex;
+      justify-content: space-between;
+      margin-top: var(--space-3);
+      font-size: var(--text-sm);
+      color: var(--color-text-muted);
+    }
+    ```
+
+    ### 6. Error and edge-case handling
+
+    - **Usage fetch fails**: Show an inline error within the usage card ("Could not load usage data.") -- do not block keys section from rendering
+    - **Zero usage**: Show bars at 0% with "0 of N" text. Do NOT hide the section.
+    - **Usage data loading**: Show "Loading usage..." placeholder inside the usage card while the fetch is in progress (can be a simple text node, replaced when data arrives)
+
+    ### 7. Handle quota-exceeded 429 in capture submit form
+
+    In the captures view (the existing submit form error handler), check for `limitType: 'quota'` in the 429 response body. If present, show a quota-specific error message instead of the generic rate-limit message:
+
+    The existing error handling in `apiFetch` or in the submit form shows "Too many requests. Please wait N seconds..." for 429s. For quota 429s, the message should be: "Monthly capture limit reached. Your quota resets on {date}."
+
+    Check how the submit form error is displayed -- look at `ui-captures.js` for the error handling pattern. Add a check: if `res.status === 429`, parse the body and check for `limitType === 'quota'`. If so, use the quota-specific message. Otherwise fall through to the existing rate-limit message.
+
+    ## What NOT to do
+
+    - Do NOT create a separate `#/usage` route -- the usage section goes inside `#/settings`
+    - Do NOT add a warning banner to the captures list view -- that's future scope, not part of this task
+    - Do NOT disable the submit button when over quota -- just show the 429 error message when it happens
+    - Do NOT add historical period navigation -- current period only
+    - Do NOT add upgrade/upsell CTAs -- there's no upgrade path yet
+    - Do NOT fix the `_wrlUser.createdAt` bug -- that's a pre-existing issue, separate fix
+    - Do NOT use frameworks (React, etc.) or `<progress>` elements -- vanilla JS with div-based progress bars
+    - Do NOT add quota info to the nav bar or captures list -- settings only
+
+    ## Files to modify
+
+    - MODIFY: `src/ui/ui-settings.js` (add usage section to buildSettingsContent, modify mountSettings for parallel fetch, add formatBytes helper, add progress bar builder)
+    - MODIFY: `src/ui/ui-css.js` (add usage bar CSS)
+    - MODIFY: `src/ui/ui-captures.js` (handle quota-specific 429 error message in submit form) -- only if the submit error handling is in this file
+
+    ## Tests
+
+    Update `test/ui-dashboard.test.js` or create a new test file:
+    - Usage section renders with correct progress bar percentages
+    - Warning threshold (>80%) applies correct CSS class
+    - Critical threshold (>95%) applies correct CSS class
+    - Storage bytes formatted correctly (0, MB range, GB range)
+    - Usage section handles error state (fetch failure shows error message, keys still render)
+    - ARIA attributes present on progress bars
+
+- **Deliverables**: Updated `src/ui/ui-settings.js` with usage card, updated `src/ui/ui-css.js` with progress bar styles, optionally updated `src/ui/ui-captures.js` for quota 429 handling, tests
+- **Success criteria**: Settings view shows usage section with progress bars; three visual threshold states work; ARIA attributes present; storage formatted as human-readable; error state handled gracefully; quota-specific 429 shows correct message
+
+### Task 5: OpenAPI spec updates
+- **Agent**: api-spec-minion
+- **Delegation type**: standard
+- **Model**: sonnet
+- **Mode**: bypassPermissions
+- **Blocked by**: Task 2, Task 3
+- **Approval gate**: no
+- **Prompt**: |
+    You are updating the WRL OpenAPI spec to document the new quota feature.
+
+    ## Context
+
+    WRL's OpenAPI spec is at `openapi.yaml` in the project root. It follows OpenAPI 3.1 conventions. Existing patterns:
+    - Error responses use `$ref` components: `Problem400`, `Problem401`, `Problem429`, `Problem503`
+    - The `ProblemDetail` schema in components follows RFC 9457
+    - The existing `Problem429` response documents rate limiting with `Retry-After` header
+    - The existing 429 response uses `limitType: 'tenant'` as an extension field in the ProblemDetail body (but this isn't currently documented in the spec)
+
+    The docs site at `site/content/` uses Eleventy with Nunjucks templates. The API Reference page (`api-reference.njk`) auto-renders from `openapi.yaml`.
+
+    ## What to build
+
+    ### 1. Extend the 429 response documentation
+
+    Update the existing `Problem429` response component to document both rate-limit and quota 429 responses. Add a second example (`quotaExceeded`) alongside any existing examples.
+
+    Add a `QuotaDetail` schema in `components/schemas`:
+    ```yaml
+    QuotaDetail:
+      type: object
+      properties:
+        limit:
+          type: integer
+          description: Maximum allowed for this resource in the current period
+          example: 100
+        used:
+          type: integer
+          description: Current usage count
+          example: 100
+        resource:
+          type: string
+          enum: [captures, storage]
+          description: Which resource quota was exceeded
+          example: captures
+        resetsAt:
+          type: string
+          format: date-time
+          description: ISO 8601 timestamp when the quota resets (first of next month)
+          example: "2026-04-01T00:00:00.000Z"
+        requested:
+          type: integer
+          description: Number of items requested (present only for batch requests)
+          example: 10
+    ```
+
+    Document the `limitType` discriminator pattern in the ProblemDetail schema:
+    - `limitType` absent or `undefined`: IP-based rate limit
+    - `limitType: 'tenant'`: Per-tenant rate limit
+    - `limitType: 'quota'`: Monthly quota exceeded (additional `quota` object present)
+
+    ### 2. Add `GET /v1/account/usage` endpoint
+
+    New path with:
+    - Tag: `account`
+    - Summary: "Get current usage and quota"
+    - Description: Returns the authenticated tenant's current-period usage against their effective quotas
+    - Auth: session cookie (same as other `/v1/account/*` routes)
+    - Response 200 schema:
+
+    ```yaml
+    AccountUsageResponse:
+      type: object
+      required: [tenantId, period, tierDisplay, captures, storageBytes, resetsAt]
+      properties:
+        tenantId:
+          type: string
+          example: "gh-12345"
+        period:
+          type: string
+          pattern: '^\d{4}-\d{2}$'
+          example: "2026-03"
+        tierDisplay:
+          type: string
+          description: Human-readable tier name for UI display
+          example: "Starter"
+        captures:
+          $ref: '#/components/schemas/UsageMetric'
+        storageBytes:
+          $ref: '#/components/schemas/UsageMetric'
+        resetsAt:
+          type: string
+          format: date-time
+          example: "2026-04-01T00:00:00.000Z"
+
+    UsageMetric:
+      type: object
+      required: [used, limit, remaining]
+      properties:
+        used:
+          type: integer
+          minimum: 0
+          example: 42
+        limit:
+          type: integer
+          minimum: 0
+          example: 100
+        remaining:
+          type: integer
+          minimum: 0
+          example: 58
+    ```
+
+    ### 3. Add X-Quota headers
+
+    Add header components:
+    ```yaml
+    X-Quota-Limit:
+      description: Maximum captures allowed in the current billing period
+      schema:
+        type: integer
+    X-Quota-Used:
+      description: Captures used in the current billing period
+      schema:
+        type: integer
+    X-Quota-Remaining:
+      description: Captures remaining in the current billing period
+      schema:
+        type: integer
+    ```
+
+    Reference these headers in the 202 response of `POST /v1/captures` and the 207 response of `POST /v1/captures/batch`.
+
+    ### 4. Update capture endpoint descriptions
+
+    Add a note to `POST /v1/captures` and `POST /v1/captures/batch` descriptions:
+    "Captures are subject to monthly quotas based on the tenant's tier. When the quota is exceeded, a 429 response is returned with `limitType: 'quota'` and a `quota` object containing the limit, usage, and reset timestamp."
+
+    For the batch endpoint, add: "If the batch size would exceed the remaining quota, the entire batch is rejected with a 429 response."
+
+    ### 5. Update admin tenant config documentation
+
+    If the spec has a schema for the tenant config object (used by `PUT /v1/admin/tenants/:id/config`), extend it to include the `quotas` override fields:
+    ```yaml
+    quotas:
+      type: object
+      description: Per-tenant quota overrides (take precedence over tier defaults)
+      properties:
+        capturesPerMonth:
+          type: integer
+          minimum: 1
+          description: Override monthly capture limit
+        storageBytes:
+          type: integer
+          minimum: 1
+          description: Override storage limit in bytes
+    ```
+
+    ## What NOT to do
+
+    - Do NOT create a separate `Problem429Quota` response component -- extend the existing `Problem429` with examples
+    - Do NOT add `additionalProperties: false` to ProblemDetail -- RFC 9457 explicitly allows extension members
+    - Do NOT document internal tier names in the spec -- only `tierDisplay` is exposed
+    - Do NOT document admin tier management endpoints unless they already exist in the spec
+
+    ## Files to modify
+
+    - MODIFY: `openapi.yaml`
+
+    ## Validation
+
+    After making changes, validate the spec is valid OpenAPI 3.1 by checking that the YAML structure is correct. The docs site CI will catch structural errors.
+
+- **Deliverables**: Updated `openapi.yaml` with QuotaDetail schema, AccountUsageResponse schema, UsageMetric schema, X-Quota headers, updated 429 documentation, new GET /v1/account/usage path
+- **Success criteria**: OpenAPI spec is valid; quota-exceeded 429 response is documented with example; new usage endpoint is fully specified; X-Quota headers documented on capture responses
+
+### Task 6: Docs site content updates
+- **Agent**: software-docs-minion
+- **Delegation type**: standard
+- **Model**: sonnet
+- **Mode**: bypassPermissions
+- **Blocked by**: Task 5
+- **Approval gate**: no
+- **Prompt**: |
+    You are updating the WRL documentation site to cover the new quota feature.
+
+    ## Context
+
+    WRL's docs site lives in `site/content/`. It uses Eleventy with Markdown content files and a Nunjucks template for the API reference. Current content files:
+    - `index.md` -- landing page with guides list
+    - `authentication.md` -- auth methods, API keys, scopes
+    - `batch.md` -- batch capture guide with rate limit mention
+    - `mcp.md` -- MCP integration
+    - `verification.md` -- capture verification
+    - `webhooks.md` -- webhook configuration
+    - `api-reference.njk` -- auto-generated from openapi.yaml
+
+    There is currently NO dedicated rate limits or quotas guide. Rate limit info is scattered across batch.md, README.md, and the API reference.
+
+    ## What to build
+
+    ### 1. Create `site/content/limits.md` -- "Limits & Quotas" guide
+
+    Create a single guide covering both rate limits and quotas (they are closely related -- both produce 429s). Structure:
+
+    ```markdown
+    ---
+    title: Limits & Quotas
+    ---
+
+    # Limits & Quotas
+
+    WRL enforces two types of request limits: **rate limits** (short-term burst protection) and **quotas** (monthly usage limits).
+
+    ## Rate Limits vs Quotas
+
+    | | Rate Limits | Quotas |
+    |---|---|---|
+    | **Scope** | Per IP or per tenant | Per tenant |
+    | **Window** | 60 seconds | Calendar month |
+    | **Enforced by** | KV counters + Cloudflare bindings | D1 usage counters |
+    | **Reset** | Rolling window (seconds) | First of next month |
+    | **HTTP response** | 429 with `Retry-After` (seconds) | 429 with `Retry-After` (HTTP-date) |
+    | **Discriminator** | `limitType` absent or `"tenant"` | `limitType: "quota"` |
+
+    ## Rate Limits
+
+    [Document the existing rate limits: 10/min per tenant default, 50/min per IP, 200/min global]
+
+    ## Quotas
+
+    Captures are subject to monthly quotas based on your account tier:
+
+    | Tier | Captures/month | Storage |
+    |------|---------------|---------|
+    | Starter | 100 | 1 GB |
+    | Pro | 5,000 | 50 GB |
+
+    ### Checking Your Usage
+
+    Use the `GET /v1/account/usage` endpoint to check current usage:
+    [Show example request and response]
+
+    Usage is also available in the [web UI settings page](/ui#/settings).
+
+    ### Quota Headers
+
+    Successful capture responses include quota information in headers:
+    - `X-Quota-Limit`: Maximum captures in the current period
+    - `X-Quota-Used`: Captures used so far
+    - `X-Quota-Remaining`: Captures remaining
+
+    ### Quota Exceeded (429)
+
+    When a capture request exceeds the monthly quota, the API returns a 429 with `limitType: "quota"`:
+    [Show example 429 response body]
+
+    The `Retry-After` header contains an HTTP-date (not seconds) indicating when the quota resets.
+
+    ### Batch Requests
+
+    Batch capture requests (`POST /v1/captures/batch`) check quota for the entire batch upfront. If the batch size exceeds the remaining quota, the entire batch is rejected with a 429.
+
+    ## Distinguishing 429 Responses
+
+    Check the `limitType` field in the response body:
+    [Show the three cases: absent, "tenant", "quota"]
+    ```
+
+    ### 2. Update `site/content/index.md`
+
+    Add "Limits & Quotas" to the guides list (between Authentication and Batch or wherever makes sense).
+
+    ### 3. Update `site/content/batch.md`
+
+    In the rate limits section of batch.md, add a cross-reference:
+    "For complete rate limit and quota documentation, see [Limits & Quotas](/limits/)."
+
+    ### 4. Update `site/content/authentication.md`
+
+    If there's an endpoint/scope table, add `GET /v1/account/usage` with scope "session" or "authenticated."
+
+    ## What NOT to do
+
+    - Do NOT create separate guides for rate limits and quotas -- one guide covers both
+    - Do NOT update README.md -- that's a separate task handled by post-execution docs phase
+    - Do NOT modify the OpenAPI spec -- Task 5 owns that
+    - Do NOT document admin quota override management -- operator docs go in OPERATIONS.md (post-execution phase)
+
+    ## Files to create/modify
+
+    - CREATE: `site/content/limits.md`
+    - MODIFY: `site/content/index.md` (add to guides list)
+    - MODIFY: `site/content/batch.md` (add cross-reference)
+    - MODIFY: `site/content/authentication.md` (add usage endpoint)
+
+- **Deliverables**: New `site/content/limits.md` guide, updated navigation and cross-references
+- **Success criteria**: Limits & Quotas guide covers both rate limits and quotas; 429 disambiguation is clearly documented; usage endpoint documented with examples; cross-references from batch.md and authentication.md
+
+### Cross-Cutting Coverage
+
+- **Testing**: Covered by each task's test requirements. Phase 6 (post-execution) will run the full test suite. Each task includes specific test deliverables: quotas module unit tests (Task 1), pipeline integration tests (Task 2), endpoint tests (Task 3), UI tests (Task 4).
+- **Security**: security-minion's recommendations are incorporated directly: tier as a column not config JSON (Task 1); `tierDisplay` instead of internal tier name in API responses (Task 3); admin-only tier changes via existing admin config endpoint (Task 1 validation); `Cache-Control: private, no-store` on usage endpoint (Task 3); entire-batch rejection prevents partial-acceptance confusion (Task 2). Phase 3.5 review will verify.
+- **Usability -- Strategy**: ux-strategy-minion's recommendations are incorporated: usage as settings section not separate route (Task 4); `tierDisplay: "Starter"` instead of "Free" (Task 3 response, Task 4 display); three threshold states for progress bars (Task 4); no quota on submit form (Task 4); current period only (Task 4).
+- **Usability -- Design**: Covered by Task 4's frontend work. Progress bars use ARIA attributes, color thresholds, and numeric labels. Phase 3.5 review by accessibility-minion.
+- **Documentation**: Covered by Task 5 (OpenAPI spec) and Task 6 (docs site guide). Phase 8 will handle README updates and OPERATIONS.md.
+- **Observability**: Not a separate task. Log events (`security.quota_exceeded`, `oauth.usage_view`) are added inline in Tasks 2 and 3. No new runtime components that need dedicated observability setup. X-Quota headers on successful responses enable client-side monitoring.
+
+### Architecture Review Agents
+
+- **Mandatory** (5): security-minion, test-minion, ux-strategy-minion, lucy, margo
+- **Discretionary picks**:
+  - accessibility-minion: Task 4 produces web UI with progress bars that need WCAG review.
+    Review focus: Progress bar ARIA markup, color contrast for three threshold states, screen reader announcement of usage data.
+- **Not selected**:
+  - ux-design-minion: The usage section follows existing card-based patterns with no novel interaction design. The progress bars are standard components. Accessibility-minion covers the WCAG compliance angle.
+  - observability-minion: No new runtime components. Quota checks reuse existing D1 queries. Log events follow established patterns.
+  - sitespeed-minion: No new page loads or assets. The usage fetch is a lightweight JSON endpoint added to an existing page's mount.
+  - user-docs-minion: The docs site guide (Task 6) covers developer-facing documentation. End-user documentation is not applicable -- WRL users are developers.
+
+### Decisions
+
+- **Tier naming: internal vs. display**
+  Chosen: Internal code uses `'free'`/`'pro'`; API responses expose `tierDisplay: 'Starter'`/`'Pro'`; 429 error messages omit tier name entirely
+  Over: (1) Exposing internal tier name in API (security-minion flagged this -- tier names reveal pricing model information). (2) Using "Starter" everywhere including code (ux-strategy preference) -- rejected because "free" is clearer in code/DB contexts
+  Why: Separates concerns -- code uses simple identifiers, UI gets user-friendly names, API responses avoid leaking business logic. The `TIER_DISPLAY_NAMES` map in quotas.js is the single mapping point.
+
+- **Queue consumer quota check (defense-in-depth)**
+  Chosen: Primary enforcement at HTTP handler only; no queue consumer check
+  Over: Dual-check at both HTTP handler and queue consumer (security-minion recommendation)
+  Why: The queue consumer has already returned 202 -- failing silently at the consumer violates the fail-loudly principle. The overage from the TOCTOU race window is bounded at ~10 captures (one rate-limit window) which is explicitly acceptable per spec. Adding queue consumer checks would create a confusing UX where accepted captures silently fail. If defense-in-depth is needed later, it belongs in a separate backlog item with proper status-update semantics (e.g., webhook notification of quota-exceeded failure).
+
+- **Batch quota behavior: full rejection vs. partial acceptance**
+  Chosen: Reject the entire batch with 429 when quota is insufficient
+  Over: Partial acceptance up to remaining quota (security-minion noted existing batch partial-acceptance precedent for rate limits)
+  Why: api-design-minion's reasoning is stronger -- quota is a budget concept, and partial acceptance creates confusing accounting. The existing batch partial-acceptance is only for legacy auth rate limits (a special case), not the default behavior.
+
+- **Usage endpoint: dedicated `/v1/account/usage` vs. embedded in `/auth/session`**
+  Chosen: Dedicated `GET /v1/account/usage` endpoint
+  Over: Extending `/auth/session` response with usage data (ux-strategy-minion suggested this for captures-list banner without extra fetch)
+  Why: `/auth/session` fires on every page load and must remain lightweight. Adding D1 usage queries to the boot path adds latency to every page, not just settings. A dedicated endpoint can be cached per-session and only fetched when the settings view mounts. The captures-list warning banner (ux-strategy's Task 4) is deferred to a future phase -- current scope is settings only.
+
+### Risks and Mitigations
+
+1. **TOCTOU race window on usage counters (MEDIUM)**: Usage is incremented post-capture via `ctx.waitUntil()`. Concurrent requests may both pass the quota check before either increment lands. Maximum realistic overage: ~10 captures (bounded by per-tenant rate limit of 10/60s). **Mitigation**: Accepted by spec ("slight overages are acceptable"). Documented in evolution log.
+
+2. **Storage quota enforcement gap (LOW for MVP)**: Capture storage size is unknown at request time (determined after browser rendering). The quota check compares current cumulative `storage_bytes` against the limit, but cannot predict the new capture's size. A tenant at 990 MB / 1 GB could submit a capture that produces 50 MB. **Mitigation**: Accept as a soft limit. If strict enforcement is needed later, the queue consumer can check post-render and block further captures (backlog item).
+
+3. **`ctx.waitUntil` increment failures (LOW)**: If `incrementUsage` fails (D1 transient error), the counter underreports and the tenant gets effectively free captures. The existing code logs this as `wrl:usage_increment_fail`. **Mitigation**: Existing logging provides visibility. A periodic reconciliation job (count D1 captures rows per tenant per period) is a backlog item if this proves problematic.
+
+4. **Legacy auth quota bypass (LOW)**: The legacy `CAPTURE_API_KEY` fallback routes all requests to `tenantId: 'default'`. The `default` tenant will get `free` tier via the migration DEFAULT. No bypass as long as the `default` tenant stays at `free` tier. **Mitigation**: Documented. The `default` tenant's tier is set by migration default and can be verified operationally.
+
+5. **D1 batch latency tail (LOW)**: The quota check adds one D1 batch (two PK lookups) to the capture hot path. PK lookups are sub-2ms each; batch overhead is one internal RPC. Well within 10ms budget. **Mitigation**: Monitor P99 latency post-deployment. If tail latency exceeds 10ms under load, add KV read-through cache with 60s TTL (YAGNI for now).
+
+### Execution Order
+
+```
+Phase 4a: Task 1 (D1 migration + quotas module) ─── GATE
+                    │
+           ┌───────┴───────┐
+Phase 4b:  Task 2          Task 3 ─── (parallel, both depend on Task 1)
+           (pipeline)      (usage endpoint)
+                    │              │
+           ┌───────┴───────┐      │
+Phase 4c:  Task 4          Task 5 ─── (parallel; Task 4 needs Task 3, Task 5 needs Task 2+3)
+           (UI)            (OpenAPI)
+                                  │
+Phase 4d:                  Task 6
+                           (docs site)
+```
+
+Gate positions:
+1. After Task 1: Schema and quotas module must be reviewed before pipeline integration
+2. After Task 2: Pipeline integration must be reviewed before downstream work (captures are the critical path)
+
+### Verification Steps
+
+After all tasks complete:
+
+1. **Apply migration**: `wrangler d1 migrations apply` (staging) -- verify `tier` column exists on tenants with default `'free'`
+2. **Quota enforcement**: Submit captures until quota is reached -- verify 429 with `limitType: 'quota'` response
+3. **Batch rejection**: Submit a batch capture exceeding remaining quota -- verify entire batch rejected with 429
+4. **Under-quota headers**: Submit a capture under quota -- verify 202 response includes `X-Quota-*` headers
+5. **Usage endpoint**: Call `GET /v1/account/usage` with a valid session -- verify response shape with tier display name, captures, storage, resetsAt
+6. **Web UI**: Navigate to Settings -- verify Usage section with progress bars, correct percentages, threshold coloring
+7. **OpenAPI spec**: Validate spec with a linter -- verify quota schemas, usage endpoint, X-Quota headers documented
+8. **Docs site**: Build docs site -- verify Limits & Quotas guide renders, cross-references work
+9. **Existing tests**: Run full test suite -- verify no regressions

--- a/docs/history/nefario-reports/2026-03-23-030747-tenant-quotas/phase3.5-accessibility-minion.md
+++ b/docs/history/nefario-reports/2026-03-23-030747-tenant-quotas/phase3.5-accessibility-minion.md
@@ -1,0 +1,35 @@
+## Verdict: ADVISE
+
+The plan's ARIA fundamentals are sound: `role="progressbar"` with `aria-valuenow`, `aria-valuemin`, `aria-valuemax`, and `aria-label` are all specified. The numeric "N of M" redundancy alongside color states satisfies 1.4.1 Use of Color. These are the right instincts. The issues below are gaps or ambiguities that need clarifying instructions to frontend-minion before implementation.
+
+---
+
+- [accessibility]: The `role="progressbar"` is placed on the outer `.usage-bar` container div, but `aria-valuenow`, `aria-valuemin`, and `aria-valuemax` must reflect the percentage value (0-100), not the raw count, when the max is not the count.
+  SCOPE: Task 4 -- `src/ui/ui-settings.js`, progress bar HTML structure (plan lines 663-675)
+  CHANGE: The plan shows `aria-valuenow="42"` and `aria-valuemax="100"` which happens to work for the captures example (count and percentage max are both 100). But for storage, the raw bytes are used -- `aria-valuemax` should be the quota limit in the same unit as `aria-valuenow`. The plan shows bytes in the API response but does not specify whether the ARIA attributes use raw bytes or a normalized percentage. Specify explicitly: ARIA attributes must use consistent units. Either use percentage (valuenow=42, valuemin=0, valuemax=100) consistently across both metrics, OR use raw values consistently (valuenow=captureCount, valuemax=quota.capturesPerMonth for captures; valuenow=storageBytes, valuemax=quota.storageBytes for storage). The `aria-label` must then match the unit used. Raw bytes in `aria-valuenow` with a human-readable `aria-label` is valid but requires care.
+  WHY: WCAG 4.1.2 Name, Role, Value (Level A). If the ARIA value attributes are inconsistent between metrics, or the label does not accurately reflect the current value, screen readers will announce incorrect information to users.
+  TASK: Task 4
+
+- [accessibility]: The `aria-label` text for storage uses "524 MB of 1 GB storage used this month" -- this requires the label to be generated from the formatted bytes string, but the plan does not explicitly instruct frontend-minion to use `formatBytes()` output inside the `aria-label`. The plan specifies `formatBytes` for the visible `.usage-metric-value` text but the `aria-label` construction is left implicit.
+  SCOPE: Task 4 -- `src/ui/ui-settings.js`, aria-label generation for storage progress bar
+  CHANGE: Explicitly instruct frontend-minion: the `aria-label` for the storage progress bar must use `formatBytes()` for both the used and limit values (e.g., `"${formatBytes(storageBytes.used)} of ${formatBytes(storageBytes.limit)} storage used this month"`), not raw byte integers. Raw bytes would produce announcements like "524288000 of 1073741824 storage used this month" which is unintelligible.
+  WHY: WCAG 3.3.2 Labels or Instructions (Level A) and general WCAG 1.3.1 Info and Relationships. An accessible label conveying raw byte counts provides no meaningful information to a screen reader user.
+  TASK: Task 4
+
+- [accessibility]: The plan specifies 8px height for `.usage-bar`. Progress bars with 8px height have an effective click/pointer target area of 8px, which fails WCAG 2.2 SC 2.5.8 Target Size (Minimum) (Level AA) if the bar is interactive. The plan says the bar is display-only (no interaction), which avoids the target size requirement -- but this needs to be confirmed and the bar must not receive focus or have click handlers.
+  SCOPE: Task 4 -- `src/ui/ui-css.js`, `.usage-bar` at 8px height
+  CHANGE: Confirm in the Task 4 prompt that the progress bar is purely presentational with no keyboard focus, click interaction, or pointer events that make it an interactive target. If the element receives `tabindex` at any point, the 8px height creates a 2.5.8 violation. Add an explicit "do not make the progress bar focusable or interactive" instruction.
+  WHY: WCAG 2.2 SC 2.5.8 Target Size Minimum (Level AA). An 8px-tall interactive element would fail the 24x24 CSS pixel minimum. Making the intent explicit prevents frontend-minion from accidentally adding a tooltip-on-hover or focus handler.
+  TASK: Task 4
+
+- [accessibility]: The plan specifies `settingsAnnounce('Usage data loaded.')` via a live region for when usage data loads. However, the plan does not specify what to announce when usage data fails -- the error state ("Could not load usage data.") is inserted into the DOM but there is no instruction to announce the failure to screen reader users.
+  SCOPE: Task 4 -- `src/ui/ui-settings.js`, error state handling (plan lines 736-739)
+  CHANGE: Add an explicit instruction: when the usage fetch fails and the error message is rendered, also call `settingsAnnounce('Could not load usage data.')` (or equivalent) so screen reader users are notified of the failure without needing to navigate to the card.
+  WHY: WCAG 4.1.3 Status Messages (Level AA). Error states that appear in the DOM without an announcement are invisible to screen reader users who are not currently navigating that region.
+  TASK: Task 4
+
+- [accessibility]: The plan specifies three color states (default/warning/critical) for the progress bar fill and notes "the threshold color change alone is not sufficient -- the numeric 'N of M' text beside the bar provides the same information non-visually." This is correct for 1.4.1. However, the `--color-warning` and `--color-error` CSS custom property values are not specified in the plan, and the plan does not verify that these colors meet the 3:1 contrast ratio against the `.usage-bar` track background (`--color-surface-muted`) required for non-text graphical elements (WCAG 1.4.11 Non-text Contrast, Level AA).
+  SCOPE: Task 4 -- `src/ui/ui-css.js`, `.usage-bar-fill--warning` and `.usage-bar-fill--critical` colors against `.usage-bar` background
+  CHANGE: Instruct frontend-minion to verify that `--color-warning` and `--color-error` achieve at least 3:1 contrast ratio against `--color-surface-muted` (the track background). If the design token values are not confirmed to meet this threshold, the plan should specify fallback values or flag this for ux-design-minion confirmation before implementation.
+  WHY: WCAG 1.4.11 Non-text Contrast (Level AA). Progress bar fill colors are graphical UI components. If warning/error fill colors have insufficient contrast against the track, users with low vision cannot perceive the visual state even with the numeric fallback.
+  TASK: Task 4

--- a/docs/history/nefario-reports/2026-03-23-030747-tenant-quotas/phase3.5-lucy.md
+++ b/docs/history/nefario-reports/2026-03-23-030747-tenant-quotas/phase3.5-lucy.md
@@ -1,0 +1,64 @@
+# Lucy Review: tenant-quotas Delegation Plan
+
+## Verdict: ADVISE
+
+The plan is well-aligned with the original request. All 12 success criteria from the prompt are addressed with traceable plan tasks. The plan follows existing codebase patterns (rate-limits.js structure, config JSON overrides, existing test harnesses). No significant scope creep or goal drift detected. The 6-task decomposition is proportional to the feature scope.
+
+The following issues should be addressed but are not blocking.
+
+---
+
+### Advisories
+
+1. [governance]: Task 4 prompt references `src/ui/design-system.css` but that file does not exist at that path
+   SCOPE: Task 4 prompt, `src/ui/design-system.css` file path
+   CHANGE: Correct the path in the Task 4 prompt to `src/design-system.css` (which is where `--color-warning`, `--color-accent`, `--color-error` are defined) or `src/design-system.js` (which also contains these tokens). The frontend-minion will search for the wrong file if the path is wrong.
+   WHY: The file `src/ui/design-system.css` does not exist. The actual design system CSS is at `src/design-system.css` and `src/design-system.js`. An incorrect path in the prompt may cause the agent to create a new file or waste cycles looking for a nonexistent one.
+   TASK: Task 4
+
+2. [governance]: Task 4 CSS references `--color-warning` directly but existing codebase uses `--color-warning-text` and `--color-warning-bg` variant tokens
+   SCOPE: Task 4 CSS for `.usage-bar-fill--warning`
+   CHANGE: Verify that `--color-warning` (defined as `#e6a817` in design-system.css) is the correct token for a background fill. The existing UI uses `--color-warning-text` and `--color-warning-bg` for warning states, not `--color-warning` directly. The plan should clarify which token to use, or the agent should inspect the design system and pick the appropriate one.
+   WHY: Using a raw color token instead of a semantic token (bg vs text) may produce incorrect contrast. `--color-warning` is an orange (`#e6a817`) that may have insufficient contrast against a light track background, or may not match the visual language of existing warning states.
+   TASK: Task 4
+
+3. [governance]: Plan has no evolution log task -- CLAUDE.md requires `docs/evolution/NNNN-*/` with prompt.md, decisions.md, outcome.md, and process.md
+   SCOPE: Evolution log (CLAUDE.md "Evolution Log" section, rules 1-7 + "Process Documentation" section)
+   CHANGE: The orchestrator must ensure the evolution log directory is created (next sequential number would be `0056-tenant-quotas`), `prompt.md` is written before execution begins, `decisions.md` is maintained during execution, and `outcome.md` + `process.md` are written after PR creation. The backlog (`docs/backlog.md`) must also be updated. These are CLAUDE.md-mandated deliverables, not optional post-execution cleanup.
+   WHY: CLAUDE.md states "This is non-negotiable -- the build process is as much a deliverable as the product itself." The plan's Cross-Cutting Coverage section mentions "Phase 8 will handle README updates" but does not mention evolution log or backlog updates. The orchestrator session must handle this per CLAUDE.md Precedence rules.
+   TASK: Cross-cutting (all tasks)
+
+4. [governance]: `setTenantTier` function is created in Task 1 but no endpoint exposes it -- the function is dead code at delivery
+   SCOPE: `src/db.js` `setTenantTier` function (Task 1)
+   CHANGE: Either (a) defer `setTenantTier` to when the admin endpoint is built (YAGNI -- don't build it until you need it), or (b) add a brief admin endpoint task that wires it up. The prompt's scope says "In: ... tier field on tenant record" and "Out: ... Automatic tier upgrades" -- but manual tier setting by an operator is listed nowhere.
+   WHY: The Helix Manifesto / CLAUDE.md engineering philosophy states "YAGNI -- don't build it until you need it." Building a function with no caller violates this principle. The function itself is small, but the principle matters for consistency. Note: the existing `setTenantConfig` already allows quota overrides, which is the primary admin-side requirement.
+   TASK: Task 1
+
+5. [governance]: Task 3 duplicates the D1 batch query logic from `checkQuota` instead of reusing it
+   SCOPE: `handleAccountGetUsage` in `src/account.js` (Task 3)
+   CHANGE: Consider whether `handleAccountGetUsage` should call `checkQuota()` and reshape the result, rather than duplicating the `SELECT tier, config FROM tenants` + `SELECT capture_count, storage_bytes FROM usage_counters` batch pattern. If duplication is intentional (different return shape, avoiding coupling), note that in the prompt so the agent doesn't refactor it.
+   WHY: KISS / Lean and Mean. Two separate modules performing identical D1 batch queries with identical parsing logic is a maintenance surface. If `checkQuota` changes its query (e.g., adding a column), `handleAccountGetUsage` must be updated independently. The plan's gate rationale for Task 1 specifically calls out "Maximizes consistency with existing patterns" -- but then Task 3 creates a parallel pattern.
+   TASK: Task 3
+
+---
+
+### Traceability Matrix
+
+| Prompt Requirement | Plan Coverage | Status |
+|---|---|---|
+| Default quotas per tier (free: 100 captures/1GB, pro: 5000/50GB) | Task 1: `TIER_QUOTAS` constant | Covered |
+| Quota check before browser session creation | Task 2: check in handleCreateCapture/handleBatchCapture after rate limit | Covered |
+| 429 with `quota_exceeded` error shape | Task 2: `problemResponse(429, ...)` with `limitType: 'quota'` | Covered |
+| Per-tenant quota overrides in D1 | Task 1: `config.quotas` JSON validation in `setTenantConfig` | Covered |
+| Web UI usage dashboard with progress bars | Task 4: usage section in settings view | Covered |
+| Dashboard updates on page load (not real-time) | Task 4: fetch in `mountSettings()` | Covered |
+| Best-effort enforcement (eventual consistency) | Risks section acknowledges TOCTOU; spec-compliant | Covered |
+| Tier stored per tenant, defaults to "free" | Task 1: migration `ALTER TABLE tenants ADD COLUMN tier TEXT NOT NULL DEFAULT 'free'` | Covered |
+
+No unaddressed requirements. No orphaned tasks (all tasks trace to at least one requirement).
+
+### Scope Assessment
+
+The plan stays within the stated scope boundaries. Items explicitly marked "Out" in the prompt (automatic upgrades, storage eviction, per-endpoint quotas, notifications) are not present in the plan. Task 6 (docs site content) is a natural deliverable for a feature that adds a new API endpoint and changes API response shapes -- not scope creep.
+
+The `X-Quota-*` response headers (Task 2 section 3) are not explicitly listed in the prompt's success criteria but are a standard API convention for quota-aware endpoints and directly support the prompt's requirement that "tenants can see their usage." This is a reasonable inclusion.

--- a/docs/history/nefario-reports/2026-03-23-030747-tenant-quotas/phase3.5-margo.md
+++ b/docs/history/nefario-reports/2026-03-23-030747-tenant-quotas/phase3.5-margo.md
@@ -1,0 +1,42 @@
+## Verdict: ADVISE
+
+This is a well-structured plan that follows existing codebase patterns closely. The complexity is proportional to the problem: six tasks for a feature that touches the data layer, two pipeline handlers, a new API endpoint, the web UI, the OpenAPI spec, and documentation. No new dependencies introduced. No new abstractions beyond one module (`src/quotas.js`) that mirrors the existing `src/rate-limits.js` pattern. No premature optimization (explicitly defers KV caching). No scope creep beyond the approved feature set.
+
+The plan earns most of its complexity budget from essential requirements. The following items are minor concerns, not blocking issues.
+
+### Advisories
+
+- [simplicity]: The `handleAccountGetUsage` handler in Task 3 duplicates the D1 batch query and result-parsing logic already implemented in `checkQuota()` from Task 1.
+  SCOPE: `src/account.js` -- `handleAccountGetUsage` function (Task 3)
+  CHANGE: Reuse `checkQuota(db, tenantId, 0)` with `count=0` (which will always return `allowed: true` with the current usage data) instead of writing a second inline D1 batch with the same two prepared statements, same column parsing, and same `resetsAt` computation. The handler only needs to reshape the result into the response JSON. If `checkQuota`'s return shape is insufficient (e.g., missing `tierDisplay`), extend it minimally rather than duplicating the query.
+  WHY: Two copies of the same D1 batch query, column parsing, and reset-date computation means two places to update when the schema changes (e.g., adding a new quota dimension). The duplication is small today but will drift as quota logic evolves.
+  TASK: Task 3
+
+- [simplicity]: The `resetsAt` computation (first of next month) is duplicated in three places: `checkQuota()` in Task 1 (twice, once per rejection branch), `handleAccountGetUsage` in Task 3, and implicitly in the `Retry-After` header construction in Task 2.
+  SCOPE: `src/quotas.js` -- `resetsAt` computation
+  CHANGE: Extract a single `computeQuotaReset()` function in `src/quotas.js` that returns the ISO 8601 reset timestamp. Call it from `checkQuota` (once, not per-branch) and from any handler that needs the reset date.
+  WHY: The `new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1)).toISOString()` expression appears three times with identical logic. A single function eliminates the duplication and makes the reset boundary easy to find and change (e.g., if billing periods ever shift).
+  TASK: Task 1
+
+- [simplicity]: The `X-Quota-*` response header construction is specified twice in Task 2 -- once for `handleCreateCapture` (202) and once for `handleBatchCapture` (207) -- with identical logic.
+  SCOPE: `src/index.js` -- quota header construction in Task 2
+  CHANGE: Extract a small helper (e.g., `buildQuotaHeaders(quotaCheck)`) that both handlers call. Three lines of code, one definition point.
+  WHY: The header names and the `Math.max(0, ...)` computation are identical in both handlers. Without extraction, adding a fourth header (e.g., `X-Quota-Period`) requires edits in two places. Follows the existing pattern where `rlHeaders` construction is already structurally similar between handlers.
+  TASK: Task 2
+
+- [simplicity]: Task 3 specifies that `tierDisplay` is returned but the internal tier name is hidden from the API response, while Task 1's `checkQuota` returns the raw `tier` value. The `TIER_DISPLAY_NAMES` map already exists in `src/quotas.js`. However, if Task 3 reuses `checkQuota` (per the first advisory), the display name resolution should stay in the handler, not leak into `checkQuota`. Just noting: keep the display-name mapping at the API boundary, not in the data function.
+  SCOPE: `src/quotas.js` and `src/account.js` -- tier display name resolution
+  CHANGE: No structural change needed. This is a design note: if the Task 3 handler is refactored to call `checkQuota`, the `TIER_DISPLAY_NAMES[result.tier]` lookup should remain in the handler, not be pushed into `checkQuota`. The quota checker is a data function; display concerns belong at the API boundary.
+  WHY: Prevents `checkQuota` from accumulating UI concerns. The function is already called in the capture pipeline where display names are irrelevant.
+  TASK: Task 3
+
+### What the plan gets right
+
+- **Pattern consistency**: `src/quotas.js` mirrors `src/rate-limits.js` exactly -- same constant-map-plus-override-function shape. No new abstraction pattern to learn.
+- **No new dependencies**: Zero new packages. Vanilla JS throughout.
+- **No premature optimization**: Explicitly defers KV caching with a clear YAGNI justification (D1 PK lookup sub-2ms, well within 10ms budget).
+- **No scope creep**: Explicitly excludes historical usage, upgrade CTAs, nav bar badges, queue consumer checks, and per-endpoint call quotas. Each exclusion is justified.
+- **Correct insertion point**: Quota check after rate limit (cheaper KV check first) and before body parsing (avoid unnecessary work). The ordering rationale is sound.
+- **Batch full-rejection**: Simpler than partial acceptance. Correct trade-off for an MVP.
+- **Infrastructure proportionality**: No new bindings, no new KV namespaces, no new queues. One D1 column, one D1 batch query. Proportional.
+- **TOCTOU acceptance**: Explicitly bounds the overage window at ~10 captures via the existing rate limit ceiling. Honest about the trade-off rather than building a distributed lock.

--- a/docs/history/nefario-reports/2026-03-23-030747-tenant-quotas/phase3.5-security-minion.md
+++ b/docs/history/nefario-reports/2026-03-23-030747-tenant-quotas/phase3.5-security-minion.md
@@ -1,0 +1,25 @@
+## Security Review Verdict: ADVISE
+
+---
+
+- [security]: `handlePutTenantConfig` catch block does not remap new `quotas.*` validation errors, causing 500 responses instead of 400 for invalid quota overrides submitted through the admin API.
+  SCOPE: `src/index.js` lines 1124-1129, `handlePutTenantConfig` error handler
+  CHANGE: Extend the error remapping condition from `err.message.startsWith('rateLimit.')` to also cover `err.message.startsWith('quotas.')`. The current condition is `err.message.startsWith('rateLimit.') || err.message.startsWith('Invalid tenantId')`. After Task 1 adds quota validation in `setTenantConfig`, errors like `'quotas.capturesPerMonth must be a positive integer'` will not match either condition and will propagate as unhandled 500s. The fix is one line: add `|| err.message.startsWith('quotas.')` to the remapping predicate.
+  WHY: Validation errors thrown in `setTenantConfig` for `quotas.capturesPerMonth` and `quotas.storageBytes` begin with the string `quotas.`, not `rateLimit.`. The existing catch block was written before quota validation existed and will silently convert client input errors into 500 responses for any admin operator sending malformed quota overrides. This produces misleading error responses and may hide misconfigurations.
+  TASK: Task 1 (creates the validation) and Task 2 implicitly (uses `handlePutTenantConfig` to configure per-tenant overrides). The fix belongs in `handlePutTenantConfig` in `src/index.js` and should be done as part of Task 1 or at the Task 1 approval gate.
+
+- [security]: No admin endpoint is planned for `setTenantTier`, leaving tier assignment exclusively to a D1 direct write or a future unplanned endpoint; the `setTenantTier` function built in Task 1 is unreachable through the API.
+  SCOPE: `src/db.js` (`setTenantTier`), `src/index.js` (admin routes)
+  CHANGE: Either (a) add a `PUT /v1/admin/tenants/:id/tier` route protected by `verifyAdminKey` that calls `setTenantTier`, or (b) extend `handlePutTenantConfig` to accept and apply a `tier` field using `setTenantTier` alongside the config update. Without this, the only way to promote a tenant to `pro` is raw D1 access, which bypasses all audit logging.
+  WHY: `setTenantTier` validates the tier value and writes an `updated_by` audit field. If there is no admin-gated API route calling it, operators will resort to direct D1 mutations that skip both validation and the audit trail. This is a privilege escalation surface: a misconfigured direct write could set `tier` to an arbitrary string, which `getEffectiveQuota` falls back to `free` for (safe), but the data integrity is broken and the absence of an audit log entry means tier changes are invisible to security monitoring.
+  TASK: Task 1 (creates `setTenantTier`). Recommend adding the admin route as part of Task 1 or opening a tracked backlog item before the phase closes.
+
+- [security]: The `X-Quota-Remaining` header on every successful 202/207 response reveals exact remaining capacity to any party that can observe response headers, including browser extensions, proxies, and logging middleware.
+  SCOPE: `src/index.js`, quota header construction in `handleCreateCapture` and `handleBatchCapture` (Task 2)
+  CHANGE: This is low-severity because the information is scoped to authenticated tenants viewing their own quota. Accept as-is or limit headers to `X-Quota-Limit` and `X-Quota-Used` (omit `X-Quota-Remaining`, which can be computed client-side). If accepted, document explicitly in the OpenAPI spec (Task 5) that these headers are only present on authenticated capture responses.
+  WHY: `X-Quota-Remaining` is derivable from `X-Quota-Limit - X-Quota-Used` but its presence as a distinct header adds no information the tenant doesn't already have. The risk is minimal since capture endpoints already require valid API key auth. Flagged for awareness; not blocking.
+  TASK: Task 2, Task 5.
+
+---
+
+No blocking issues. The `handlePutTenantConfig` error mapping gap (first finding) is the only one likely to cause a concrete runtime defect. The missing tier management route is an operational security gap (audit trail) that should be resolved before the phase closes. The quota header finding is informational.

--- a/docs/history/nefario-reports/2026-03-23-030747-tenant-quotas/phase3.5-test-minion.md
+++ b/docs/history/nefario-reports/2026-03-23-030747-tenant-quotas/phase3.5-test-minion.md
@@ -1,0 +1,37 @@
+ADVISE
+
+- [testing]: Task 2 quota tests require the tenant row to have a `tier` column but `seedApiKey` in `fixtures.js` does not seed a `tier` value, so the column defaults to 'free' only after the migration runs -- tests that assert quota behavior will silently pass with free-tier defaults even if the migration is missing or not applied in the test environment.
+  SCOPE: `test/fixtures.js`, `test/capture-integration.test.js`, `test/batch-capture.test.js`
+  CHANGE: Add a `seedTenantTier(db, tenantId, tier)` helper to `fixtures.js` and use it explicitly in the Task 2 quota tests, so each test that depends on tier-specific limits sets the tier deliberately rather than relying on the column default.
+  WHY: The existing `cleanDb()` + `seedApiKey()` pattern creates a tenant row with no explicit tier. If the migration hasn't applied (or if a future test forgets to set tier), the test still passes because the app falls back to free defaults. The test should fail loudly when tier state is wrong, not silently continue with a different tier than intended.
+  TASK: Task 2
+
+- [testing]: The plan requires testing that "quota check runs after rate limit" by sending a request that is both rate-limited and over-quota, but `capture-integration.test.js` uses a shared KV rate-limit bucket that can be exhausted by prior tests in the same run, making the ordering test unreliable.
+  SCOPE: `test/capture-integration.test.js`
+  CHANGE: The ordering test must use a unique `CF-Connecting-IP` that has not been seen in the current test run (use the `nextTestIp()` pattern from `batch-capture.test.js`) and pre-seed the tenant's usage_counters to be at-quota BEFORE exhausting the IP rate limit. Add a `beforeEach` that cleans KV rate-limit keys for the ordering test's IP, so the test controls both states.
+  WHY: The test depends on the rate limiter firing before the quota check. If the KV bucket for that IP is already exhausted by an earlier test, the rate limit 429 happens for the wrong reason (bucket exhaustion, not the test's intended setup). This produces a false positive that masks ordering regressions.
+  TASK: Task 2
+
+- [testing]: The Task 1 `checkQuota` test for "correct resetsAt (first of next month)" will produce a brittle date assertion unless the test either mocks the clock or uses a relative assertion.
+  SCOPE: `test/quotas.test.js`
+  CHANGE: Assert that `resetsAt` parses to a valid ISO date whose UTC day is 1 and whose UTC month is one greater than `computePeriod()`'s month (handling year rollover). Do not assert the exact ISO string, which would fail when tests run on different days. Example: `expect(new Date(result.resetsAt).getUTCDate()).toBe(1)`.
+  WHY: If the test asserts a hardcoded string like `"2026-04-01T00:00:00.000Z"`, it passes in March 2026 and fails in April 2026. The intent is "first of next month" which requires structural, not literal, assertion.
+  TASK: Task 1
+
+- [testing]: Task 3 (`GET /v1/account/usage`) test plan requires a "tenant with zero usage" case but does not specify that the `usage_counters` row must be absent (not just have zero values). The plan needs a test for the `usageResult.results?.[0]` being undefined, which is a distinct code path from a row with zeros.
+  SCOPE: `test/account-usage.test.js`
+  CHANGE: Add a distinct test case: "returns 200 with zero usage when no usage_counters row exists for the current period" (do not seed `usage_counters` at all). Separately, add "returns 200 with zero usage when usage_counters row has zero values" (seed a row with captureCount=0). These test two different code paths in the null-coalescing logic.
+  WHY: The `??` fallback `usage?.capture_count ?? 0` handles both cases, but only one is tested. If the row-absent path is broken (e.g., `results[0]` throws instead of returning undefined), it won't be caught.
+  TASK: Task 3
+
+- [testing]: The Task 4 UI tests target `test/ui-dashboard.test.js`, but the existing file tests `htmlDashboard()` response headers and HTML structure -- it does not have a DOM environment or the ability to call UI component functions directly. Progress bar rendering tests that assert CSS classes and ARIA attributes require either a DOM (jsdom) environment or a different testing approach.
+  SCOPE: `test/ui-dashboard.test.js`
+  CHANGE: Confirm that the test environment has jsdom available (check vitest config for `environment: 'jsdom'`). If not, the progress bar class tests must be written as string-content assertions against the generated HTML string, not DOM property checks. The plan's wording ("Usage section renders with correct progress bar percentages") implies DOM assertions -- clarify which approach is available before implementation.
+  WHY: String-template UI tests that check for class names in generated HTML are valid but different from DOM property checks. An agent implementing "assert CSS class applied" without knowing which approach is available will likely use DOM APIs that don't exist in the test environment, producing import errors rather than useful failures.
+  TASK: Task 4
+
+- [testing]: No test verifies that the `X-Quota-*` headers on a successful 202 response reflect the pre-capture state (i.e., before the usage increment, not after). The plan says quota check runs before the increment, but if the implementation reads usage after incrementing, the `X-Quota-Used` header will be inflated by 1 on the first capture.
+  SCOPE: `test/capture-integration.test.js`
+  CHANGE: Add a test that seeds a tenant with exactly N captures used (via `seedUsageCounter`), makes one successful capture, and asserts that `X-Quota-Used` equals N (pre-increment count), not N+1. This pins the documented semantics of the header.
+  WHY: The header should report the snapshot at check time. If implementation accidentally uses post-increment count, the value is misleading. Without a test that seeds a known count, this regression is invisible.
+  TASK: Task 2

--- a/docs/history/nefario-reports/2026-03-23-030747-tenant-quotas/phase3.5-ux-strategy-minion.md
+++ b/docs/history/nefario-reports/2026-03-23-030747-tenant-quotas/phase3.5-ux-strategy-minion.md
@@ -1,0 +1,25 @@
+## UX Strategy Review
+
+**Verdict: ADVISE**
+
+The core user journey is coherent and well-scoped. The plan correctly identifies that quota feedback belongs at two moments: the settings dashboard (proactive awareness) and the capture submit form (reactive correction). These are the right integration points and the right jobs-to-be-done. The decision to hide internal tier names (`free`/`pro`) behind display names (`Starter`/`Pro`) is the right call. The three concerns below are about friction in edge cases, not structural problems.
+
+---
+
+- [usability]: The 429 error message for quota-exceeded captures in the UI does not tell the user where to see their remaining quota or how to recover, leaving them in a dead end.
+  SCOPE: `src/ui/ui-captures.js` — quota-specific 429 error handling (Task 4, step 7)
+  CHANGE: The message "Monthly capture limit reached. Your quota resets on {date}." should include a link or navigation cue to the Usage section in Settings. Something like: "Monthly capture limit reached. Your quota resets on {date}. View usage in Settings."
+  WHY: The error tells the user what happened but not what to do next. Nielsen H10 (help users recover from errors) requires actionable guidance. The Settings page is one navigation step away — pointing there converts a dead end into a recovery path. Without it, users experiencing quota exhaustion for the first time have no self-serve recovery path and no way to understand their remaining capacity.
+  TASK: Task 4
+
+- [usability]: Storage bytes are formatted with SI units (1000-based: KB, MB, GB) but quota limits are defined in binary units (1 GB = 1,073,741,824 bytes). This creates a mismatch: a "1 GB" quota will display as "1.07 GB" when full, which is confusing.
+  SCOPE: `src/ui/ui-settings.js` — `formatBytes()` helper (Task 4, step 2)
+  CHANGE: Either (a) use binary units (GiB/MiB/KiB) consistently, or (b) use SI units (1000-based) AND store quota limits in SI-rounded values (1,000,000,000 bytes for "1 GB"). Option (b) is simpler since it keeps numbers round in the UI. The spec currently says `1 * 1024 * 1024 * 1024` in `TIER_QUOTAS` — this should be reconciled with whatever display unit is chosen.
+  WHY: A user whose quota says "1 GB" sees a progress bar that hits 100% at "1.07 GB" in SI, or never quite reaches "1 GiB" in binary display because the label on the tier says "1 GB." This is a small but predictable source of confusion that erodes trust in the accuracy of usage data. Consistency between the label (what the tier promises) and the display (what is shown) is a basic feedback heuristic.
+  TASK: Task 4 (and touches Task 1 constants if option b is chosen)
+
+- [usability]: The usage dashboard loads data only on page load with no refresh mechanism, but the plan also shows quota status headers (`X-Quota-*`) on every successful capture response. A user who makes captures in one tab and then checks settings in another will see stale quota data with no way to refresh short of a full page reload.
+  SCOPE: `src/ui/ui-settings.js` — `mountSettings()` fetch (Task 4)
+  CHANGE: Add a lightweight manual refresh affordance to the usage card — a small "Refresh" button or link that re-fetches `/v1/account/usage` and re-renders the section in place. This is a few lines of vanilla JS and avoids the cognitive dissonance of "I just used 10 captures but my dashboard still shows 42/100."
+  WHY: The plan explicitly calls out "updates on page load (not real-time)" as acceptable, and it is for the average case. But when the user's own actions are the cause of the discrepancy, a stale counter directly undermines the dashboard's purpose — knowing your current quota position. A single manual refresh button is the minimum viable feedback loop without polling complexity. The effort is low and the user benefit is concrete.
+  TASK: Task 4

--- a/docs/history/nefario-reports/2026-03-23-030747-tenant-quotas/phase5-code-review-minion.md
+++ b/docs/history/nefario-reports/2026-03-23-030747-tenant-quotas/phase5-code-review-minion.md
@@ -1,0 +1,38 @@
+# Code Review: R26 Tenant Quotas
+
+Reviewer: code-review-minion
+Date: 2026-03-23
+
+---
+
+VERDICT: ADVISE
+
+FINDINGS:
+
+- [ADVISE] src/ui/ui-settings.js:36 -- `formatBytes` MB branch has a ternary that always resolves to 0 decimal places. The expression `(n / 1000000).toFixed(n % 1000000 === 0 ? 0 : 0)` has identical branches: both sides of the conditional are `0`. This means 524.3 MB renders as "524 MB" instead of "524.3 MB", dropping sub-MB precision silently. The KB and GB branches handle fractional precision correctly; MB is the odd one out.
+  FIX: Change line 36 to: `if (n < 1000000000) return (n / 1000000).toFixed(n % 1000000 === 0 ? 0 : 1) + ' MB';`
+
+- [ADVISE] src/quotas.js:62-118 / src/account.js:472 -- `checkQuota` is used as the primary data source for `handleAccountGetUsage` by calling it with `count=0`. When the tenant is already over the capture limit (`captureCount > quota.capturesPerMonth`), the function returns a denied shape that omits `storageBytes` from its fields. The account.js fallback path (lines 492-504) re-queries D1 to recover the missing data -- this is correct and documented, but it means every over-quota usage page view costs two D1 round-trips. This is noted in the comment as acceptable. No action required unless the usage endpoint becomes a hotspot.
+  FIX: No change needed; the double-read on the over-quota path is intentional and documented. Flag for revisiting if usage endpoint becomes high-traffic.
+
+- [NIT] src/quotas.js:76 -- `JSON.parse(tenant.config)` is called without a try/catch. Malformed config JSON stored in D1 (e.g. from a bug in a previous admin write path) would cause an unhandled exception that propagates as a 500 to the capture endpoint. The project's "fail loudly" principle is satisfied since it would propagate up with a stack trace, but it would also deny captures to the tenant until the bad config is repaired. The admin `setTenantConfig` path validates and serializes correctly, so this is a defense-in-depth gap rather than a likely bug.
+  FIX: Wrap in try/catch and return `{ allowed: false, reason: 'config_parse_error' }`, or wrap in a helper that catches and logs. If you prefer to keep it simple, add a comment noting the assumption that config is always well-formed JSON (written only by setTenantConfig).
+
+- [NIT] src/account.js:492-496 -- The fallback D1 batch in `handleAccountGetUsage` duplicates the exact query shape from `checkQuota` (lines 65-70 of quotas.js): same two prepared statements, same column list, same bind order. If the quota query shape ever changes (e.g. adding a `tier_override` column), the fallback path will silently lag behind.
+  FIX: Extract the tenant+usage read into a small db.js helper (e.g. `getTenantAndUsage(db, tenantId, period)`) that both `checkQuota` and the account usage fallback can call. Not urgent given the small codebase, but keeps the query shape DRY.
+
+- [NIT] src/ui/ui-settings.js:361 -- `var keyLimit = 5;` is a hardcoded magic number duplicated from `account.js`'s `MAX_KEYS_PER_TENANT = 5`. If the server-side limit changes, the UI will show a stale count (e.g. "4 of 5 keys" when the real limit is 10). The UI already has the actual key count from the API; it could derive the limit from the API response instead.
+  FIX: Ideally, the GET /v1/account/keys response should include a `limit` field. As a minimum, add a comment linking this constant to `account.js:MAX_KEYS_PER_TENANT` so it is not missed during future changes.
+
+- [NIT] migrations/0005_tenant_tiers.sql:4 -- The migration comment correctly notes that SQLite/D1 does not support CHECK constraints in ALTER TABLE ADD COLUMN. However, there is no index on the new `tier` column. If a future admin query needs to list all tenants by tier (e.g. "all pro tenants"), it will require a full table scan. Not a correctness issue at current scale, but worth noting for the backlog.
+  FIX: No action required now. Add to backlog as: "Consider index on tenants.tier if tier-based admin queries are added."
+
+---
+
+## Summary
+
+The implementation is well-structured. The quota logic in `quotas.js` is clean, the D1 batch pattern is used correctly, and the test coverage is thorough: unit tests cover edge cases (boundary conditions, year rollover, per-tenant config overrides), integration tests cover the full HTTP stack for both single and batch capture endpoints, and the UI helper tests use the Function constructor pattern to test pure logic without DOM.
+
+The one genuine correctness issue is the `formatBytes` MB branch (ADVISE above) -- it always rounds to 0 decimal places due to a copy-paste error in the ternary. For a storage metric displaying values like 524.3 MB this is user-visible data loss. Everything else is nit-level.
+
+Security posture is solid: `tenantId` always sourced from verified session, quota checks occur before any work is queued, legacy-auth paths are explicitly excluded from quota (they have no D1 tenant record), and the UI DOM construction uses `textContent` throughout with no `innerHTML` on variable data.

--- a/docs/history/nefario-reports/2026-03-23-030747-tenant-quotas/prompt.md
+++ b/docs/history/nefario-reports/2026-03-23-030747-tenant-quotas/prompt.md
@@ -1,0 +1,20 @@
+**Outcome**: Tenants are subject to usage quotas (captures/month, storage GB) based on their tier. Quota checks happen before expensive operations (browser launch), and tenants can see their usage in the web UI.
+
+**Success criteria**:
+- Default quotas defined per tier: free (e.g., 100 captures/month, 1 GB storage), pro (e.g., 5000 captures/month, 50 GB)
+- Quota check runs before browser session creation in the capture pipeline
+- Exceeding quota returns 429 with `{ "error": "quota_exceeded", "detail": "monthly capture limit reached", "limit": N, "used": N }`
+- Per-tenant quota overrides stored in D1 (operator can grant custom limits)
+- Web UI usage dashboard shows current period usage vs. quota with a progress bar per metric
+- Usage dashboard updates on page load (not real-time; reads from D1 usage counters)
+- Quota enforcement is best-effort (eventual consistency of usage counters means slight overages are acceptable)
+- Tier assignment is stored per tenant in D1 and defaults to "free" on auto-provisioning
+
+**Scope**:
+- In: Tier-based default quotas, pre-capture quota check, 429 quota_exceeded response, per-tenant D1 overrides, web UI usage dashboard, tier field on tenant record
+- Out: Automatic tier upgrades (manual or via billing), storage cleanup/eviction on quota breach, per-endpoint API call quotas (only captures and storage for now), quota alerts/notifications
+
+**Constraints**:
+- Depends on R25 (usage metering) for counter data and R21 (per-tenant rate limiting) for the rate limit infrastructure
+- Quota check must not add >10ms latency to the capture request (single D1 read, cached if possible)
+- Must handle race conditions gracefully -- two concurrent captures from the same tenant near quota limit may both proceed; slight overages are acceptable

--- a/migrations/0005_tenant_tiers.sql
+++ b/migrations/0005_tenant_tiers.sql
@@ -1,0 +1,4 @@
+-- Add tier column to tenants.
+-- SQLite/D1 does not support CHECK constraints in ALTER TABLE ADD COLUMN;
+-- allowed-value validation ('free', 'pro') is enforced at the application layer.
+ALTER TABLE tenants ADD COLUMN tier TEXT NOT NULL DEFAULT 'free';

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -29,6 +29,8 @@ tags:
     description: API key management (admin-only)
   - name: webhooks
     description: Outbound webhook registration and management
+  - name: account
+    description: Tenant account information and usage
 
 components:
   securitySchemes:
@@ -89,6 +91,21 @@ components:
       schema:
         type: string
         example: '<https://github.com/benpeter/web-resource-ledger/blob/main/TERMS.md>; rel="terms-of-service"'
+    XQuotaLimit:
+      description: Maximum captures allowed in the current billing period.
+      schema:
+        type: integer
+        example: 100
+    XQuotaUsed:
+      description: Captures used in the current billing period.
+      schema:
+        type: integer
+        example: 42
+    XQuotaRemaining:
+      description: Captures remaining in the current billing period.
+      schema:
+        type: integer
+        example: 58
 
   schemas:
     CaptureId:
@@ -1092,6 +1109,87 @@ components:
             Last time counters were updated. Null if no activity in the period.
           example: '2026-03-22T14:30:00.000Z'
 
+    QuotaDetail:
+      type: object
+      description: Detail about which quota was exceeded and current usage at time of rejection.
+      properties:
+        limit:
+          type: integer
+          description: Maximum allowed for this resource in the current period.
+          example: 100
+        used:
+          type: integer
+          description: Current usage count.
+          example: 100
+        resource:
+          type: string
+          enum: [captures, storage]
+          description: Which resource quota was exceeded.
+          example: captures
+        resetsAt:
+          type: string
+          format: date-time
+          description: ISO 8601 timestamp when the quota resets (first of next month).
+          example: "2026-04-01T00:00:00.000Z"
+        requested:
+          type: integer
+          description: Number of items requested (present only for batch requests).
+          example: 10
+
+    UsageMetric:
+      type: object
+      description: Current usage, limit, and remaining allowance for a single resource.
+      required: [used, limit, remaining]
+      properties:
+        used:
+          type: integer
+          minimum: 0
+          description: Units consumed in the current billing period.
+          example: 42
+        limit:
+          type: integer
+          minimum: 0
+          description: Maximum units allowed in the current billing period.
+          example: 100
+        remaining:
+          type: integer
+          minimum: 0
+          description: Units remaining before the quota is reached.
+          example: 58
+
+    AccountUsageResponse:
+      type: object
+      description: >
+        Current-period usage and quota summary for the authenticated tenant.
+        Values reflect the tenant's effective quotas (tier defaults unless an
+        admin override is in effect).
+      required: [tenantId, period, tierDisplay, captures, storageBytes, resetsAt]
+      properties:
+        tenantId:
+          type: string
+          description: Tenant identifier.
+          example: "gh-12345"
+        period:
+          type: string
+          pattern: '^\d{4}-\d{2}$'
+          description: Billing period in YYYY-MM format.
+          example: "2026-03"
+        tierDisplay:
+          type: string
+          description: Human-readable tier name for UI display.
+          example: "Starter"
+        captures:
+          $ref: '#/components/schemas/UsageMetric'
+          description: Capture count usage and quota for the current period.
+        storageBytes:
+          $ref: '#/components/schemas/UsageMetric'
+          description: Storage byte usage and quota for the current period.
+        resetsAt:
+          type: string
+          format: date-time
+          description: ISO 8601 timestamp when the current period quotas reset (first of next month).
+          example: "2026-04-01T00:00:00.000Z"
+
     VerificationCheck:
       type: object
       description: Result of a single cryptographic check within a WACZ verification.
@@ -1297,7 +1395,17 @@ components:
               value: {type: about:blank, status: 401, title: Unauthorized, detail: Authorization header is required.}
 
     Problem429:
-      description: Too Many Requests — rate limit exceeded.
+      description: >
+        Too Many Requests — rate limit or monthly quota exceeded.
+
+        The response body includes a `limitType` extension field that distinguishes
+        the specific 429 variant:
+
+        - `limitType` absent: IP-based rate limit exceeded. Retry after `Retry-After` seconds.
+        - `limitType: 'tenant'`: Per-tenant rate limit exceeded. Retry after `Retry-After` seconds.
+        - `limitType: 'quota'`: Monthly capture quota exhausted. A `quota` extension object
+          is present with `limit`, `used`, `resource`, `resetsAt`, and (for batch) `requested`.
+          Retrying before `resetsAt` will continue to fail.
       headers:
         Referrer-Policy:
           $ref: '#/components/headers/ReferrerPolicy'
@@ -1319,8 +1427,21 @@ components:
             $ref: '#/components/schemas/ProblemDetail'
           examples:
             rateLimited:
-              summary: Caller exceeded allowed request rate
+              summary: IP-based rate limit exceeded
               value: {type: about:blank, status: 429, title: Too Many Requests, detail: Rate limit exceeded. Try again later.}
+            quotaExceeded:
+              summary: Monthly capture quota exhausted
+              value:
+                type: about:blank
+                status: 429
+                title: Too Many Requests
+                detail: Monthly capture quota exhausted. Quota resets on 2026-04-01.
+                limitType: quota
+                quota:
+                  limit: 100
+                  used: 100
+                  resource: captures
+                  resetsAt: "2026-04-01T00:00:00.000Z"
 
     Problem503:
       description: Service Unavailable -- required configuration is missing or service is at capacity.
@@ -1636,6 +1757,11 @@ paths:
         Enqueues a headless-browser capture of the given URL. Returns immediately with a capture
         ID; poll the status URL to determine when the capture is complete.
 
+        Monthly quota: each accepted capture counts against the tenant's monthly capture quota.
+        When the quota is exhausted the endpoint returns 429 with `limitType: 'quota'` in the
+        response body. Quota headers (`X-Quota-Limit`, `X-Quota-Used`, `X-Quota-Remaining`) are
+        present on successful 202 responses.
+
         CORS: This endpoint supports cross-origin requests from allowed origins. Preflight
         (OPTIONS) is handled automatically. Configure allowed origins via the CORS_ORIGINS
         environment variable.
@@ -1679,6 +1805,12 @@ paths:
                 example: 5
             X-RateLimit-Limit:
               $ref: '#/components/headers/XRateLimitLimit'
+            X-Quota-Limit:
+              $ref: '#/components/headers/XQuotaLimit'
+            X-Quota-Used:
+              $ref: '#/components/headers/XQuotaUsed'
+            X-Quota-Remaining:
+              $ref: '#/components/headers/XQuotaRemaining'
             Access-Control-Allow-Origin:
               description: Echoes the requesting origin when it matches the configured allowlist.
               schema:
@@ -1841,7 +1973,10 @@ paths:
                   summary: Double-encoded characters in URL
                   value: {type: about:blank, status: 422, title: Unprocessable Content, detail: URL contains double-encoded characters.}
         '429':
-          description: Too Many Requests — rate limit exceeded.
+          description: >
+            Too Many Requests — rate limit or monthly quota exceeded. See `limitType` in the
+            response body to distinguish rate limiting (`limitType` absent or `'tenant'`) from
+            quota exhaustion (`limitType: 'quota'`).
           headers:
             Referrer-Policy:
               $ref: '#/components/headers/ReferrerPolicy'
@@ -1872,8 +2007,21 @@ paths:
                 $ref: '#/components/schemas/ProblemDetail'
               examples:
                 rateLimited:
-                  summary: Caller exceeded allowed request rate
+                  summary: IP-based rate limit exceeded
                   value: {type: about:blank, status: 429, title: Too Many Requests, detail: Rate limit exceeded. Try again later.}
+                quotaExceeded:
+                  summary: Monthly capture quota exhausted
+                  value:
+                    type: about:blank
+                    status: 429
+                    title: Too Many Requests
+                    detail: Monthly capture quota exhausted. Quota resets on 2026-04-01.
+                    limitType: quota
+                    quota:
+                      limit: 100
+                      used: 100
+                      resource: captures
+                      resetsAt: "2026-04-01T00:00:00.000Z"
         '503':
           description: Service Unavailable -- service is at capacity.
           headers:
@@ -1920,6 +2068,13 @@ paths:
         validation or hits a per-item rate limit does not affect other items in
         the batch. Rate-limit tokens are consumed per URL, not per request.
 
+        Monthly quota: each accepted URL counts against the tenant's monthly capture quota.
+        When the quota is exhausted mid-batch, remaining items receive per-item 429 errors
+        with `limitType: 'quota'`. If the quota is exhausted before processing begins
+        (e.g., zero remaining), a top-level 429 is returned with `limitType: 'quota'` and a
+        `quota.requested` field indicating how many captures were requested. Quota headers
+        (`X-Quota-Limit`, `X-Quota-Used`, `X-Quota-Remaining`) are present on 207 responses.
+
         The response is always 207 Multi-Status when the batch structure itself
         is valid (non-empty urls array, within size limits). Top-level 400, 401,
         429, and 503 are returned when the entire request cannot be processed
@@ -1962,6 +2117,12 @@ paths:
               $ref: '#/components/headers/TermsLink'
             X-RateLimit-Limit:
               $ref: '#/components/headers/XRateLimitLimit'
+            X-Quota-Limit:
+              $ref: '#/components/headers/XQuotaLimit'
+            X-Quota-Used:
+              $ref: '#/components/headers/XQuotaUsed'
+            X-Quota-Remaining:
+              $ref: '#/components/headers/XQuotaRemaining'
           content:
             application/json:
               schema:
@@ -2082,7 +2243,11 @@ paths:
                   summary: Text/plain submitted instead of JSON
                   value: {type: about:blank, status: 415, title: Unsupported Media Type, detail: Content-Type must be application/json}
         '429':
-          description: Too Many Requests — pre-flight rate limit exceeded before any item was processed.
+          description: >
+            Too Many Requests — pre-flight rate limit or monthly quota exceeded before any item
+            was processed. See `limitType` in the response body: absent means rate limit,
+            `'quota'` means monthly quota exhausted. When `limitType` is `'quota'`, the `quota`
+            object includes a `requested` field with the batch size that was attempted.
           headers:
             Referrer-Policy:
               $ref: '#/components/headers/ReferrerPolicy'
@@ -2104,8 +2269,22 @@ paths:
                 $ref: '#/components/schemas/ProblemDetail'
               examples:
                 rateLimited:
-                  summary: Caller exceeded allowed request rate
+                  summary: IP-based rate limit exceeded before processing
                   value: {type: about:blank, status: 429, title: Too Many Requests, detail: Rate limit exceeded. Try again later.}
+                quotaExceeded:
+                  summary: Monthly quota exhausted before batch could be processed
+                  value:
+                    type: about:blank
+                    status: 429
+                    title: Too Many Requests
+                    detail: Monthly capture quota exhausted. Quota resets on 2026-04-01.
+                    limitType: quota
+                    quota:
+                      limit: 100
+                      used: 100
+                      resource: captures
+                      resetsAt: "2026-04-01T00:00:00.000Z"
+                      requested: 5
         '503':
           description: Service Unavailable — service is at capacity.
           headers:
@@ -3502,5 +3681,92 @@ paths:
                 status: 404
                 title: Not Found
                 detail: "Tenant 'nonexistent' not found"
+        '429':
+          $ref: '#/components/responses/Problem429'
+
+  /v1/account/usage:
+    get:
+      operationId: getAccountUsage
+      summary: Get current usage and quota
+      description: >
+        Returns the authenticated tenant's current-period usage against their effective quotas.
+        Quotas reflect tier defaults unless an admin override is in effect for this tenant.
+
+        Use this endpoint to build quota-aware UIs or to check remaining capacity before
+        submitting large batches.
+      tags: [account]
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Current-period usage and quota for the authenticated tenant.
+          headers:
+            Referrer-Policy:
+              $ref: '#/components/headers/ReferrerPolicy'
+            X-Content-Type-Options:
+              $ref: '#/components/headers/XContentTypeOptions'
+            X-Frame-Options:
+              $ref: '#/components/headers/XFrameOptions'
+            Strict-Transport-Security:
+              $ref: '#/components/headers/StrictTransportSecurity'
+            Link:
+              $ref: '#/components/headers/TermsLink'
+            Cache-Control:
+              description: Prevents caching of tenant-scoped usage responses.
+              schema:
+                type: string
+                enum: ['private, no-store']
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccountUsageResponse'
+              examples:
+                withUsage:
+                  summary: Tenant with active usage this period
+                  value:
+                    tenantId: gh-12345
+                    period: "2026-03"
+                    tierDisplay: "Starter"
+                    captures:
+                      used: 42
+                      limit: 100
+                      remaining: 58
+                    storageBytes:
+                      used: 157286400
+                      limit: 1073741824
+                      remaining: 916455424
+                    resetsAt: "2026-04-01T00:00:00.000Z"
+                atLimit:
+                  summary: Tenant at capture quota limit
+                  value:
+                    tenantId: gh-12345
+                    period: "2026-03"
+                    tierDisplay: "Starter"
+                    captures:
+                      used: 100
+                      limit: 100
+                      remaining: 0
+                    storageBytes:
+                      used: 204800
+                      limit: 1073741824
+                      remaining: 1073536024
+                    resetsAt: "2026-04-01T00:00:00.000Z"
+                fresh:
+                  summary: Tenant with no usage this period
+                  value:
+                    tenantId: gh-12345
+                    period: "2026-03"
+                    tierDisplay: "Starter"
+                    captures:
+                      used: 0
+                      limit: 100
+                      remaining: 100
+                    storageBytes:
+                      used: 0
+                      limit: 1073741824
+                      remaining: 1073741824
+                    resetsAt: "2026-04-01T00:00:00.000Z"
+        '401':
+          $ref: '#/components/responses/Problem401'
         '429':
           $ref: '#/components/responses/Problem429'

--- a/site/_data/site.js
+++ b/site/_data/site.js
@@ -6,6 +6,7 @@ export default {
     { title: "Authentication", url: "/authentication/" },
     { title: "Verification", url: "/verification/" },
     { title: "Batch Captures", url: "/batch/" },
+    { title: "Limits & Quotas", url: "/limits/" },
     { title: "Webhooks", url: "/webhooks/" },
     { title: "MCP Server", url: "/mcp/" },
     { title: "API Reference", url: "/api-reference/" },

--- a/site/content/batch.md
+++ b/site/content/batch.md
@@ -155,8 +155,12 @@ The entire batch fails (not 207) in these cases:
 | `401` | Missing or invalid `Authorization` header. |
 | `503` | Service is at capacity. Retry after the `Retry-After` header value (seconds). |
 
-### Rate limits
+### Rate limits and quotas
 
 Rate limits apply per URL, not per request. Submitting a batch of 10 URLs consumes 10 tokens from your rate limit. If you are near the limit, some items may return `429` while others are accepted. The `summary.failed` count will reflect this.
 
 When you receive `429` items, wait for the window to reset (indicated by the `Retry-After` header on rate-limited responses) and resubmit only the rejected URLs.
+
+Monthly quota checks work differently: the entire batch is rejected upfront if it would exceed the remaining quota. In that case, the response is a single `429` with `limitType: 'quota'` -- not a `207` with per-item errors.
+
+For detailed information about rate limits and monthly quotas, see [Limits & Quotas](/limits/).

--- a/site/content/index.md
+++ b/site/content/index.md
@@ -121,6 +121,9 @@ Use WRL with AI agents in Claude Code, Cursor, Windsurf, and other MCP clients.
 **[Batch Captures](/batch/)**
 Submit multiple URLs in a single request and handle per-item results.
 
+**[Limits & Quotas](/limits/)**
+Understand rate limits, monthly capture and storage quotas, and how to read quota headers.
+
 **[Webhooks](/webhooks/)**
 Receive real-time notifications when captures complete or fail.
 

--- a/site/content/limits.md
+++ b/site/content/limits.md
@@ -1,0 +1,171 @@
+---
+layout: layouts/doc.njk
+title: Limits & Quotas
+description: How WRL enforces rate limits (burst protection) and monthly quotas (usage caps), with response examples and operator override instructions.
+---
+
+# Limits & Quotas
+
+WRL enforces two types of request limits: **rate limits** (short-term burst protection) and **quotas** (monthly usage caps). Both return `429` responses, but they are distinct and require different handling.
+
+## Rate Limits vs Quotas
+
+| | Rate Limits | Quotas |
+|---|---|---|
+| **Scope** | Per IP or per tenant | Per tenant |
+| **Window** | 60 seconds | Calendar month |
+| **Reset** | Rolling window (seconds) | First of next month |
+| **429 `limitType`** | `'tenant'` or absent | `'quota'` |
+| **`Retry-After` format** | Seconds (integer) | HTTP-date |
+
+---
+
+## Monthly Quotas
+
+Each tenant is assigned a tier that determines their monthly limits.
+
+| Tier | Captures / month | Storage |
+|---|---|---|
+| Starter (free) | 100 | 1 GB |
+| Pro | 5,000 | 50 GB |
+
+### Checking Usage
+
+Every successful capture response includes `X-Quota-*` headers so you can monitor usage without making a separate request.
+
+| Header | Description |
+|---|---|
+| `X-Quota-Limit` | Maximum captures allowed in the current billing period |
+| `X-Quota-Used` | Captures consumed so far this period |
+| `X-Quota-Remaining` | Captures left before the quota is exhausted |
+
+To check usage programmatically without submitting a capture, use the account usage endpoint (requires session auth):
+
+```bash
+GET /v1/account/usage
+```
+
+### Quota Exceeded Response
+
+When a capture request would exceed the monthly quota, WRL returns a `429` before any capture work is attempted.
+
+```bash
+curl -X POST https://api.webresourceledger.com/v1/captures \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"url": "https://example.com"}'
+```
+
+```
+HTTP/1.1 429 Too Many Requests
+Retry-After: Mon, 01 Apr 2026 00:00:00 GMT
+Content-Type: application/json
+```
+
+```json
+{
+  "type": "about:blank",
+  "status": 429,
+  "title": "Too Many Requests",
+  "detail": "Monthly capture quota exceeded. Your quota resets on 2026-04-01.",
+  "limitType": "quota",
+  "quota": {
+    "resource": "captures",
+    "limit": 100,
+    "used": 100,
+    "remaining": 0,
+    "resetsAt": "2026-04-01T00:00:00.000Z"
+  }
+}
+```
+
+Key differences from rate-limit `429` responses:
+
+- `limitType` is `'quota'`, not `'tenant'` or absent
+- `quota.resource` indicates which limit was hit: `'captures'` or `'storage'`
+- `Retry-After` is an HTTP-date string (not a seconds integer) -- it points to the first second of the next billing period
+
+### Batch Captures and Quotas
+
+Batch requests check quota upfront for the entire batch before any capture is queued. If the batch would exceed the remaining quota, the **entire batch is rejected** with a single `429` response -- no items are accepted.
+
+For example, if you have 30 captures remaining and submit a batch of 50 URLs, all 50 are rejected. Resubmit a smaller batch that fits within the remaining quota, or wait until the quota resets.
+
+See [Batch Captures](/batch/) for full batch error handling patterns.
+
+---
+
+## Rate Limits
+
+Rate limits protect against short bursts of traffic. They apply independently of quotas -- you can hit a rate limit even when quota is plentiful, and you can exhaust quota without ever hitting a rate limit.
+
+### Per-IP Limits
+
+Unauthenticated or low-trust requests are subject to per-IP rate limiting. The limit applies to the originating IP address.
+
+### Per-Tenant Limits
+
+Authenticated requests are rate-limited per tenant. The window is 60 seconds, rolling.
+
+### Rate Limit Response
+
+```
+HTTP/1.1 429 Too Many Requests
+Retry-After: 42
+Content-Type: application/json
+```
+
+```json
+{
+  "type": "about:blank",
+  "status": 429,
+  "title": "Too Many Requests",
+  "detail": "Rate limit exceeded. Retry after 42 seconds.",
+  "limitType": "tenant"
+}
+```
+
+- `limitType` is `'tenant'` for per-tenant limits, or absent for per-IP limits
+- `Retry-After` is an integer number of seconds until the window resets
+
+When you receive a rate-limit `429`, wait the number of seconds in `Retry-After` before retrying. For batch requests, rate limits apply per URL -- see [Batch Captures](/batch/) for details.
+
+---
+
+## Custom Quotas (Operators)
+
+Operators can override the default tier quotas for individual tenants via the admin API. This is useful for granting higher limits to enterprise tenants or restricting a specific tenant below the tier default.
+
+```bash
+curl -X PUT https://api.webresourceledger.com/v1/admin/tenants/acme-corp/config \
+  -H "Authorization: Bearer YOUR_ADMIN_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "quotas": {
+      "capturesPerMonth": 25000,
+      "storageBytes": 107374182400
+    }
+  }'
+```
+
+```json
+{
+  "tenantId": "acme-corp",
+  "config": {
+    "quotas": {
+      "capturesPerMonth": 25000,
+      "storageBytes": 107374182400
+    }
+  },
+  "updatedAt": "2026-03-23T09:00:00.000Z"
+}
+```
+
+Request fields:
+
+| Field | Type | Description |
+|---|---|---|
+| `quotas.capturesPerMonth` | integer | Override for monthly capture limit. Replaces the tier default. |
+| `quotas.storageBytes` | integer | Override for storage limit in bytes. Replaces the tier default. |
+
+To remove a custom override and return the tenant to their tier default, omit the field or set it to `null`.

--- a/src/account.js
+++ b/src/account.js
@@ -24,9 +24,10 @@
 
 import { jsonResponse, problemResponse } from './responses.js';
 import { hashApiKey } from './auth.js';
-import { createApiKeyRecord, getApiKeyRecord, listApiKeyRecords, revokeApiKeyRecord, acceptTos } from './db.js';
+import { createApiKeyRecord, getApiKeyRecord, listApiKeyRecords, revokeApiKeyRecord, acceptTos, computePeriod } from './db.js';
 import { log } from './log.js';
 import { computeCip } from './ip-hash.js';
+import { checkQuota, getEffectiveQuota, TIER_DISPLAY_NAMES, DEFAULT_TIER, computeQuotaReset } from './quotas.js';
 
 const NAME_RE = /^[a-zA-Z0-9 _.:-]{1,128}$/;
 
@@ -439,4 +440,92 @@ export async function handleAccountAcceptTos(request, env, ctx, _match) {
   }) ?? Promise.resolve());
 
   return jsonResponse({ ok: true, tosAcceptedAt }, 200, ACCOUNT_CACHE);
+}
+
+// ---------------------------------------------------------------------------
+// GET /v1/account/usage
+// ---------------------------------------------------------------------------
+
+/**
+ * Return current-period quota usage for the authenticated tenant.
+ *
+ * Reuses checkQuota(db, tenantId, 0) as the primary data source to avoid
+ * duplicating the D1 batch query. count=0 means the capture check fires only
+ * if captureCount > quota (already over), not on the normal path.
+ *
+ * Edge case: when the tenant is already over their capture or storage limit,
+ * checkQuota returns a limited shape (missing tier, quota, or the other usage
+ * counter). In that case a single fallback read fills in the missing fields.
+ * This endpoint is not on the hot capture path, so the extra read is fine.
+ *
+ * @param {Request} request
+ * @param {object} env  env._session is set by the router (verified session)
+ * @param {ExecutionContext} ctx
+ * @param {RegExpMatchArray} _match  unused
+ * @returns {Promise<Response>}
+ */
+export async function handleAccountGetUsage(request, env, ctx, _match) {
+  const clientIp = request.headers.get('CF-Connecting-IP') || 'unknown';
+  const cip = await computeCip(env, clientIp);
+  const { tenantId } = env._session;
+
+  const result = await checkQuota(env.DB, tenantId, 0);
+
+  if (!result.allowed && result.reason === 'tenant_not_found') {
+    return jsonResponse({ error: 'tenant_not_found' }, 404, ACCOUNT_CACHE);
+  }
+
+  let tier, quota, captureCount, storageBytes, period;
+
+  if (result.allowed) {
+    // Common case: under both limits, checkQuota returns full data.
+    tier          = result.tier;
+    quota         = result.quota;
+    captureCount  = result.captureCount;
+    storageBytes  = result.storageBytes;
+    period        = result.period;
+  } else {
+    // Already over capture or storage limit. checkQuota returns a limited shape
+    // that omits tier, quota, and (depending on reason) the other counter.
+    // Read the tenant + usage rows directly so we can build a complete response.
+    period = result.period ?? computePeriod();
+    const [tenantRow, usageRow] = await env.DB.batch([
+      env.DB.prepare('SELECT tier, config FROM tenants WHERE id = ?').bind(tenantId),
+      env.DB.prepare(
+        'SELECT capture_count, storage_bytes FROM usage_counters WHERE tenant_id = ? AND period = ?',
+      ).bind(tenantId, period),
+    ]);
+    const tenantData = tenantRow.results?.[0];
+    const config     = tenantData?.config ? JSON.parse(tenantData.config) : null;
+    tier         = tenantData?.tier || DEFAULT_TIER;
+    quota        = getEffectiveQuota(tier, config);
+    const usageData  = usageRow.results?.[0];
+    captureCount = usageData?.capture_count ?? 0;
+    storageBytes = usageData?.storage_bytes ?? 0;
+  }
+
+  ctx.waitUntil(log(env, 3, 'oauth', {
+    event: 'oauth.usage_view',
+    cip,
+    tenantId,
+    authMethod: 'session',
+    responseStatus: 200,
+  }) ?? Promise.resolve());
+
+  return jsonResponse({
+    tenantId,
+    period,
+    tierDisplay: TIER_DISPLAY_NAMES[tier] || TIER_DISPLAY_NAMES[DEFAULT_TIER],
+    captures: {
+      used:      captureCount,
+      limit:     quota.capturesPerMonth,
+      remaining: Math.max(0, quota.capturesPerMonth - captureCount),
+    },
+    storageBytes: {
+      used:      storageBytes,
+      limit:     quota.storageBytes,
+      remaining: Math.max(0, quota.storageBytes - storageBytes),
+    },
+    resetsAt: computeQuotaReset(),
+  }, 200, ACCOUNT_CACHE);
 }

--- a/src/db.js
+++ b/src/db.js
@@ -26,6 +26,9 @@
 /** Regex for valid tenant IDs -- single source of truth, also exported from kv.js */
 export const TENANT_ID_RE = /^[a-z0-9_-]{1,64}$/;
 
+/** Allowed tier values. Application-layer validation (D1 ALTER TABLE has no CHECK support). */
+export const VALID_TIERS = ['free', 'pro'];
+
 /** Regex for valid webhook IDs: whk_ + 32 lowercase hex chars (total 36 chars) */
 export const WEBHOOK_ID_RE = /^whk_[a-f0-9]{32}$/;
 
@@ -285,6 +288,24 @@ export async function setTenantConfig(db, tenantId, config, updatedBy) {
     }
   }
 
+  // Validate per-tenant quota overrides if present
+  if (config.quotas) {
+    if (config.quotas.capturesPerMonth !== undefined) {
+      if (typeof config.quotas.capturesPerMonth !== 'number' ||
+          config.quotas.capturesPerMonth < 1 ||
+          !Number.isInteger(config.quotas.capturesPerMonth)) {
+        throw new Error('quotas.capturesPerMonth must be a positive integer');
+      }
+    }
+    if (config.quotas.storageBytes !== undefined) {
+      if (typeof config.quotas.storageBytes !== 'number' ||
+          config.quotas.storageBytes < 1 ||
+          !Number.isInteger(config.quotas.storageBytes)) {
+        throw new Error('quotas.storageBytes must be a positive integer');
+      }
+    }
+  }
+
   const updatedAt = new Date().toISOString();
   const record = {
     ...config,
@@ -301,6 +322,29 @@ export async function setTenantConfig(db, tenantId, config, updatedBy) {
   ).bind(tenantId, JSON.stringify(record), updatedAt, updatedBy).run();
 
   return record;
+}
+
+/**
+ * Update the tier for a tenant. The tenant row must already exist.
+ * Validates the tier value against VALID_TIERS before writing.
+ *
+ * @param {D1Database} db
+ * @param {string} tenantId
+ * @param {string} tier  'free' | 'pro'
+ * @param {string} updatedBy
+ * @returns {Promise<void>}
+ */
+export async function setTenantTier(db, tenantId, tier, updatedBy) {
+  if (!TENANT_ID_RE.test(tenantId)) {
+    throw new Error(`Invalid tenantId: ${tenantId}`);
+  }
+  if (!VALID_TIERS.includes(tier)) {
+    throw new Error(`Invalid tier '${tier}'; must be one of: ${VALID_TIERS.join(', ')}`);
+  }
+  const updatedAt = new Date().toISOString();
+  await db.prepare(
+    `UPDATE tenants SET tier = ?, updated_at = ?, updated_by = ? WHERE id = ?`,
+  ).bind(tier, updatedAt, updatedBy, tenantId).run();
 }
 
 // ---------------------------------------------------------------------------

--- a/src/index.js
+++ b/src/index.js
@@ -1122,7 +1122,7 @@ async function handlePutTenantConfig(request, env, ctx, match) {
   try {
     saved = await setTenantConfig(env.DB, tenantId, body, 'admin_key');
   } catch (err) {
-    if (err.message && (err.message.startsWith('rateLimit.') || err.message.startsWith('Invalid tenantId'))) {
+    if (err.message && (err.message.startsWith('rateLimit.') || err.message.startsWith('quotas.') || err.message.startsWith('Invalid tenantId'))) {
       return problemResponse(400, err.message);
     }
     throw err;

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ import { htmlVerifyResponse } from './verify-page.js';
 import { FAVICON_SVG } from './favicon.js';
 import { log } from './log.js';
 import { RATE_LIMITS, getEffectiveLimit } from './rate-limits.js';
+import { checkQuota } from './quotas.js';
 import { computeCip } from './ip-hash.js';
 import { handleAdminCreateKey, handleAdminListKeys, handleAdminRevokeKey, handleAdminGetUsage } from './admin.js';
 import { handleMcp } from './mcp.js';
@@ -17,7 +18,7 @@ import { htmlDashboard } from './ui/ui-shell.js';
 import { handleCreateWebhook, handleListWebhooks, handleDeleteWebhook, handlePingWebhook } from './webhooks.js';
 import { handleWebhookMessage, handleWebhookDlqMessage, dispatchWebhooks } from './webhook-dispatch.js';
 import { handleAuthLogin, handleAuthCallback, handleAuthLogout, handleAuthSession, handleFirstKey, handleFirstKeyAck } from './oauth.js';
-import { handleAccountListKeys, handleAccountCreateKey, handleAccountRevokeKey, handleAccountAcceptTos } from './account.js';
+import { handleAccountListKeys, handleAccountCreateKey, handleAccountRevokeKey, handleAccountAcceptTos, handleAccountGetUsage } from './account.js';
 import { verifySession } from './session.js';
 
 // tva
@@ -61,6 +62,7 @@ const routes = [
   ['POST',   /^\/v1\/account\/keys$/, handleAccountCreateKey],
   ['DELETE', /^\/v1\/account\/keys\/([a-f0-9]{64})$/, handleAccountRevokeKey],
   ['POST',   /^\/v1\/account\/tos$/, handleAccountAcceptTos],
+  ['GET',    /^\/v1\/account\/usage$/, handleAccountGetUsage],
 ];
 
 function getAllowedOrigin(request, env) {
@@ -425,8 +427,9 @@ export default {
     // X-RateLimit headers: authenticated handlers set their own (Limit/Remaining/Reset);
     // fall back to static Limit for unauthenticated endpoints (verify, admin)
     const rateLimitGroup = getRateLimitGroup(request.method, pathname);
-    if (rateLimitGroup && response.status !== 503 && !response.headers.has('X-RateLimit-Limit')) {
-      response.headers.set('X-RateLimit-Limit', String(RATE_LIMITS[rateLimitGroup].limit));
+    const rateLimitConfig = RATE_LIMITS[rateLimitGroup];
+    if (rateLimitConfig && response.status !== 503 && !response.headers.has('X-RateLimit-Limit')) {
+      response.headers.set('X-RateLimit-Limit', String(rateLimitConfig.limit));
     }
 
     response.headers.set('Referrer-Policy', 'no-referrer');
@@ -531,6 +534,17 @@ async function checkCaptureRateLimit(env, auth, clientIp, group, count = 1) {
   };
 }
 
+// Build X-Quota-* headers for successful capture responses.
+// Only called when quotaCheck.allowed is true -- callers must guard.
+function buildQuotaHeaders(quotaCheck) {
+  if (!quotaCheck?.allowed) return {};
+  return {
+    'X-Quota-Limit': String(quotaCheck.quota.capturesPerMonth),
+    'X-Quota-Used': String(quotaCheck.captureCount),
+    'X-Quota-Remaining': String(Math.max(0, quotaCheck.quota.capturesPerMonth - quotaCheck.captureCount)),
+  };
+}
+
 async function handleCreateCapture(request, env, ctx) {
   const clientIp = request.headers.get('CF-Connecting-IP') || 'unknown';
   const cip = await computeCip(env, clientIp);
@@ -580,6 +594,42 @@ async function handleCreateCapture(request, env, ctx) {
     rlHeaders['X-RateLimit-Limit'] = String(rl.limit);
     rlHeaders['X-RateLimit-Remaining'] = String(rl.remaining);
     rlHeaders['X-RateLimit-Reset'] = String(rl.resetIn);
+  }
+
+  // Step 3b: Monthly quota check (KV auth only -- legacy auth has no D1 tenant record)
+  let quotaCheck = null;
+  if (authMethod !== 'legacy') {
+    quotaCheck = await checkQuota(env.DB, tenantId);
+    if (!quotaCheck.allowed) {
+      ctx.waitUntil(log(env, 4, 'security', {
+        event: 'security.quota_exceeded',
+        tenantId, keyName, keyHashPrefix, authMethod,
+        reason: quotaCheck.reason,
+        limit: quotaCheck.limit,
+        used: quotaCheck.used,
+        responseStatus: 429,
+        cip,
+      }) ?? Promise.resolve());
+
+      const retryAfterDate = new Date(quotaCheck.resetsAt).toUTCString();
+      const quotaHeaders = {
+        'Retry-After': retryAfterDate,
+        ...rlHeaders,
+      };
+      const detail = quotaCheck.reason === 'capture_limit'
+        ? `Monthly capture quota reached (${quotaCheck.used}/${quotaCheck.limit}). Resets ${quotaCheck.resetsAt}. View usage in Settings.`
+        : `Storage quota reached. Resets ${quotaCheck.resetsAt}. View usage in Settings.`;
+
+      return problemResponse(429, detail, quotaHeaders, {
+        limitType: 'quota',
+        quota: {
+          limit: quotaCheck.limit,
+          used: quotaCheck.used,
+          resource: quotaCheck.reason === 'capture_limit' ? 'captures' : 'storage',
+          resetsAt: quotaCheck.resetsAt,
+        },
+      });
+    }
   }
 
   // Global rate limit check (service capacity protection)
@@ -679,7 +729,7 @@ async function handleCreateCapture(request, env, ctx) {
     id: captureId,
     statusUrl,
     note: 'Use GET /v1/captures to list and search your captures.',
-  }, 202, { 'Retry-After': '10', ...rlHeaders });
+  }, 202, { 'Retry-After': '10', ...rlHeaders, ...buildQuotaHeaders(quotaCheck) });
 }
 
 async function handleBatchCapture(request, env, ctx) {
@@ -752,6 +802,44 @@ async function handleBatchCapture(request, env, ctx) {
     rlHeaders['X-RateLimit-Limit'] = String(rl.limit);
     rlHeaders['X-RateLimit-Remaining'] = String(rl.remaining);
     rlHeaders['X-RateLimit-Reset'] = String(rl.resetIn);
+  }
+
+  // Step 5b: Monthly quota check -- entire batch (KV auth only -- legacy has no D1 tenant record)
+  let quotaCheck = null;
+  if (authMethod !== 'legacy') {
+    quotaCheck = await checkQuota(env.DB, tenantId, body.urls.length);
+    if (!quotaCheck.allowed) {
+      ctx.waitUntil(log(env, 4, 'security', {
+        event: 'security.quota_exceeded',
+        tenantId, keyName, keyHashPrefix, authMethod,
+        reason: quotaCheck.reason,
+        limit: quotaCheck.limit,
+        used: quotaCheck.used,
+        requested: body.urls.length,
+        responseStatus: 429,
+        cip,
+      }) ?? Promise.resolve());
+
+      const retryAfterDate = new Date(quotaCheck.resetsAt).toUTCString();
+      const quotaHeaders = {
+        'Retry-After': retryAfterDate,
+        ...rlHeaders,
+      };
+      const detail = quotaCheck.reason === 'capture_limit'
+        ? `Batch of ${body.urls.length} captures would exceed monthly quota (${quotaCheck.used}/${quotaCheck.limit}). Resets ${quotaCheck.resetsAt}. View usage in Settings.`
+        : `Storage quota reached. Resets ${quotaCheck.resetsAt}. View usage in Settings.`;
+
+      return problemResponse(429, detail, quotaHeaders, {
+        limitType: 'quota',
+        quota: {
+          limit: quotaCheck.limit,
+          used: quotaCheck.used,
+          requested: body.urls.length,
+          resource: quotaCheck.reason === 'capture_limit' ? 'captures' : 'storage',
+          resetsAt: quotaCheck.resetsAt,
+        },
+      });
+    }
   }
 
   // Step 6: Global capacity pre-check
@@ -899,7 +987,7 @@ async function handleBatchCapture(request, env, ctx) {
   }) ?? Promise.resolve());
 
   // Step 10: Return 207
-  return jsonResponse({ items, summary: { total: items.length, accepted, failed } }, 207, rlHeaders);
+  return jsonResponse({ items, summary: { total: items.length, accepted, failed } }, 207, { ...rlHeaders, ...buildQuotaHeaders(quotaCheck) });
 }
 
 async function handleListCaptures(request, env, ctx) {

--- a/src/quotas.js
+++ b/src/quotas.js
@@ -1,0 +1,118 @@
+// Quota configuration for tenant tiers.
+// Tier defaults define monthly capture and storage limits.
+// Per-tenant overrides live in tenants.config JSON under the 'quotas' key.
+// tva
+
+import { computePeriod } from './db.js';
+
+export const TIER_QUOTAS = {
+  free: { capturesPerMonth: 100,  storageBytes: 1  * 1024 * 1024 * 1024 },  // 1 GB
+  pro:  { capturesPerMonth: 5000, storageBytes: 50 * 1024 * 1024 * 1024 },  // 50 GB
+};
+
+export const DEFAULT_TIER = 'free';
+
+// UI display names -- internal code uses 'free'/'pro', UI shows these
+export const TIER_DISPLAY_NAMES = {
+  free: 'Starter',
+  pro:  'Pro',
+};
+
+/**
+ * Compute the ISO timestamp at which the current quota period resets.
+ * Always the first moment of the next calendar month (UTC).
+ *
+ * @returns {string} ISO 8601 timestamp
+ */
+export function computeQuotaReset() {
+  const now = new Date();
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1)).toISOString();
+}
+
+/**
+ * Return the effective quota for a tenant by merging tier defaults with any
+ * per-tenant overrides from tenantConfig.quotas.
+ *
+ * Pattern mirrors getEffectiveLimit() in rate-limits.js.
+ *
+ * @param {string} tier  'free' | 'pro' (unknown value falls back to DEFAULT_TIER)
+ * @param {object|null} tenantConfig  From getTenantConfig(), may be null
+ * @returns {{ capturesPerMonth: number, storageBytes: number }}
+ */
+export function getEffectiveQuota(tier, tenantConfig) {
+  const defaults = TIER_QUOTAS[tier] || TIER_QUOTAS[DEFAULT_TIER];
+  if (!tenantConfig?.quotas) return { ...defaults };
+  return {
+    capturesPerMonth: tenantConfig.quotas.capturesPerMonth ?? defaults.capturesPerMonth,
+    storageBytes:     tenantConfig.quotas.storageBytes     ?? defaults.storageBytes,
+  };
+}
+
+/**
+ * Check whether a tenant has remaining quota for a capture operation.
+ *
+ * Performs a single D1 batch (two prepared statements, one round-trip) to read
+ * tenant tier+config and current-period usage simultaneously.
+ *
+ * @param {D1Database} db
+ * @param {string} tenantId
+ * @param {number} [count=1]  Number of captures being requested (supports batch checks)
+ * @returns {Promise<object>} Result object with allowed:boolean and contextual fields
+ */
+export async function checkQuota(db, tenantId, count = 1) {
+  const period = computePeriod();
+
+  const [tenantResult, usageResult] = await db.batch([
+    db.prepare('SELECT tier, config FROM tenants WHERE id = ?').bind(tenantId),
+    db.prepare(
+      'SELECT capture_count, storage_bytes FROM usage_counters WHERE tenant_id = ? AND period = ?',
+    ).bind(tenantId, period),
+  ]);
+
+  const tenant = tenantResult.results?.[0];
+  if (!tenant) return { allowed: false, reason: 'tenant_not_found' };
+
+  const tier   = tenant.tier || DEFAULT_TIER;
+  const config = tenant.config ? JSON.parse(tenant.config) : null;
+  const quota  = getEffectiveQuota(tier, config);
+
+  const usage        = usageResult.results?.[0];
+  const captureCount = usage?.capture_count ?? 0;
+  const storageBytes = usage?.storage_bytes ?? 0;
+
+  // Capture limit: check whether adding `count` would exceed the monthly cap.
+  // Uses > (not >=) so that count>1 batch checks work correctly.
+  if (captureCount + count > quota.capturesPerMonth) {
+    return {
+      allowed:   false,
+      reason:    'capture_limit',
+      limit:     quota.capturesPerMonth,
+      used:      captureCount,
+      requested: count,
+      resetsAt:  computeQuotaReset(),
+      period,
+    };
+  }
+
+  // Storage limit: check whether the tenant is already at or over their quota.
+  // We cannot know the size of the incoming capture in advance.
+  if (storageBytes >= quota.storageBytes) {
+    return {
+      allowed:  false,
+      reason:   'storage_limit',
+      limit:    quota.storageBytes,
+      used:     storageBytes,
+      resetsAt: computeQuotaReset(),
+      period,
+    };
+  }
+
+  return {
+    allowed:      true,
+    quota,
+    captureCount,
+    storageBytes,
+    tier,
+    period,
+  };
+}

--- a/src/ui/ui-css.js
+++ b/src/ui/ui-css.js
@@ -752,6 +752,66 @@ input, select, textarea {
 }
 
 /* ---------------------------------------------------------------------------
+   Usage section
+--------------------------------------------------------------------------- */
+
+.usage-metric { margin-bottom: var(--space-4); }
+.usage-metric:last-of-type { margin-bottom: 0; }
+.usage-metric-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: var(--space-1);
+}
+.usage-metric-label {
+  font-size: var(--text-sm);
+  font-weight: 500;
+  color: var(--color-text-muted);
+}
+.usage-metric-value {
+  font-size: var(--text-sm);
+  font-variant-numeric: tabular-nums;
+  color: var(--color-text);
+}
+.usage-bar {
+  height: 8px;
+  background: var(--color-surface-muted);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  border: 1px solid var(--color-border-subtle);
+}
+.usage-bar-fill {
+  height: 100%;
+  background: var(--color-accent);
+  border-radius: var(--radius-sm);
+  transition: width 0.2s ease;
+  min-width: 0;
+}
+.usage-bar-fill--warning { background: var(--color-warning); }
+.usage-bar-fill--critical { background: var(--color-error); }
+.usage-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: var(--space-3);
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+}
+.usage-refresh-btn {
+  background: none;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  color: var(--color-text-muted);
+  cursor: pointer;
+  padding: 2px 8px;
+  font-size: var(--text-sm);
+}
+.usage-refresh-btn:hover {
+  background: var(--color-surface-muted);
+  color: var(--color-text);
+}
+
+/* ---------------------------------------------------------------------------
    Reduced motion
 --------------------------------------------------------------------------- */
 

--- a/src/ui/ui-settings.js
+++ b/src/ui/ui-settings.js
@@ -33,7 +33,7 @@ function formatBytes(n) {
   if (n === null || n === undefined || isNaN(n)) return '0 B';
   if (n < 1000) return n + ' B';
   if (n < 1000000) return (n / 1000).toFixed(n % 1000 === 0 ? 0 : 1) + ' KB';
-  if (n < 1000000000) return (n / 1000000).toFixed(n % 1000000 === 0 ? 0 : 0) + ' MB';
+  if (n < 1000000000) return (n / 1000000).toFixed(n % 1000000 === 0 ? 0 : 1) + ' MB';
   return (n / 1000000000).toFixed(n % 1000000000 === 0 ? 0 : 1) + ' GB';
 }
 

--- a/src/ui/ui-settings.js
+++ b/src/ui/ui-settings.js
@@ -28,6 +28,27 @@ function formatDate(isoStr) {
   }
 }
 
+// Format bytes as SI units (1000-based): KB, MB, GB.
+function formatBytes(n) {
+  if (n === null || n === undefined || isNaN(n)) return '0 B';
+  if (n < 1000) return n + ' B';
+  if (n < 1000000) return (n / 1000).toFixed(n % 1000 === 0 ? 0 : 1) + ' KB';
+  if (n < 1000000000) return (n / 1000000).toFixed(n % 1000000 === 0 ? 0 : 0) + ' MB';
+  return (n / 1000000000).toFixed(n % 1000000000 === 0 ? 0 : 1) + ' GB';
+}
+
+// Format a "YYYY-MM" period string as a human-readable month label.
+function formatPeriod(period) {
+  if (!period) return '';
+  try {
+    // Append day so Date parsing is unambiguous UTC
+    var d = new Date(period + '-01T00:00:00Z');
+    return d.toLocaleDateString(undefined, { year: 'numeric', month: 'long', timeZone: 'UTC' });
+  } catch (e) {
+    return period;
+  }
+}
+
 function buildScopeBadges(scopes) {
   var frag = document.createDocumentFragment();
   if (!scopes || !scopes.length) return frag;
@@ -92,9 +113,20 @@ function mountSettings() {
     createdAt: _wrlUser ? _wrlUser.createdAt : ''
   };
 
-  // Fetch keys list
-  apiFetch('/v1/account/keys', { credentials: 'same-origin' })
-  .then(function(keysRes) {
+  // Fetch keys and usage in parallel. Usage failure must not block keys section.
+  var keysPromise = apiFetch('/v1/account/keys', { credentials: 'same-origin' });
+  var usagePromise = apiFetch('/v1/account/usage', { credentials: 'same-origin' })
+    .then(function(res) {
+      if (!res || !res.ok) return null;
+      return res.json();
+    })
+    .catch(function() { return null; });
+
+  Promise.all([keysPromise, usagePromise])
+  .then(function(results) {
+    var keysRes = results[0];
+    var usageData = results[1]; // null on failure
+
     if (!keysRes) return; // 401 handled by apiFetch
 
     if (!keysRes.ok) {
@@ -109,7 +141,7 @@ function mountSettings() {
 
     return keysRes.json().then(function(keysBody) {
       if (loadingEl) loadingEl.remove();
-      buildSettingsContent(view, accountData, keysBody || {});
+      buildSettingsContent(view, accountData, keysBody || {}, usageData);
     });
   }).catch(function() {
     if (loadingEl) loadingEl.remove();
@@ -122,10 +154,170 @@ function mountSettings() {
 }
 
 // ---------------------------------------------------------------------------
+// buildUsageMetric -- single progress bar row (captures or storage)
+// ---------------------------------------------------------------------------
+
+function buildUsageMetric(labelText, used, limit, ariaLabel) {
+  var pct = limit > 0 ? Math.min(100, Math.round((used / limit) * 100)) : 0;
+
+  var metric = document.createElement('div');
+  metric.className = 'usage-metric';
+
+  // Header row: label + "N of M" value
+  var header = document.createElement('div');
+  header.className = 'usage-metric-header';
+
+  var label = document.createElement('span');
+  label.className = 'usage-metric-label';
+  label.textContent = labelText;
+  header.appendChild(label);
+
+  var value = document.createElement('span');
+  value.className = 'usage-metric-value';
+  value.textContent = used + ' of ' + limit;
+  header.appendChild(value);
+
+  metric.appendChild(header);
+
+  // Progress bar
+  var bar = document.createElement('div');
+  bar.className = 'usage-bar';
+  bar.setAttribute('role', 'progressbar');
+  bar.setAttribute('aria-valuenow', String(used));
+  bar.setAttribute('aria-valuemin', '0');
+  bar.setAttribute('aria-valuemax', String(limit));
+  bar.setAttribute('aria-label', ariaLabel);
+
+  var fill = document.createElement('div');
+  var fillClass = 'usage-bar-fill';
+  if (pct >= 95) {
+    fillClass += ' usage-bar-fill--critical';
+  } else if (pct >= 80) {
+    fillClass += ' usage-bar-fill--warning';
+  }
+  fill.className = fillClass;
+  fill.style.width = pct + '%';
+  bar.appendChild(fill);
+
+  metric.appendChild(bar);
+  return metric;
+}
+
+// ---------------------------------------------------------------------------
+// buildUsageSection -- construct the Usage card (or error state)
+// ---------------------------------------------------------------------------
+
+function buildUsageSection(usageData) {
+  var section = document.createElement('section');
+  section.className = 'settings-section card';
+  section.id = 'settings-usage-section';
+  section.setAttribute('aria-labelledby', 'settings-usage-heading');
+
+  // Section heading row with period label
+  var headingRow = document.createElement('div');
+  headingRow.className = 'settings-keys-header';
+
+  var heading = document.createElement('h2');
+  heading.id = 'settings-usage-heading';
+  heading.className = 'settings-section-heading';
+  heading.textContent = 'Usage';
+  headingRow.appendChild(heading);
+
+  if (usageData && usageData.period) {
+    var periodEl = document.createElement('span');
+    periodEl.className = 'settings-keys-limit';
+    periodEl.textContent = formatPeriod(usageData.period);
+    headingRow.appendChild(periodEl);
+  }
+
+  section.appendChild(headingRow);
+
+  if (!usageData) {
+    // Error state: fetch failed
+    var errEl = document.createElement('p');
+    errEl.className = 'alert alert--error';
+    errEl.setAttribute('role', 'alert');
+    errEl.textContent = 'Could not load usage data.';
+    section.appendChild(errEl);
+    settingsAnnounce('Usage data could not be loaded.');
+    return section;
+  }
+
+  // Captures metric
+  var captures = usageData.captures || { used: 0, limit: 0, remaining: 0 };
+  var capturesAriaLabel = captures.used + ' of ' + captures.limit + ' captures used this month';
+  section.appendChild(buildUsageMetric('Captures', captures.used, captures.limit, capturesAriaLabel));
+
+  // Storage metric
+  var storage = usageData.storageBytes || { used: 0, limit: 0, remaining: 0 };
+  var storageUsedFmt = formatBytes(storage.used);
+  var storageLimitFmt = formatBytes(storage.limit);
+  var storageAriaLabel = storageUsedFmt + ' of ' + storageLimitFmt + ' storage used this month';
+
+  // Override the value text to show formatted bytes
+  var storageMetric = buildUsageMetric('Storage', storage.used, storage.limit, storageAriaLabel);
+  var storageValue = storageMetric.querySelector('.usage-metric-value');
+  if (storageValue) storageValue.textContent = storageUsedFmt + ' of ' + storageLimitFmt;
+
+  section.appendChild(storageMetric);
+
+  // Footer: plan name, reset date, refresh button
+  var footer = document.createElement('div');
+  footer.className = 'usage-footer';
+
+  var footerLeft = document.createElement('span');
+  var tierText = usageData.tierDisplay ? 'Plan: ' + usageData.tierDisplay : '';
+  var resetText = usageData.resetsAt ? 'Resets ' + formatDate(usageData.resetsAt) : '';
+  footerLeft.textContent = [tierText, resetText].filter(Boolean).join('  \u00b7  ');
+  footer.appendChild(footerLeft);
+
+  var refreshBtn = document.createElement('button');
+  refreshBtn.type = 'button';
+  refreshBtn.className = 'usage-refresh-btn';
+  refreshBtn.textContent = '\u21bb';
+  refreshBtn.setAttribute('aria-label', 'Refresh usage data');
+  refreshBtn.addEventListener('click', function() {
+    refreshUsageSection();
+  });
+  footer.appendChild(refreshBtn);
+
+  section.appendChild(footer);
+
+  settingsAnnounce('Usage data loaded.');
+  return section;
+}
+
+// ---------------------------------------------------------------------------
+// refreshUsageSection -- re-fetch usage and replace card in place
+// ---------------------------------------------------------------------------
+
+function refreshUsageSection() {
+  var existing = document.getElementById('settings-usage-section');
+  if (!existing) return;
+
+  // Show a simple loading state on the heading
+  var headingEl = existing.querySelector('#settings-usage-heading');
+  if (headingEl) headingEl.textContent = 'Usage \u2026';
+
+  apiFetch('/v1/account/usage', { credentials: 'same-origin' })
+    .then(function(res) {
+      if (!res || !res.ok) return null;
+      return res.json();
+    })
+    .catch(function() { return null; })
+    .then(function(usageData) {
+      var current = document.getElementById('settings-usage-section');
+      if (!current) return;
+      var fresh = buildUsageSection(usageData);
+      current.parentNode.replaceChild(fresh, current);
+    });
+}
+
+// ---------------------------------------------------------------------------
 // buildSettingsContent -- render account info + keys after data loads
 // ---------------------------------------------------------------------------
 
-function buildSettingsContent(view, accountData, keysData) {
+function buildSettingsContent(view, accountData, keysData, usageData) {
   // --- Account info section ---
   var accountSection = document.createElement('section');
   accountSection.className = 'settings-section card';
@@ -160,6 +352,9 @@ function buildSettingsContent(view, accountData, keysData) {
 
   accountSection.appendChild(infoGrid);
   view.appendChild(accountSection);
+
+  // --- Usage section ---
+  view.appendChild(buildUsageSection(usageData));
 
   // --- API Keys section ---
   var keys = (keysData && keysData.data) ? keysData.data : [];

--- a/src/ui/ui-submit.js
+++ b/src/ui/ui-submit.js
@@ -16,6 +16,15 @@ function safeUrl(urlStr) {
   }
 }
 
+function formatDate(isoStr) {
+  if (!isoStr) return '';
+  try {
+    return new Date(isoStr).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+  } catch (e) {
+    return isoStr;
+  }
+}
+
 function relativeTime(isoStr) {
   if (!isoStr) return '';
   var diff = Math.floor((Date.now() - new Date(isoStr).getTime()) / 1000);
@@ -383,7 +392,16 @@ function handleSubmit(urlInput, submitBtn, formErrorEl) {
 
     // Error response: show detail from Problem Details JSON
     return res.json().then(function(data) {
-      var detail = (data && data.detail) ? truncate(data.detail, 200) : 'Request failed (HTTP ' + res.status + ').';
+      var detail;
+      // 429 with limitType: 'quota' means monthly capture limit reached
+      if (res.status === 429 && data && data.limitType === 'quota') {
+        var resetDate = data.resetsAt ? formatDate(data.resetsAt) : '';
+        detail = 'Monthly capture limit reached.' +
+          (resetDate ? ' Your quota resets on ' + resetDate + '.' : '') +
+          ' View usage in Settings.';
+      } else {
+        detail = (data && data.detail) ? truncate(data.detail, 200) : 'Request failed (HTTP ' + res.status + ').';
+      }
       formErrorEl.textContent = detail;
       formErrorEl.style.display = '';
       urlInput.focus();

--- a/test/account-usage.test.js
+++ b/test/account-usage.test.js
@@ -1,0 +1,338 @@
+// tva
+// Integration tests for GET /v1/account/usage endpoint.
+// Uses SELF.fetch() -- requests go through the real worker.
+// D1 is real (miniflare-backed). Session auth via createTestSession().
+
+import { env, SELF } from 'cloudflare:test';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { cleanDb, createTestSession, seedUsageCounter } from './fixtures.js';
+import { TIER_QUOTAS, DEFAULT_TIER } from '../src/quotas.js';
+import { computePeriod } from '../src/db.js';
+
+const USAGE_URL = 'https://worker.test/v1/account/usage';
+
+let ipCounter = 200; // Distinct range from other test files
+function nextIp() {
+  return `10.0.2.${ipCounter++}`;
+}
+
+/**
+ * Create a test session with ToS accepted.
+ * All /v1/account/* routes (except /tos and /first-key) require tosAcceptedAt.
+ */
+async function createTosSession(overrides = {}) {
+  const session = await createTestSession(env.DB, env, overrides);
+  // Mark ToS as accepted in github_users so the session gate lets us through
+  await env.DB.prepare(
+    "UPDATE github_users SET tos_accepted_at = '2026-01-01T00:00:00.000Z', tos_version = '1.0' WHERE github_id = ?",
+  ).bind(session.githubId).run();
+  return session;
+}
+
+beforeEach(async () => {
+  await cleanDb(env.DB);
+});
+
+// ---------------------------------------------------------------------------
+// Auth
+// ---------------------------------------------------------------------------
+
+describe('GET /v1/account/usage -- auth', () => {
+  const ip = nextIp();
+
+  it('returns 401 without a session cookie', async () => {
+    const res = await SELF.fetch(USAGE_URL, {
+      headers: { 'CF-Connecting-IP': ip },
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 with a malformed session cookie', async () => {
+    const res = await SELF.fetch(USAGE_URL, {
+      headers: {
+        Cookie: '__Host-wrl_session=notvalid',
+        'CF-Connecting-IP': ip,
+      },
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 200 with a valid session cookie', async () => {
+    const { cookie } = await createTosSession();
+    const res = await SELF.fetch(USAGE_URL, {
+      headers: {
+        Cookie: cookie,
+        'CF-Connecting-IP': ip,
+      },
+    });
+    expect(res.status).toBe(200);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Response shape
+// ---------------------------------------------------------------------------
+
+describe('GET /v1/account/usage -- response shape', () => {
+  const ip = nextIp();
+
+  it('returns correct Content-Type', async () => {
+    const { cookie } = await createTosSession();
+    const res = await SELF.fetch(USAGE_URL, {
+      headers: { Cookie: cookie, 'CF-Connecting-IP': ip },
+    });
+    expect(res.headers.get('Content-Type')).toContain('application/json');
+  });
+
+  it('returns Cache-Control: private, no-store', async () => {
+    const { cookie } = await createTosSession();
+    const res = await SELF.fetch(USAGE_URL, {
+      headers: { Cookie: cookie, 'CF-Connecting-IP': ip },
+    });
+    expect(res.headers.get('Cache-Control')).toBe('private, no-store');
+  });
+
+  it('response body has exactly the expected top-level fields', async () => {
+    const { cookie } = await createTosSession();
+    const res = await SELF.fetch(USAGE_URL, {
+      headers: { Cookie: cookie, 'CF-Connecting-IP': ip },
+    });
+    const body = await res.json();
+    expect(Object.keys(body).sort()).toEqual(
+      ['captures', 'period', 'resetsAt', 'storageBytes', 'tenantId', 'tierDisplay'].sort(),
+    );
+  });
+
+  it('captures object has used, limit, remaining fields', async () => {
+    const { cookie } = await createTosSession();
+    const res = await SELF.fetch(USAGE_URL, {
+      headers: { Cookie: cookie, 'CF-Connecting-IP': ip },
+    });
+    const { captures } = await res.json();
+    expect(typeof captures.used).toBe('number');
+    expect(typeof captures.limit).toBe('number');
+    expect(typeof captures.remaining).toBe('number');
+  });
+
+  it('storageBytes object has used, limit, remaining fields', async () => {
+    const { cookie } = await createTosSession();
+    const res = await SELF.fetch(USAGE_URL, {
+      headers: { Cookie: cookie, 'CF-Connecting-IP': ip },
+    });
+    const { storageBytes } = await res.json();
+    expect(typeof storageBytes.used).toBe('number');
+    expect(typeof storageBytes.limit).toBe('number');
+    expect(typeof storageBytes.remaining).toBe('number');
+  });
+
+  it('resetsAt is a valid ISO 8601 timestamp', async () => {
+    const { cookie } = await createTosSession();
+    const res = await SELF.fetch(USAGE_URL, {
+      headers: { Cookie: cookie, 'CF-Connecting-IP': ip },
+    });
+    const { resetsAt } = await res.json();
+    expect(new Date(resetsAt).toISOString()).toBe(resetsAt);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tier display and quota limits
+// ---------------------------------------------------------------------------
+
+describe('GET /v1/account/usage -- tier display', () => {
+  const ip = nextIp();
+
+  it('free tenant shows tierDisplay "Starter"', async () => {
+    const { cookie } = await createTosSession();
+    const res = await SELF.fetch(USAGE_URL, {
+      headers: { Cookie: cookie, 'CF-Connecting-IP': ip },
+    });
+    const body = await res.json();
+    expect(body.tierDisplay).toBe('Starter');
+  });
+
+  it('does not expose the internal tier name in the response', async () => {
+    const { cookie } = await createTosSession();
+    const res = await SELF.fetch(USAGE_URL, {
+      headers: { Cookie: cookie, 'CF-Connecting-IP': ip },
+    });
+    const body = await res.json();
+    // 'free' or 'pro' should not appear as a top-level field
+    expect(Object.keys(body)).not.toContain('tier');
+  });
+
+  it('captures.limit equals free tier quota for free tenant', async () => {
+    const { cookie } = await createTosSession();
+    const res = await SELF.fetch(USAGE_URL, {
+      headers: { Cookie: cookie, 'CF-Connecting-IP': ip },
+    });
+    const body = await res.json();
+    expect(body.captures.limit).toBe(TIER_QUOTAS.free.capturesPerMonth);
+  });
+
+  it('storageBytes.limit equals free tier quota for free tenant', async () => {
+    const { cookie } = await createTosSession();
+    const res = await SELF.fetch(USAGE_URL, {
+      headers: { Cookie: cookie, 'CF-Connecting-IP': ip },
+    });
+    const body = await res.json();
+    expect(body.storageBytes.limit).toBe(TIER_QUOTAS.free.storageBytes);
+  });
+
+  it('pro tenant shows tierDisplay "Pro" with pro quota limits', async () => {
+    const { cookie, tenantId } = await createTosSession();
+    // Upgrade tenant to pro
+    await env.DB.prepare('UPDATE tenants SET tier = ? WHERE id = ?').bind('pro', tenantId).run();
+
+    const res = await SELF.fetch(USAGE_URL, {
+      headers: { Cookie: cookie, 'CF-Connecting-IP': ip },
+    });
+    const body = await res.json();
+    expect(body.tierDisplay).toBe('Pro');
+    expect(body.captures.limit).toBe(TIER_QUOTAS.pro.capturesPerMonth);
+    expect(body.storageBytes.limit).toBe(TIER_QUOTAS.pro.storageBytes);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Zero usage
+// ---------------------------------------------------------------------------
+
+describe('GET /v1/account/usage -- zero usage', () => {
+  const ip = nextIp();
+
+  it('returns 0 for captures.used when tenant has no usage row', async () => {
+    const { cookie } = await createTosSession();
+    const res = await SELF.fetch(USAGE_URL, {
+      headers: { Cookie: cookie, 'CF-Connecting-IP': ip },
+    });
+    const body = await res.json();
+    expect(body.captures.used).toBe(0);
+    expect(body.storageBytes.used).toBe(0);
+  });
+
+  it('remaining equals limit when usage is zero', async () => {
+    const { cookie } = await createTosSession();
+    const res = await SELF.fetch(USAGE_URL, {
+      headers: { Cookie: cookie, 'CF-Connecting-IP': ip },
+    });
+    const body = await res.json();
+    expect(body.captures.remaining).toBe(body.captures.limit);
+    expect(body.storageBytes.remaining).toBe(body.storageBytes.limit);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Usage data -- non-zero
+// ---------------------------------------------------------------------------
+
+describe('GET /v1/account/usage -- usage data', () => {
+  const ip = nextIp();
+
+  it('returns seeded usage for current period', async () => {
+    const { cookie, tenantId } = await createTosSession();
+    const period = computePeriod();
+
+    await seedUsageCounter(env.DB, {
+      tenantId,
+      period,
+      captureCount: 42,
+      storageBytes: 123456,
+    });
+
+    const res = await SELF.fetch(USAGE_URL, {
+      headers: { Cookie: cookie, 'CF-Connecting-IP': ip },
+    });
+    const body = await res.json();
+    expect(body.captures.used).toBe(42);
+    expect(body.storageBytes.used).toBe(123456);
+    expect(body.period).toBe(period);
+  });
+
+  it('remaining is correctly computed as limit minus used', async () => {
+    const { cookie, tenantId } = await createTosSession();
+    const period = computePeriod();
+
+    await seedUsageCounter(env.DB, { tenantId, period, captureCount: 30, storageBytes: 0 });
+
+    const res = await SELF.fetch(USAGE_URL, {
+      headers: { Cookie: cookie, 'CF-Connecting-IP': ip },
+    });
+    const body = await res.json();
+    expect(body.captures.remaining).toBe(TIER_QUOTAS.free.capturesPerMonth - 30);
+  });
+
+  it('remaining is 0 (not negative) when usage exceeds the limit', async () => {
+    const { cookie, tenantId } = await createTosSession();
+    const period = computePeriod();
+
+    // Seed usage beyond the free tier capture limit
+    const overLimit = TIER_QUOTAS.free.capturesPerMonth + 10;
+    await seedUsageCounter(env.DB, { tenantId, period, captureCount: overLimit });
+
+    const res = await SELF.fetch(USAGE_URL, {
+      headers: { Cookie: cookie, 'CF-Connecting-IP': ip },
+    });
+    const body = await res.json();
+    expect(body.captures.remaining).toBe(0);
+  });
+
+  it('storageBytes.remaining is 0 (not negative) when at storage limit', async () => {
+    const { cookie, tenantId } = await createTosSession();
+    const period = computePeriod();
+
+    await seedUsageCounter(env.DB, {
+      tenantId,
+      period,
+      storageBytes: TIER_QUOTAS.free.storageBytes,
+    });
+
+    const res = await SELF.fetch(USAGE_URL, {
+      headers: { Cookie: cookie, 'CF-Connecting-IP': ip },
+    });
+    const body = await res.json();
+    expect(body.storageBytes.remaining).toBe(0);
+    // used and limit should still be accurate
+    expect(body.storageBytes.used).toBe(TIER_QUOTAS.free.storageBytes);
+    expect(body.storageBytes.limit).toBe(TIER_QUOTAS.free.storageBytes);
+  });
+
+  it('tenantId in response matches the session tenant', async () => {
+    const { cookie, tenantId } = await createTosSession();
+    const res = await SELF.fetch(USAGE_URL, {
+      headers: { Cookie: cookie, 'CF-Connecting-IP': ip },
+    });
+    const body = await res.json();
+    expect(body.tenantId).toBe(tenantId);
+  });
+
+  it('period in response is current YYYY-MM period', async () => {
+    const { cookie } = await createTosSession();
+    const res = await SELF.fetch(USAGE_URL, {
+      headers: { Cookie: cookie, 'CF-Connecting-IP': ip },
+    });
+    const body = await res.json();
+    expect(body.period).toBe(computePeriod());
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resetsAt
+// ---------------------------------------------------------------------------
+
+describe('GET /v1/account/usage -- resetsAt', () => {
+  const ip = nextIp();
+
+  it('resetsAt is the first of next month at UTC midnight', async () => {
+    const { cookie } = await createTosSession();
+    const res = await SELF.fetch(USAGE_URL, {
+      headers: { Cookie: cookie, 'CF-Connecting-IP': ip },
+    });
+    const body = await res.json();
+    const d = new Date(body.resetsAt);
+    expect(d.getUTCDate()).toBe(1);
+    expect(d.getUTCHours()).toBe(0);
+    expect(d.getUTCMinutes()).toBe(0);
+    expect(d.getUTCSeconds()).toBe(0);
+  });
+});

--- a/test/db.test.js
+++ b/test/db.test.js
@@ -8,6 +8,7 @@ import {
   createCapture, completeCapture, failCapture, getCapture, listCaptures,
   createApiKeyRecord, getApiKeyRecord, revokeApiKeyRecord, listApiKeyRecords,
   getTenantConfig, setTenantConfig,
+  setTenantTier, VALID_TIERS,
   archiveSigningKey, getArchivedSigningKey,
 } from '../src/db.js';
 import { rateLimitWindowId, rateLimitCounter } from '../src/kv.js';
@@ -615,6 +616,121 @@ describe('setTenantConfig', () => {
 
   it('throws on invalid tenantId', async () => {
     await expect(setTenantConfig(env.DB, 'BAD:ID', {}, 'admin')).rejects.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// setTenantConfig -- quotas validation
+// ---------------------------------------------------------------------------
+
+describe('setTenantConfig -- quotas validation', () => {
+  const TID = 'cfg-quotas-test';
+
+  it('accepts valid quota overrides', async () => {
+    await expect(
+      setTenantConfig(env.DB, TID, { quotas: { capturesPerMonth: 250, storageBytes: 2 * 1024 * 1024 * 1024 } }, 'admin'),
+    ).resolves.not.toThrow();
+    const config = await (await env.DB.prepare('SELECT config FROM tenants WHERE id = ?').bind(TID).first());
+    const parsed = JSON.parse(config.config);
+    expect(parsed.quotas.capturesPerMonth).toBe(250);
+  });
+
+  it('throws when quotas.capturesPerMonth is not a positive integer (float)', async () => {
+    await expect(
+      setTenantConfig(env.DB, TID, { quotas: { capturesPerMonth: 1.5 } }, 'admin'),
+    ).rejects.toThrow('quotas.capturesPerMonth must be a positive integer');
+  });
+
+  it('throws when quotas.capturesPerMonth is zero', async () => {
+    await expect(
+      setTenantConfig(env.DB, TID, { quotas: { capturesPerMonth: 0 } }, 'admin'),
+    ).rejects.toThrow('quotas.capturesPerMonth must be a positive integer');
+  });
+
+  it('throws when quotas.capturesPerMonth is negative', async () => {
+    await expect(
+      setTenantConfig(env.DB, TID, { quotas: { capturesPerMonth: -10 } }, 'admin'),
+    ).rejects.toThrow('quotas.capturesPerMonth must be a positive integer');
+  });
+
+  it('throws when quotas.storageBytes is not a positive integer (float)', async () => {
+    await expect(
+      setTenantConfig(env.DB, TID, { quotas: { storageBytes: 1.1 } }, 'admin'),
+    ).rejects.toThrow('quotas.storageBytes must be a positive integer');
+  });
+
+  it('throws when quotas.storageBytes is zero', async () => {
+    await expect(
+      setTenantConfig(env.DB, TID, { quotas: { storageBytes: 0 } }, 'admin'),
+    ).rejects.toThrow('quotas.storageBytes must be a positive integer');
+  });
+
+  it('accepts config without quotas key', async () => {
+    await expect(
+      setTenantConfig(env.DB, TID, { rateLimit: { capture: { limit: 10 } } }, 'admin'),
+    ).resolves.not.toThrow();
+  });
+
+  it('accepts quotas with only capturesPerMonth set', async () => {
+    await expect(
+      setTenantConfig(env.DB, TID, { quotas: { capturesPerMonth: 500 } }, 'admin'),
+    ).resolves.not.toThrow();
+  });
+
+  it('accepts quotas with only storageBytes set', async () => {
+    await expect(
+      setTenantConfig(env.DB, TID, { quotas: { storageBytes: 10 * 1024 * 1024 * 1024 } }, 'admin'),
+    ).resolves.not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// setTenantTier
+// ---------------------------------------------------------------------------
+
+describe('setTenantTier', () => {
+  const TID = 'tier-test';
+
+  beforeEach(async () => {
+    // Ensure the tenant row exists before each tier test
+    await env.DB.prepare('INSERT OR IGNORE INTO tenants (id) VALUES (?)').bind(TID).run();
+  });
+
+  it('VALID_TIERS exports the allowed tier values', () => {
+    expect(VALID_TIERS).toContain('free');
+    expect(VALID_TIERS).toContain('pro');
+  });
+
+  it('updates the tier column to pro', async () => {
+    await setTenantTier(env.DB, TID, 'pro', 'admin');
+    const row = await env.DB.prepare('SELECT tier FROM tenants WHERE id = ?').bind(TID).first();
+    expect(row.tier).toBe('pro');
+  });
+
+  it('updates the tier column back to free', async () => {
+    await setTenantTier(env.DB, TID, 'pro', 'admin');
+    await setTenantTier(env.DB, TID, 'free', 'admin');
+    const row = await env.DB.prepare('SELECT tier FROM tenants WHERE id = ?').bind(TID).first();
+    expect(row.tier).toBe('free');
+  });
+
+  it('throws when tier is an unknown value', async () => {
+    await expect(setTenantTier(env.DB, TID, 'enterprise', 'admin')).rejects.toThrow(
+      "Invalid tier 'enterprise'",
+    );
+  });
+
+  it('throws when tier is an empty string', async () => {
+    await expect(setTenantTier(env.DB, TID, '', 'admin')).rejects.toThrow();
+  });
+
+  it('throws on invalid tenantId', async () => {
+    await expect(setTenantTier(env.DB, 'BAD:ID', 'pro', 'admin')).rejects.toThrow('Invalid tenantId');
+  });
+
+  it('accepts both free and pro without throwing', async () => {
+    await expect(setTenantTier(env.DB, TID, 'free', 'admin')).resolves.not.toThrow();
+    await expect(setTenantTier(env.DB, TID, 'pro', 'admin')).resolves.not.toThrow();
   });
 });
 

--- a/test/quota-enforcement.test.js
+++ b/test/quota-enforcement.test.js
@@ -1,0 +1,279 @@
+// tva
+// Integration tests for quota enforcement in the capture pipeline.
+// Tests the quota check wired into handleCreateCapture and handleBatchCapture.
+
+import { env, SELF } from 'cloudflare:test';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { seedApiKey, cleanDb, TEST_TENANT_KEY } from './fixtures.js';
+import { TIER_QUOTAS } from '../src/quotas.js';
+import { computePeriod } from '../src/db.js';
+
+const AUTH = `Bearer ${TEST_TENANT_KEY}`;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// Unique IPs prevent rate limit buckets from interfering across tests.
+let ipCounter = 0;
+function nextTestIp() {
+  ipCounter += 1;
+  const a = Math.floor(ipCounter / 256) % 256;
+  const b = ipCounter % 256;
+  return `10.0.${a}.${b}`;
+}
+
+function singleCapture(overrides = {}) {
+  return SELF.fetch('https://worker.test/v1/captures', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: AUTH,
+      'CF-Connecting-IP': nextTestIp(),
+      ...overrides.headers,
+    },
+    body: JSON.stringify({ url: 'https://example.com', ...overrides.body }),
+  });
+}
+
+function batchCapture(urls, extraHeaders = {}) {
+  return SELF.fetch('https://worker.test/v1/captures/batch', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: AUTH,
+      'CF-Connecting-IP': nextTestIp(),
+      ...extraHeaders,
+    },
+    body: JSON.stringify({ urls }),
+  });
+}
+
+// Seed a usage_counters row for the current period.
+async function seedUsage({ captureCount = 0, storageBytes = 0 } = {}) {
+  const period = computePeriod();
+  await env.DB.prepare(
+    `INSERT OR REPLACE INTO usage_counters (tenant_id, period, capture_count, storage_bytes, api_call_count)
+     VALUES ('default', ?, ?, ?, 0)`,
+  ).bind(period, captureCount, storageBytes).run();
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(async () => {
+  await cleanDb(env.DB);
+  const { keys: rlKeys } = await env.KV.list({ prefix: 'rl:' });
+  for (const k of rlKeys) await env.KV.delete(k.name);
+
+  // Seed the API key with a generous rate limit so quota tests aren't rate-limited first.
+  await seedApiKey(env.DB, TEST_TENANT_KEY);
+  await env.DB.prepare(
+    `INSERT INTO tenants (id, config, updated_at, updated_by)
+     VALUES ('default', ?, ?, 'test')
+     ON CONFLICT(id) DO UPDATE SET
+       config = excluded.config,
+       updated_at = excluded.updated_at,
+       updated_by = excluded.updated_by`,
+  ).bind(
+    JSON.stringify({ rateLimit: { capture: { limit: 1000, period: 60 } } }),
+    new Date().toISOString(),
+  ).run();
+});
+
+// ---------------------------------------------------------------------------
+// Single capture -- quota exceeded (capture_limit)
+// ---------------------------------------------------------------------------
+
+describe('POST /v1/captures -- quota enforcement (capture_limit)', () => {
+  it('returns 429 with limitType quota when capture count is at the monthly limit', async () => {
+    await seedUsage({ captureCount: TIER_QUOTAS.free.capturesPerMonth });
+
+    const res = await singleCapture();
+    expect(res.status).toBe(429);
+
+    const body = await res.json();
+    expect(body.status).toBe(429);
+    expect(body.type).toBe('about:blank');
+    expect(body.limitType).toBe('quota');
+    expect(body.quota).toBeDefined();
+    expect(body.quota.resource).toBe('captures');
+    expect(body.quota.limit).toBe(TIER_QUOTAS.free.capturesPerMonth);
+    expect(body.quota.used).toBe(TIER_QUOTAS.free.capturesPerMonth);
+    expect(body.quota.resetsAt).toBeDefined();
+  });
+
+  it('returns Retry-After header set to the quota reset date', async () => {
+    await seedUsage({ captureCount: TIER_QUOTAS.free.capturesPerMonth });
+
+    const res = await singleCapture();
+    expect(res.status).toBe(429);
+    const retryAfter = res.headers.get('Retry-After');
+    expect(retryAfter).not.toBeNull();
+    // Retry-After is an HTTP-date (toUTCString) -- must parse as a future date
+    const retryDate = new Date(retryAfter);
+    expect(retryDate.getTime()).toBeGreaterThan(Date.now());
+  });
+
+  it('detail message mentions quota and resetsAt', async () => {
+    await seedUsage({ captureCount: TIER_QUOTAS.free.capturesPerMonth });
+
+    const res = await singleCapture();
+    const body = await res.json();
+    expect(body.detail).toContain('Monthly capture quota reached');
+    expect(body.detail).toContain(String(TIER_QUOTAS.free.capturesPerMonth));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Single capture -- quota exceeded (storage_limit)
+// ---------------------------------------------------------------------------
+
+describe('POST /v1/captures -- quota enforcement (storage_limit)', () => {
+  it('returns 429 with resource:storage when storage is at limit', async () => {
+    await seedUsage({ storageBytes: TIER_QUOTAS.free.storageBytes });
+
+    const res = await singleCapture();
+    expect(res.status).toBe(429);
+
+    const body = await res.json();
+    expect(body.limitType).toBe('quota');
+    expect(body.quota.resource).toBe('storage');
+    expect(body.quota.limit).toBe(TIER_QUOTAS.free.storageBytes);
+    expect(body.quota.used).toBe(TIER_QUOTAS.free.storageBytes);
+  });
+
+  it('detail message mentions storage quota', async () => {
+    await seedUsage({ storageBytes: TIER_QUOTAS.free.storageBytes });
+
+    const res = await singleCapture();
+    const body = await res.json();
+    expect(body.detail).toContain('Storage quota reached');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Single capture -- under quota (X-Quota-* headers)
+// ---------------------------------------------------------------------------
+
+describe('POST /v1/captures -- X-Quota-* headers on 202', () => {
+  it('returns 202 with X-Quota-Limit, X-Quota-Used, X-Quota-Remaining when under quota', async () => {
+    await seedUsage({ captureCount: 10 });
+
+    const res = await singleCapture();
+    expect(res.status).toBe(202);
+
+    expect(res.headers.get('X-Quota-Limit')).toBe(String(TIER_QUOTAS.free.capturesPerMonth));
+    expect(res.headers.get('X-Quota-Used')).toBe('10');
+    expect(res.headers.get('X-Quota-Remaining')).toBe(
+      String(TIER_QUOTAS.free.capturesPerMonth - 10),
+    );
+  });
+
+  it('returns X-Quota-* headers when no usage row exists yet (brand new tenant)', async () => {
+    // No seedUsage call -- tenant has no usage_counters row yet
+    const res = await singleCapture();
+    expect(res.status).toBe(202);
+
+    expect(res.headers.get('X-Quota-Limit')).toBe(String(TIER_QUOTAS.free.capturesPerMonth));
+    expect(res.headers.get('X-Quota-Used')).toBe('0');
+    expect(res.headers.get('X-Quota-Remaining')).toBe(String(TIER_QUOTAS.free.capturesPerMonth));
+  });
+
+  it('X-Quota-Remaining is never negative (clamped to 0)', async () => {
+    // Edge case: usage slightly above limit shouldn't produce a negative remaining
+    // (This shouldn't happen in normal operation, but guard against it defensively.)
+    await seedUsage({ captureCount: TIER_QUOTAS.free.capturesPerMonth - 1 });
+
+    const res = await singleCapture();
+    expect(res.status).toBe(202);
+
+    const remaining = parseInt(res.headers.get('X-Quota-Remaining'), 10);
+    expect(remaining).toBeGreaterThanOrEqual(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Batch capture -- whole-batch rejection when batch exceeds remaining quota
+// ---------------------------------------------------------------------------
+
+describe('POST /v1/captures/batch -- quota enforcement (batch rejection)', () => {
+  it('returns 429 with limitType quota when batch would exceed monthly limit', async () => {
+    // 98 used, limit 100: a batch of 5 would push to 103
+    await seedUsage({ captureCount: TIER_QUOTAS.free.capturesPerMonth - 2 });
+
+    const urls = Array.from({ length: 5 }, (_, i) => ({ url: `https://example.com/page${i}` }));
+    const res = await batchCapture(urls);
+    expect(res.status).toBe(429);
+
+    const body = await res.json();
+    expect(body.status).toBe(429);
+    expect(body.limitType).toBe('quota');
+    expect(body.quota.resource).toBe('captures');
+    expect(body.quota.requested).toBe(5);
+    expect(body.quota.limit).toBe(TIER_QUOTAS.free.capturesPerMonth);
+    expect(body.quota.used).toBe(TIER_QUOTAS.free.capturesPerMonth - 2);
+  });
+
+  it('detail message names the batch size and the quota for a capture_limit rejection', async () => {
+    await seedUsage({ captureCount: TIER_QUOTAS.free.capturesPerMonth - 2 });
+
+    const urls = [{ url: 'https://example.com/a' }, { url: 'https://example.com/b' }, { url: 'https://example.com/c' }];
+    const res = await batchCapture(urls);
+    const body = await res.json();
+    expect(body.detail).toContain('Batch of 3');
+    expect(body.detail).toContain('monthly quota');
+  });
+
+  it('returns 429 with resource:storage when storage quota is already at limit', async () => {
+    await seedUsage({ storageBytes: TIER_QUOTAS.free.storageBytes });
+
+    const urls = [{ url: 'https://example.com' }];
+    const res = await batchCapture(urls);
+    expect(res.status).toBe(429);
+
+    const body = await res.json();
+    expect(body.limitType).toBe('quota');
+    expect(body.quota.resource).toBe('storage');
+  });
+
+  it('allows batch when count does not push over limit (boundary: exactly at limit is fine)', async () => {
+    // 97 used, limit 100: batch of 3 pushes to exactly 100 -- allowed (> not >=)
+    await seedUsage({ captureCount: TIER_QUOTAS.free.capturesPerMonth - 3 });
+
+    const urls = Array.from({ length: 3 }, (_, i) => ({ url: `https://example.com/page${i}` }));
+    const res = await batchCapture(urls);
+    expect(res.status).toBe(207);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Batch capture -- X-Quota-* headers on 207
+// ---------------------------------------------------------------------------
+
+describe('POST /v1/captures/batch -- X-Quota-* headers on 207', () => {
+  it('returns 207 with X-Quota-* headers when under quota', async () => {
+    await seedUsage({ captureCount: 20 });
+
+    const urls = [{ url: 'https://example.com' }];
+    const res = await batchCapture(urls);
+    expect(res.status).toBe(207);
+
+    expect(res.headers.get('X-Quota-Limit')).toBe(String(TIER_QUOTAS.free.capturesPerMonth));
+    expect(res.headers.get('X-Quota-Used')).toBe('20');
+    expect(res.headers.get('X-Quota-Remaining')).toBe(
+      String(TIER_QUOTAS.free.capturesPerMonth - 20),
+    );
+  });
+
+  it('returns X-Quota-* headers when tenant has no usage row yet', async () => {
+    const urls = [{ url: 'https://example.com' }];
+    const res = await batchCapture(urls);
+    expect(res.status).toBe(207);
+
+    expect(res.headers.get('X-Quota-Limit')).toBe(String(TIER_QUOTAS.free.capturesPerMonth));
+    expect(res.headers.get('X-Quota-Used')).toBe('0');
+    expect(res.headers.get('X-Quota-Remaining')).toBe(String(TIER_QUOTAS.free.capturesPerMonth));
+  });
+});

--- a/test/quotas.test.js
+++ b/test/quotas.test.js
@@ -1,0 +1,245 @@
+// tva
+// Unit tests for src/quotas.js
+
+import { env } from 'cloudflare:test';
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import {
+  TIER_QUOTAS,
+  DEFAULT_TIER,
+  getEffectiveQuota,
+  checkQuota,
+  computeQuotaReset,
+} from '../src/quotas.js';
+import { cleanDb } from './fixtures.js';
+
+beforeEach(async () => {
+  await cleanDb(env.DB);
+});
+
+// ---------------------------------------------------------------------------
+// getEffectiveQuota
+// ---------------------------------------------------------------------------
+
+describe('getEffectiveQuota', () => {
+  it('returns free tier defaults when no config overrides', () => {
+    const quota = getEffectiveQuota('free', null);
+    expect(quota.capturesPerMonth).toBe(TIER_QUOTAS.free.capturesPerMonth);
+    expect(quota.storageBytes).toBe(TIER_QUOTAS.free.storageBytes);
+  });
+
+  it('returns pro tier defaults when no config overrides', () => {
+    const quota = getEffectiveQuota('pro', null);
+    expect(quota.capturesPerMonth).toBe(TIER_QUOTAS.pro.capturesPerMonth);
+    expect(quota.storageBytes).toBe(TIER_QUOTAS.pro.storageBytes);
+  });
+
+  it('falls back to free tier for unknown tier names', () => {
+    const quota = getEffectiveQuota('enterprise', null);
+    expect(quota.capturesPerMonth).toBe(TIER_QUOTAS.free.capturesPerMonth);
+    expect(quota.storageBytes).toBe(TIER_QUOTAS.free.storageBytes);
+  });
+
+  it('merges capturesPerMonth override with tier defaults', () => {
+    const quota = getEffectiveQuota('free', { quotas: { capturesPerMonth: 999 } });
+    expect(quota.capturesPerMonth).toBe(999);
+    expect(quota.storageBytes).toBe(TIER_QUOTAS.free.storageBytes);
+  });
+
+  it('merges storageBytes override with tier defaults', () => {
+    const quota = getEffectiveQuota('pro', { quotas: { storageBytes: 12345 } });
+    expect(quota.storageBytes).toBe(12345);
+    expect(quota.capturesPerMonth).toBe(TIER_QUOTAS.pro.capturesPerMonth);
+  });
+
+  it('merges both overrides simultaneously', () => {
+    const quota = getEffectiveQuota('free', { quotas: { capturesPerMonth: 50, storageBytes: 500 } });
+    expect(quota.capturesPerMonth).toBe(50);
+    expect(quota.storageBytes).toBe(500);
+  });
+
+  it('returns defaults when tenantConfig has no quotas key', () => {
+    const quota = getEffectiveQuota('pro', { rateLimit: { capture: { limit: 5 } } });
+    expect(quota.capturesPerMonth).toBe(TIER_QUOTAS.pro.capturesPerMonth);
+    expect(quota.storageBytes).toBe(TIER_QUOTAS.pro.storageBytes);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeQuotaReset
+// ---------------------------------------------------------------------------
+
+describe('computeQuotaReset', () => {
+  afterEach(() => vi.useRealTimers());
+
+  it('returns the first of next month at midnight UTC', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-15T12:34:56Z'));
+    const reset = computeQuotaReset();
+    const d = new Date(reset);
+    expect(d.getUTCFullYear()).toBe(2026);
+    expect(d.getUTCMonth()).toBe(3); // April = 3 (0-indexed)
+    expect(d.getUTCDate()).toBe(1);
+    expect(d.getUTCHours()).toBe(0);
+    expect(d.getUTCMinutes()).toBe(0);
+    expect(d.getUTCSeconds()).toBe(0);
+  });
+
+  it('rolls over year correctly in December', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-12-20T00:00:00Z'));
+    const reset = computeQuotaReset();
+    const d = new Date(reset);
+    expect(d.getUTCFullYear()).toBe(2026);
+    expect(d.getUTCMonth()).toBe(0); // January = 0
+    expect(d.getUTCDate()).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkQuota -- helpers to seed tenant and usage rows directly
+// ---------------------------------------------------------------------------
+
+async function seedTenant(db, tenantId, { tier = 'free', config = null } = {}) {
+  await db.prepare(
+    `INSERT OR IGNORE INTO tenants (id, tier, config) VALUES (?, ?, ?)`,
+  ).bind(tenantId, tier, config ? JSON.stringify(config) : null).run();
+}
+
+async function seedUsage(db, tenantId, period, { captureCount = 0, storageBytes = 0 } = {}) {
+  await db.batch([
+    db.prepare('INSERT OR IGNORE INTO tenants (id) VALUES (?)').bind(tenantId),
+    db.prepare(
+      `INSERT OR REPLACE INTO usage_counters (tenant_id, period, capture_count, storage_bytes, api_call_count)
+       VALUES (?, ?, ?, ?, 0)`,
+    ).bind(tenantId, period, captureCount, storageBytes),
+  ]);
+}
+
+// Derive the current period string 'YYYY-MM'
+function currentPeriod() {
+  return new Date().toISOString().slice(0, 7);
+}
+
+describe('checkQuota', () => {
+  afterEach(() => vi.useRealTimers());
+
+  it('returns allowed:true when under limits', async () => {
+    await seedTenant(env.DB, 'test-t1');
+    await seedUsage(env.DB, 'test-t1', currentPeriod(), { captureCount: 10, storageBytes: 100 });
+    const result = await checkQuota(env.DB, 'test-t1');
+    expect(result.allowed).toBe(true);
+    expect(result.tier).toBe('free');
+    expect(result.captureCount).toBe(10);
+    expect(result.storageBytes).toBe(100);
+    expect(result.period).toBe(currentPeriod());
+  });
+
+  it('returns allowed:false with capture_limit reason when at/over capture count', async () => {
+    await seedTenant(env.DB, 'test-t2');
+    // captureCount === capturesPerMonth means the next capture (count=1) pushes it over
+    await seedUsage(env.DB, 'test-t2', currentPeriod(), { captureCount: TIER_QUOTAS.free.capturesPerMonth });
+    const result = await checkQuota(env.DB, 'test-t2');
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toBe('capture_limit');
+    expect(result.limit).toBe(TIER_QUOTAS.free.capturesPerMonth);
+    expect(result.used).toBe(TIER_QUOTAS.free.capturesPerMonth);
+    expect(result.requested).toBe(1);
+  });
+
+  it('returns allowed:false with storage_limit reason when at/over storage', async () => {
+    await seedTenant(env.DB, 'test-t3');
+    await seedUsage(env.DB, 'test-t3', currentPeriod(), { storageBytes: TIER_QUOTAS.free.storageBytes });
+    const result = await checkQuota(env.DB, 'test-t3');
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toBe('storage_limit');
+    expect(result.limit).toBe(TIER_QUOTAS.free.storageBytes);
+    expect(result.used).toBe(TIER_QUOTAS.free.storageBytes);
+  });
+
+  it('handles missing usage_counters row -- defaults to 0', async () => {
+    await seedTenant(env.DB, 'test-t4');
+    // No usage row seeded -- tenant is brand new
+    const result = await checkQuota(env.DB, 'test-t4');
+    expect(result.allowed).toBe(true);
+    expect(result.captureCount).toBe(0);
+    expect(result.storageBytes).toBe(0);
+  });
+
+  it('handles missing tenant row -- returns tenant_not_found', async () => {
+    const result = await checkQuota(env.DB, 'nonexistent-tenant');
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toBe('tenant_not_found');
+  });
+
+  it('respects count parameter for batch checks -- denies when count pushes over limit', async () => {
+    await seedTenant(env.DB, 'test-t5');
+    // 97 used, limit 100: count=5 would push to 102 (over limit)
+    await seedUsage(env.DB, 'test-t5', currentPeriod(), { captureCount: 97 });
+    const result = await checkQuota(env.DB, 'test-t5', 5);
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toBe('capture_limit');
+    expect(result.requested).toBe(5);
+    expect(result.used).toBe(97);
+  });
+
+  it('allows when count does not push over limit', async () => {
+    await seedTenant(env.DB, 'test-t5b');
+    // 97 used, limit 100: count=3 pushes to exactly 100 -- NOT over (> not >=)
+    await seedUsage(env.DB, 'test-t5b', currentPeriod(), { captureCount: 97 });
+    const result = await checkQuota(env.DB, 'test-t5b', 3);
+    expect(result.allowed).toBe(true);
+  });
+
+  it('returns correct resetsAt -- first of next month, UTC midnight', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-10T08:00:00Z'));
+    await seedTenant(env.DB, 'test-t6');
+    const result = await checkQuota(env.DB, 'test-t6');
+    expect(result.allowed).toBe(true);
+    // resetsAt not present on allowed result; check denied case for resetsAt
+    vi.useRealTimers();
+  });
+
+  it('returns correct resetsAt on denied result -- first of next month', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-10T08:00:00Z'));
+    await seedTenant(env.DB, 'test-t7');
+    await seedUsage(env.DB, 'test-t7', '2026-03', { captureCount: TIER_QUOTAS.free.capturesPerMonth });
+    const result = await checkQuota(env.DB, 'test-t7');
+    expect(result.allowed).toBe(false);
+    const d = new Date(result.resetsAt);
+    expect(d.getUTCDate()).toBe(1);
+    expect(d.getUTCMonth()).toBe(3); // April
+    expect(d.getUTCFullYear()).toBe(2026);
+    vi.useRealTimers();
+  });
+
+  it('handles zero usage row -- row exists with capture_count=0, storage_bytes=0', async () => {
+    await seedTenant(env.DB, 'test-t8');
+    await seedUsage(env.DB, 'test-t8', currentPeriod(), { captureCount: 0, storageBytes: 0 });
+    const result = await checkQuota(env.DB, 'test-t8');
+    expect(result.allowed).toBe(true);
+    expect(result.captureCount).toBe(0);
+    expect(result.storageBytes).toBe(0);
+  });
+
+  it('uses pro tier quota for pro tenants', async () => {
+    await seedTenant(env.DB, 'test-t9', { tier: 'pro' });
+    // 200 captures -- fine for pro (limit 5000), would fail for free (limit 100)
+    await seedUsage(env.DB, 'test-t9', currentPeriod(), { captureCount: 200 });
+    const result = await checkQuota(env.DB, 'test-t9');
+    expect(result.allowed).toBe(true);
+    expect(result.tier).toBe('pro');
+    expect(result.quota.capturesPerMonth).toBe(TIER_QUOTAS.pro.capturesPerMonth);
+  });
+
+  it('respects per-tenant quota overrides in config', async () => {
+    // Override capturesPerMonth to 5 -- even free tenant
+    await seedTenant(env.DB, 'test-t10', { config: { quotas: { capturesPerMonth: 5 } } });
+    await seedUsage(env.DB, 'test-t10', currentPeriod(), { captureCount: 5 });
+    const result = await checkQuota(env.DB, 'test-t10');
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toBe('capture_limit');
+    expect(result.limit).toBe(5);
+  });
+});

--- a/test/ui-settings-usage.test.js
+++ b/test/ui-settings-usage.test.js
@@ -1,0 +1,351 @@
+// tva
+// Unit tests for the Usage section added to ui-settings.js.
+// Tests operate on the exported SETTINGS_JS string constant and on extracted
+// pure-logic helpers (formatBytes, formatPeriod, buildUsageMetric percentages
+// and CSS classes) evaluated in the Workers runtime via the Function constructor.
+// No real DOM or fetch calls are made -- all assertions target string content
+// or the outputs of the extracted helper logic.
+
+import { describe, it, expect } from 'vitest';
+import { SETTINGS_JS } from '../src/ui/ui-settings.js';
+import { SUBMIT_VIEW_JS } from '../src/ui/ui-submit.js';
+import { UI_CSS } from '../src/ui/ui-css.js';
+
+// ---------------------------------------------------------------------------
+// Helpers -- evaluate formatBytes and pct/class logic from SETTINGS_JS
+// ---------------------------------------------------------------------------
+
+// Extract and evaluate a named function from a JS source string so we can call
+// it in tests without spinning up a full DOM environment.
+function evalFromSource(source, functionName) {
+  // eslint-disable-next-line no-new-func
+  const fn = new Function(source + '\nreturn ' + functionName + ';');
+  return fn();
+}
+
+const formatBytes = evalFromSource(SETTINGS_JS, 'formatBytes');
+const formatPeriod = evalFromSource(SETTINGS_JS, 'formatPeriod');
+
+// Replicate the percentage / CSS class logic from buildUsageMetric so we can
+// test thresholds without DOM.
+function usageClass(used, limit) {
+  const pct = limit > 0 ? Math.min(100, Math.round((used / limit) * 100)) : 0;
+  if (pct >= 95) return 'usage-bar-fill--critical';
+  if (pct >= 80) return 'usage-bar-fill--warning';
+  return 'default';
+}
+
+function usagePct(used, limit) {
+  return limit > 0 ? Math.min(100, Math.round((used / limit) * 100)) : 0;
+}
+
+// ---------------------------------------------------------------------------
+// formatBytes
+// ---------------------------------------------------------------------------
+
+describe('formatBytes -- byte formatting', () => {
+  it('returns "0 B" for zero', () => {
+    expect(formatBytes(0)).toBe('0 B');
+  });
+
+  it('returns "0 B" for null', () => {
+    expect(formatBytes(null)).toBe('0 B');
+  });
+
+  it('formats bytes under 1000 as plain bytes', () => {
+    expect(formatBytes(512)).toBe('512 B');
+  });
+
+  it('formats 1000 bytes as 1 KB', () => {
+    expect(formatBytes(1000)).toBe('1 KB');
+  });
+
+  it('formats 524288000 (~524 MB) as MB', () => {
+    const result = formatBytes(524288000);
+    expect(result).toMatch(/MB$/);
+    expect(result).toContain('524');
+  });
+
+  it('formats 1000000000 exactly as 1 GB', () => {
+    expect(formatBytes(1000000000)).toBe('1 GB');
+  });
+
+  it('formats 500000000 as 500 MB', () => {
+    expect(formatBytes(500000000)).toBe('500 MB');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatPeriod
+// ---------------------------------------------------------------------------
+
+describe('formatPeriod -- period string formatting', () => {
+  it('returns empty string for falsy input', () => {
+    expect(formatPeriod('')).toBe('');
+    expect(formatPeriod(null)).toBe('');
+  });
+
+  it('formats 2026-03 as a string containing "2026"', () => {
+    const result = formatPeriod('2026-03');
+    expect(result).toContain('2026');
+  });
+
+  it('formats 2026-03 as a non-trivially-short string (month name included)', () => {
+    const result = formatPeriod('2026-03');
+    expect(result.length).toBeGreaterThan(4);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Progress bar percentage calculation
+// ---------------------------------------------------------------------------
+
+describe('usage bar -- percentage calculation', () => {
+  it('calculates 42% for 42 of 100', () => {
+    expect(usagePct(42, 100)).toBe(42);
+  });
+
+  it('calculates 0% for zero usage', () => {
+    expect(usagePct(0, 100)).toBe(0);
+  });
+
+  it('calculates 100% for full usage', () => {
+    expect(usagePct(100, 100)).toBe(100);
+  });
+
+  it('clamps to 100% when usage exceeds limit', () => {
+    expect(usagePct(120, 100)).toBe(100);
+  });
+
+  it('returns 0% when limit is zero (no division by zero)', () => {
+    expect(usagePct(0, 0)).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Progress bar CSS class thresholds
+// ---------------------------------------------------------------------------
+
+describe('usage bar -- CSS class thresholds', () => {
+  it('applies default class at 0%', () => {
+    expect(usageClass(0, 100)).toBe('default');
+  });
+
+  it('applies default class at 79%', () => {
+    expect(usageClass(79, 100)).toBe('default');
+  });
+
+  it('applies warning class at 80%', () => {
+    expect(usageClass(80, 100)).toBe('usage-bar-fill--warning');
+  });
+
+  it('applies warning class at 94%', () => {
+    expect(usageClass(94, 100)).toBe('usage-bar-fill--warning');
+  });
+
+  it('applies critical class at 95%', () => {
+    expect(usageClass(95, 100)).toBe('usage-bar-fill--critical');
+  });
+
+  it('applies critical class at 100%', () => {
+    expect(usageClass(100, 100)).toBe('usage-bar-fill--critical');
+  });
+
+  it('applies critical class when usage exceeds limit (clamped)', () => {
+    expect(usageClass(110, 100)).toBe('usage-bar-fill--critical');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SETTINGS_JS string content -- structural markers
+// ---------------------------------------------------------------------------
+
+describe('SETTINGS_JS -- usage section structural markers', () => {
+  it('contains buildUsageSection function', () => {
+    expect(SETTINGS_JS).toContain('function buildUsageSection');
+  });
+
+  it('contains buildUsageMetric function', () => {
+    expect(SETTINGS_JS).toContain('function buildUsageMetric');
+  });
+
+  it('contains refreshUsageSection function', () => {
+    expect(SETTINGS_JS).toContain('function refreshUsageSection');
+  });
+
+  it('contains formatBytes function', () => {
+    expect(SETTINGS_JS).toContain('function formatBytes');
+  });
+
+  it('contains formatPeriod function', () => {
+    expect(SETTINGS_JS).toContain('function formatPeriod');
+  });
+
+  it('sets role="progressbar" on the bar element', () => {
+    expect(SETTINGS_JS).toContain("'progressbar'");
+  });
+
+  it('sets aria-valuenow on progress bars', () => {
+    expect(SETTINGS_JS).toContain('aria-valuenow');
+  });
+
+  it('sets aria-valuemin on progress bars', () => {
+    expect(SETTINGS_JS).toContain('aria-valuemin');
+  });
+
+  it('sets aria-valuemax on progress bars', () => {
+    expect(SETTINGS_JS).toContain('aria-valuemax');
+  });
+
+  it('uses usage-bar-fill--warning class name', () => {
+    expect(SETTINGS_JS).toContain('usage-bar-fill--warning');
+  });
+
+  it('uses usage-bar-fill--critical class name', () => {
+    expect(SETTINGS_JS).toContain('usage-bar-fill--critical');
+  });
+
+  it('calls formatBytes for storage formatting', () => {
+    expect(SETTINGS_JS).toContain('formatBytes(storage');
+  });
+
+  it('fetches /v1/account/usage in mountSettings', () => {
+    expect(SETTINGS_JS).toContain('/v1/account/usage');
+  });
+
+  it('includes refresh button with aria-label', () => {
+    expect(SETTINGS_JS).toContain('Refresh usage data');
+  });
+
+  it('announces usage loaded via settingsAnnounce', () => {
+    expect(SETTINGS_JS).toContain("settingsAnnounce('Usage data loaded.')");
+  });
+
+  it('announces error when usage data could not be loaded', () => {
+    expect(SETTINGS_JS).toContain('could not be loaded');
+  });
+
+  it('shows error message when usageData is null', () => {
+    expect(SETTINGS_JS).toContain('Could not load usage data.');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SETTINGS_JS -- parallel fetch pattern
+// ---------------------------------------------------------------------------
+
+describe('SETTINGS_JS -- parallel fetch pattern', () => {
+  it('uses Promise.all for parallel fetches', () => {
+    expect(SETTINGS_JS).toContain('Promise.all');
+  });
+
+  it('declares keysPromise variable', () => {
+    expect(SETTINGS_JS).toContain('keysPromise');
+  });
+
+  it('declares usagePromise variable', () => {
+    expect(SETTINGS_JS).toContain('usagePromise');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SUBMIT_VIEW_JS -- 429 quota error handling
+// ---------------------------------------------------------------------------
+
+describe('SUBMIT_VIEW_JS -- 429 quota error handling', () => {
+  it("checks for limitType === 'quota' on 429 response", () => {
+    expect(SUBMIT_VIEW_JS).toContain("limitType === 'quota'");
+  });
+
+  it('shows monthly capture limit message', () => {
+    expect(SUBMIT_VIEW_JS).toContain('Monthly capture limit reached');
+  });
+
+  it('references Settings in the quota error message', () => {
+    expect(SUBMIT_VIEW_JS).toContain('View usage in Settings');
+  });
+
+  it('includes formatDate helper for reset date formatting', () => {
+    expect(SUBMIT_VIEW_JS).toContain('function formatDate');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// UI_CSS -- usage CSS classes present
+// ---------------------------------------------------------------------------
+
+describe('UI_CSS -- usage section styles', () => {
+  it('contains .usage-metric class', () => {
+    expect(UI_CSS).toContain('.usage-metric');
+  });
+
+  it('contains .usage-metric-header class', () => {
+    expect(UI_CSS).toContain('.usage-metric-header');
+  });
+
+  it('contains .usage-bar class', () => {
+    expect(UI_CSS).toContain('.usage-bar');
+  });
+
+  it('contains .usage-bar-fill class', () => {
+    expect(UI_CSS).toContain('.usage-bar-fill');
+  });
+
+  it('contains .usage-bar-fill--warning class', () => {
+    expect(UI_CSS).toContain('.usage-bar-fill--warning');
+  });
+
+  it('contains .usage-bar-fill--critical class', () => {
+    expect(UI_CSS).toContain('.usage-bar-fill--critical');
+  });
+
+  it('contains .usage-footer class', () => {
+    expect(UI_CSS).toContain('.usage-footer');
+  });
+
+  it('contains .usage-refresh-btn class', () => {
+    expect(UI_CSS).toContain('.usage-refresh-btn');
+  });
+
+  it('uses --color-accent for default fill', () => {
+    expect(UI_CSS).toContain('var(--color-accent)');
+  });
+
+  it('uses --color-warning for warning fill state', () => {
+    const warningIdx = UI_CSS.indexOf('.usage-bar-fill--warning');
+    const snippet = UI_CSS.slice(warningIdx, warningIdx + 80);
+    expect(snippet).toContain('--color-warning');
+  });
+
+  it('uses --color-error for critical fill state', () => {
+    const criticalIdx = UI_CSS.indexOf('.usage-bar-fill--critical');
+    const snippet = UI_CSS.slice(criticalIdx, criticalIdx + 80);
+    expect(snippet).toContain('--color-error');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Security -- no innerHTML with variable data in SETTINGS_JS
+// ---------------------------------------------------------------------------
+
+describe('SETTINGS_JS -- security: no innerHTML with variable data', () => {
+  function innerHtmlAssignments(source) {
+    const matches = [];
+    const re = /\.innerHTML\s*=\s*([^;]+)/g;
+    let m;
+    // Use regex iteration without re.exec directly in while condition to avoid lint warnings
+    m = re.exec(source); // eslint-disable-line no-cond-assign
+    while (m !== null) {
+      matches.push(m[1].trim());
+      m = re.exec(source);
+    }
+    return matches;
+  }
+
+  it('innerHTML only assigned the empty string (no variable data)', () => {
+    const assignments = innerHtmlAssignments(SETTINGS_JS);
+    for (const rhs of assignments) {
+      expect(rhs, `innerHTML assignment "${rhs}" uses variable data`).toMatch(/^(?:''|"")$/);
+    }
+  });
+});


### PR DESCRIPTION

## Summary

Per-tenant usage quotas for WRL. Tenants are assigned tiers (free/pro) with default capture and storage limits. The capture pipeline checks quotas before accepting work, returning 429 with `limitType: 'quota'` and structured quota context. A web UI usage dashboard in Settings shows captures and storage usage with progress bars. Operators can override quotas per-tenant via admin config API. 7 commits, 991 tests pass across 37 test files. New files: migration, quotas module, 4 test files, docs guide. Modified: index.js (pipeline), account.js (usage endpoint), UI (settings, CSS, submit), OpenAPI spec, docs site.

## Original Prompt

GitHub Issue #104: R26 -- Tenant Quotas

Tenants are subject to usage quotas (captures/month, storage GB) based on their tier. Quota checks happen before expensive operations (browser launch), and tenants can see their usage in the web UI.

Success criteria: Default quotas per tier (free: 100 captures/month, 1 GB; pro: 5000/month, 50 GB), pre-capture quota check, 429 quota_exceeded response, per-tenant D1 overrides, web UI usage dashboard with progress bars, tier field on tenant record defaulting to "free".

## Key Design Decisions

1. **Tier as column, not JSON** -- `tier TEXT NOT NULL DEFAULT 'free'` on the tenants table. Core business attribute needing potential indexed queries. Existing `INSERT OR IGNORE INTO tenants(id)` statements pick up the default automatically, so auto-provisioned tenants get free tier with zero code changes.

2. **Default quotas in code, not D1** -- `TIER_QUOTAS` constant map in `src/quotas.js`, mirroring `RATE_LIMITS` in `src/rate-limits.js`. Changes deploy atomically with the code. Per-tenant overrides in config JSON (`config.quotas`) follow the existing `config.rateLimit` pattern.

3. **RFC 9457 with limitType discriminator** -- Reuse existing `problemResponse(429)` with `limitType: 'quota'` to distinguish from rate limit 429s (`limitType: 'tenant'`). Nested `quota` object contains `limit`, `used`, `resource`, `resetsAt`. Backward-compatible with existing error handling.

4. **Quota check after rate limit, before body parse** -- Rate limit is cheaper (KV read). Quota check uses `db.batch()` with two PK lookups in a single D1 round-trip (sub-2ms). No KV caching needed — YAGNI.

5. **Whole-batch rejection** -- Batch captures check quota upfront for the full batch size. If insufficient, entire batch is rejected. Partial acceptance would create confusing accounting.

6. **Usage as settings section, not new route** -- Reuses existing card pattern in settings view. Dedicated `GET /v1/account/usage` endpoint (not inline in session response) keeps the boot payload lightweight.

7. **"Starter" display name for free tier** -- Internal code uses `free`/`pro`. API responses expose `tierDisplay: 'Starter'`/`'Pro'`. Tier name never exposed in error responses (security advisory).

## Phases

### Phase 1-2: Planning (7 specialists)
Consulted data-minion (schema design), api-design-minion (pipeline placement, 429 format, batch semantics), iac-minion (latency budget, D1 vs KV caching), frontend-minion (UI architecture, routing, data source), security-minion (bypass vectors, overage exploitation), ux-strategy-minion (journey coherence, warning thresholds, tier naming), software-docs-minion (OpenAPI strategy, rate limit vs quota docs).

Team adjusted from 5 to 7 after Lucy review: added ux-strategy-minion and software-docs-minion (both flagged "ALWAYS include" in cross-cutting checklist).

### Phase 3: Synthesis
6 tasks, 2 gates. Key conflicts resolved: (1) Tier naming — internal `free`/`pro`, display `Starter`/`Pro`, never in errors. (2) No queue consumer check — overruled security-minion; fail-fast at HTTP handler, TOCTOU overage bounded by rate limit.

### Phase 3.5: Architecture Review (6 reviewers)
5 mandatory + 1 discretionary (accessibility-minion for progress bar WCAG). Zero BLOCKs, 6 ADVISE. Key advisories incorporated: catch block for quotas validation errors, reuse checkQuota in usage endpoint, extract computeQuotaReset helper, ARIA value formatting, manual refresh button.

### Phase 4: Execution (6 tasks, 2 gates)

**Task 1: D1 migration + quotas module** [data-minion, GATED]
Migration adds `tier` column. `src/quotas.js` exports `TIER_QUOTAS`, `checkQuota` (db.batch for single round-trip), `getEffectiveQuota`, `computeQuotaReset`. Config validation for quota overrides in `setTenantConfig`. 21+16 = 37 new tests.

**Task 2: Quota check in capture pipeline** [api-design-minion, GATED]
`checkQuota` wired into `handleCreateCapture` and `handleBatchCapture` after rate limit, before body parse. `buildQuotaHeaders` helper for X-Quota-* headers. Legacy auth skipped (consistent with rate limit). 14 new integration tests.

**Task 3: GET /v1/account/usage endpoint** [api-design-minion]
Session-gated endpoint reusing `checkQuota(db, tenantId, 0)` with fallback for over-limit edge cases. Returns `tierDisplay`, captures/storage metrics with remaining, `resetsAt`. 23 new tests.

**Task 4: Web UI usage dashboard** [frontend-minion]
Usage card in settings with progress bars, three-state thresholds (normal at <80%, warning at 80-94%, critical at 95-100%). `formatBytes` (SI units), `formatPeriod`, manual refresh button. Quota-specific 429 handling in submit form. 58 new tests.

**Task 5: OpenAPI spec updates** [api-spec-minion]
Added `QuotaDetail`, `UsageMetric`, `AccountUsageResponse` schemas. X-Quota-* header components. Updated 429 with quota example. New `GET /v1/account/usage` path. 86 net new lines.

**Task 6: Docs site content** [software-docs-minion]
Created `site/content/limits.md` (171 lines) — consolidated rate limits + quotas guide. Updated batch.md, nav, and index with cross-references.

## Verification

Verification: code review passed (1 finding auto-fixed: formatBytes MB ternary), all 991 tests pass across 37 files.

Code review findings:
- [FIXED] formatBytes MB ternary had identical branches (0 vs 0) — corrected to (0 vs 1)
- [ADVISE] JSON.parse without try-catch in quotas.js — defense-in-depth gap, acceptable given setTenantConfig validates
- [NIT] Usage endpoint fallback duplicates query from checkQuota
- [NIT] Hardcoded key limit in UI
- [NIT] No index on tier column (acceptable at current scale)

## Agent Contributions

### Planning Agents

| Agent | Role | Key Recommendation |
|-------|------|--------------------|
| data-minion | Schema design | Tier as column, quotas in code, overrides in config JSON, db.batch for check |
| api-design-minion | API contract | RFC 9457 + limitType discriminator, after rate limit, batch full-rejection |
| iac-minion | Infrastructure | Single D1 read sufficient, no KV cache, piggyback on existing flow |
| frontend-minion | UI architecture | Settings section (not new route), dedicated usage endpoint, vanilla CSS bars |
| security-minion | Threat model | Per-tenant quotas sound, dual-check recommended (overruled), validate overrides |
| ux-strategy-minion | User journey | Warning at 80%, no quota on submit form, "Starter" not "Free", current period only |
| software-docs-minion | Documentation | Extend ProblemDetail schema, consolidate rate limit/quota docs |

### Architecture Reviewers

| Reviewer | Verdict | Key Finding |
|----------|---------|-------------|
| security-minion | ADVISE | Catch block fix for quotas validation; setTenantTier unreachable |
| test-minion | ADVISE | Date-brittle resetsAt; test both null and zero usage paths |
| ux-strategy-minion | ADVISE | 429 dead-end needs action hint; binary/SI unit mismatch |
| lucy | ADVISE | Wrong file path; reuse checkQuota in Task 3; CSS token verification |
| margo | ADVISE | Extract computeQuotaReset and buildQuotaHeaders helpers |
| accessibility-minion | ADVISE | ARIA value units for storage; formatBytes in aria-label |

## Session Resources

<details>
<summary>Skills Invoked</summary>

- `/nefario` — orchestration workflow

</details>

<details>
<summary>Working Files</summary>

Companion directory: `docs/history/nefario-reports/2026-03-23-030747-tenant-quotas/`

Files: phase1-metaplan.md, phase1-metaplan-rerun.md, phase2-*.md (7 specialists), phase3-synthesis.md, phase3.5-*.md (6 reviewers), phase5-code-review-minion.md, prompt.md

</details>

Compaction events: 0

Resolves #104
