### PR TITLE
fix: add qualifiedTimestamp check to verify CLI

### DIFF
--- a/packages/verify/lib/format.js
+++ b/packages/verify/lib/format.js
@@ -43,11 +43,12 @@ function bold(text, color)   { return color ? `${ANSI_BOLD}${text}${ANSI_RESET}`
 // ---------------------------------------------------------------------------
 
 const CHECK_LABELS = {
-  artifactHashes:  'File integrity',
-  bundleHash:      'Bundle integrity',
-  signature:       'Digital signature',
-  timestamp:       'Timestamp imprint',
-  timestampChain:  'Timestamp chain',
+  artifactHashes:       'File integrity',
+  bundleHash:           'Bundle integrity',
+  signature:            'Digital signature',
+  timestamp:            'Timestamp imprint',
+  qualifiedTimestamp:   'Qualified timestamp',
+  timestampChain:       'Timestamp chain',
 };
 
 // Fixed display order
@@ -56,6 +57,7 @@ const CHECK_ORDER = [
   'bundleHash',
   'signature',
   'timestamp',
+  'qualifiedTimestamp',
   'timestampChain',
 ];
 
@@ -84,7 +86,8 @@ function checkLabel(name) {
  *     signature?: string,
  *     publicKey?: string,
  *     signedAt?: string,
- *     timestamp?: { genTime: string, tsa: string }
+ *     timestamp?: { genTime: string, tsa: string },
+ *     qualifiedTimestamp?: { genTime: string, tsa: string }
  *   },
  *   keyResolution?: {
  *     keyId: string,
@@ -148,6 +151,11 @@ export function formatHuman(result, opts = {}) {
   const tsa = result.capture?.timestamp?.tsa;
   if (tsa) {
     process.stdout.write(`  TSA       ${tsa}\n`);
+  }
+
+  const qtsa = result.capture?.qualifiedTimestamp?.tsa;
+  if (qtsa) {
+    process.stdout.write(`  QTSA      ${qtsa} (eIDAS)\n`);
   }
 
   const kr = result.keyResolution;

--- a/packages/verify/lib/verify.js
+++ b/packages/verify/lib/verify.js
@@ -233,7 +233,32 @@ export async function verifyWacz(waczBytes, publicKeyBytes, options = {}) {
   // For v0.1.0: no timestamp check at all (3 checks, not 4)
 
   // ---------------------------------------------------------------------------
-  // Check 5: timestampChain (CLI only -- CMS certificate chain validation)
+  // Check 5: qualifiedTimestamp (v0.2.0 only, when present)
+  // ---------------------------------------------------------------------------
+  let qualifiedTimestampData = null;
+  if (version === '0.2.0') {
+    const sigs = signedData?.signatures ?? [];
+    const qtsEntry = sigs.find(s => s.type === 'rfc3161_qualified');
+
+    if (!qtsEntry) {
+      // Absent = not requested. Do NOT push a skip check -- simply omit.
+    } else {
+      try {
+        const result = verifyTimestamp(qtsEntry.token, signedData.hash);
+        if (result.valid) {
+          checks.push({ name: 'qualifiedTimestamp', status: 'pass' });
+          qualifiedTimestampData = { genTime: result.genTime, tsa: qtsEntry.tsa };
+        } else {
+          checks.push({ name: 'qualifiedTimestamp', status: 'fail', detail: 'Qualified timestamp structurally invalid' });
+        }
+      } catch {
+        checks.push({ name: 'qualifiedTimestamp', status: 'fail', detail: 'Qualified timestamp structurally invalid' });
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Check 6: timestampChain (CLI only -- CMS certificate chain validation)
   // ---------------------------------------------------------------------------
   if (version === '0.2.0' && tsToken && trustedRoots && trustedRoots.length > 0 && doCmsChain) {
     try {
@@ -278,6 +303,9 @@ export async function verifyWacz(waczBytes, publicKeyBytes, options = {}) {
     };
     if (timestampData) {
       result.capture.timestamp = timestampData;
+    }
+    if (qualifiedTimestampData) {
+      result.capture.qualifiedTimestamp = qualifiedTimestampData;
     }
   }
 


### PR DESCRIPTION
## Summary

- CLI's vendored `verify.js` was missing the `qualifiedTimestamp` check (eIDAS `rfc3161_qualified`)
- Server-side verification showed the qualified timestamp as passing, but the CLI silently omitted it
- Adds check 5 (qualifiedTimestamp) between timestamp and timestampChain checks
- Adds "Qualified timestamp" label and QTSA metadata line to CLI output

## Test plan

- [x] All 143 verify package tests pass
- [x] Server-side verify shows `qualifiedTimestamp: pass` for eIDAS captures
- [ ] CLI shows `Qualified timestamp  pass` after npm publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)