### PR TITLE
fix: make WACZ artifacts publicly accessible for verification

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -455,11 +455,14 @@ export default {
       // Auth gate for capture GET routes (retrieval, status, artifacts).
       // CRITICAL: /v1/verify/ must NOT be gated -- verify is public by design.
       // /v1/verify/ uses a different path prefix and is naturally excluded here.
+      // WACZ artifacts are also public -- independent verification requires
+      // downloading the signed bundle without authentication.
       const isCaptureGetRoute = (
         request.method === 'GET' && (
           pathname.startsWith('/v1/captures/') || pathname === '/v1/captures'
         )
       );
+      const isWaczArtifactRequest = /^\/v1\/captures\/cap_[a-f0-9]{32}\/artifacts\/wacz$/.test(pathname);
       if (!response && isCaptureGetRoute) {
         const shareToken = url.searchParams.get('token');
 
@@ -492,8 +495,11 @@ export default {
           // Standard tenant auth (API key or session)
           const auth = await verifyAuth(request, env, { requiredScope: 'read' });
           if (!auth.ok) {
-            // Propagate the original auth failure response (includes WWW-Authenticate header)
-            response = auth.response;
+            // WACZ artifacts are public for independent verification -- auth is optional.
+            // When unauthenticated, env._captureAuth stays unset; handler enforces rate limits.
+            if (!isWaczArtifactRequest) {
+              response = auth.response;
+            }
           } else {
             env._captureAuth = {
               tenantId: auth.tenantId,
@@ -1561,18 +1567,40 @@ async function handleGetCaptureArtifact(request, env, ctx, match) {
   const artifactName = match[2];
   const captureAuth = env._captureAuth;
 
+  // Public access is only allowed for WACZ (independent verification).
+  // Other artifacts require authentication.
+  if (!captureAuth && artifactName !== 'wacz') {
+    return problemResponse(401, 'Invalid or missing authentication');
+  }
+
+  // Rate-limit public (unauthenticated) WACZ requests per IP,
+  // same limiter as /v1/verify/ -- both are public verification endpoints.
+  if (!captureAuth && env.VERIFY_RATE_LIMITER) {
+    const clientIp = request.headers.get('CF-Connecting-IP') || 'unknown';
+    const { success } = await env.VERIFY_RATE_LIMITER.limit({ key: clientIp });
+    if (!success) {
+      const cip = await computeCip(env, clientIp);
+      ctx.waitUntil(log(env, 4, 'security', { event: 'security.rate_limit', limiter: 'wacz_public', cip }) ?? Promise.resolve());
+      return problemResponse(429, 'Rate limit exceeded. Try again later.', { 'Retry-After': '60' });
+    }
+  }
+
   const record = await getCapture(env.DB, captureId);
 
-  // Tenant isolation: check ownership before revealing existence.
-  // SECURITY: Return identical 404 for cross-tenant (not 403) to prevent enumeration.
   if (!record) {
     return problemResponse(404, 'Capture not found', { 'Cache-Control': 'no-store' });
   }
-  if (captureAuth.scopedCaptureId !== null && captureId !== captureAuth.scopedCaptureId) {
-    return problemResponse(404, 'Capture not found', { 'Cache-Control': 'no-store' });
-  }
-  if (record.tenantId !== captureAuth.tenantId) {
-    return problemResponse(404, 'Capture not found', { 'Cache-Control': 'no-store' });
+
+  // Tenant isolation: only enforce when authenticated.
+  // Public WACZ access skips tenant checks -- the capture ID is the access key.
+  // SECURITY: Return identical 404 for cross-tenant (not 403) to prevent enumeration.
+  if (captureAuth) {
+    if (captureAuth.scopedCaptureId !== null && captureId !== captureAuth.scopedCaptureId) {
+      return problemResponse(404, 'Capture not found', { 'Cache-Control': 'no-store' });
+    }
+    if (record.tenantId !== captureAuth.tenantId) {
+      return problemResponse(404, 'Capture not found', { 'Cache-Control': 'no-store' });
+    }
   }
 
   // Quarantined captures: return 451 before the generic status check

--- a/test/capture-retrieval.test.js
+++ b/test/capture-retrieval.test.js
@@ -2,7 +2,8 @@
 // Tests for capture retrieval auth gate and tenant isolation.
 //
 // Security invariants verified:
-//   - All retrieval endpoints require authentication (API key or session)
+//   - Non-WACZ retrieval endpoints require authentication (API key or session)
+//   - WACZ artifacts are publicly accessible for independent verification (#162)
 //   - Cross-tenant access returns 404 (NOT 403) with identical response body
 //   - Share token access only granted to the specific capture the token was issued for
 //   - The verify endpoint (/v1/verify/) must remain unauthenticated (in verify-integration.test.js)
@@ -223,9 +224,10 @@ describe('GET /v1/captures/{id}/artifacts -- auth and tenant isolation', () => {
     expect(res.status).toBe(401);
   });
 
-  it('unauthenticated wacz returns 401', async () => {
+  it('unauthenticated wacz returns 200 (public for independent verification)', async () => {
     const res = await SELF.fetch(`https://worker.test/v1/captures/${CAP_A}/artifacts/wacz`);
-    expect(res.status).toBe(401);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('application/wacz+zip');
   });
 
   it('authenticated owner can access screenshot', async () => {
@@ -269,6 +271,24 @@ describe('GET /v1/captures/{id}/artifacts -- auth and tenant isolation', () => {
     const res = await SELF.fetch(`https://worker.test/v1/captures/${CAP_A}/artifacts/wacz`, {
       headers: { Authorization: `Bearer ${TEST_TENANT_KEY_B}` },
     });
+    expect(res.status).toBe(404);
+  });
+
+  it('unauthenticated headers returns 401', async () => {
+    const res = await SELF.fetch(`https://worker.test/v1/captures/${CAP_A}/artifacts/headers`);
+    expect(res.status).toBe(401);
+  });
+
+  it('unauthenticated wacz for non-existent capture returns 404', async () => {
+    const unknownId = 'cap_' + '9'.repeat(32);
+    const res = await SELF.fetch(`https://worker.test/v1/captures/${unknownId}/artifacts/wacz`);
+    expect(res.status).toBe(404);
+  });
+
+  it('unauthenticated wacz for incomplete capture returns 404', async () => {
+    const pendingId = 'cap_' + 'f'.repeat(32);
+    await createCapture(env.DB, pendingId, 'https://example.com/pending', '1.2.3.4', TENANT_A_ID);
+    const res = await SELF.fetch(`https://worker.test/v1/captures/${pendingId}/artifacts/wacz`);
     expect(res.status).toBe(404);
   });
 


### PR DESCRIPTION
## Summary

- WACZ artifact downloads (`GET /v1/captures/{id}/artifacts/wacz`) no longer require authentication
- Other artifacts (screenshot, html, headers) still require tenant auth
- Public WACZ requests are rate-limited per-IP via `VERIFY_RATE_LIMITER`
- Authenticated WACZ requests still get full tenant isolation (no behavior change)

**Why:** Independent verification is WRL's core value prop. The verify CLI needs to download the WACZ to verify signatures locally. Requiring auth for the evidence bundle contradicts "anyone can verify, no account needed."

Closes #162

## Test plan

- [x] Unauthenticated WACZ request returns 200
- [x] Unauthenticated screenshot/html/headers still return 401
- [x] Unauthenticated WACZ for non-existent capture returns 404
- [x] Unauthenticated WACZ for incomplete capture returns 404
- [x] Authenticated WACZ still works with tenant isolation
- [x] Cross-tenant WACZ access still returns 404
- [x] Full test suite passes (1180 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)