### PR TITLE
feat(billing): add Billing tab to web UI (#170)

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -130,7 +130,7 @@ Deferred items with explicit activation triggers. Revisit when condition is met.
 | Item | Condition | Source |
 |------|-----------|--------|
 | ~~[should] Wire Stripe meter event reporting into capture pipeline~~ | ~~When first paying tenant onboards~~ -- DONE (Phase 0060): hourly batch reporter with idempotency keys, graduated pricing module, billing dashboard endpoint (Issue #108) | Phase 0058 |
-| [consider] Stripe Checkout returnUrl from client config | Currently defaults to `/ui`; make configurable when billing UI exists | Phase 0058 |
+| ~~[consider] Stripe Checkout returnUrl from client config~~ | ~~Partially addressed: Phase 0076 billing UI sets returnUrl to `/ui#/billing`; full configurability not needed~~ | Phase 0058 → 0076 |
 
 ### Security
 
@@ -192,7 +192,7 @@ Deferred items with explicit activation triggers. Revisit when condition is met.
 | [consider] Fix --color-text-muted contrast on landing page | When a11y audit runs; apply local override (same pattern as docs site in Phase 0051) | Phase 0052 |
 | [consider] Paywall and accept-only CMP handling (#156) | When a user needs to capture paywall/accept-only sites | Phase 0059b |
 | [consider] Automated autoconsent update pipeline (#152) | When manual update lag causes CMP regressions | Phase 0059b |
-| [consider] Embed Stripe payment form instead of redirect (#147) | After Billing UI ships (Phase 0076), if redirect flow is UX problem | Phase 0058 |
+| [consider] Embed Stripe payment form instead of redirect (#147) | Billing UI shipped (Phase 0076) with redirect flow; activate if redirect causes UX friction | Phase 0058 → 0076 |
 | [consider] Fetch-based capture for non-HTML resources (#143) | When a user needs to capture PDFs, APIs, or static files | Product |
 | [consider] GTM metrics: Cloudflare Web Analytics + Search Console (#148) | When GTM efforts start (Phase 0066 ecosystem push) | GTM research |
 | [consider] SEO optimization for landing page (#136) | When GTM efforts start (Phase 0066) | GTM research |

--- a/docs/evolution/0076-billing-ui-panel/decisions.md
+++ b/docs/evolution/0076-billing-ui-panel/decisions.md
@@ -1,0 +1,31 @@
+# Phase 0076: Billing UI Panel -- Decisions
+
+## D1: Separate Billing tab vs. billing inside Settings
+
+**Chosen**: Separate `#/billing` route with dedicated `ui-billing.js` module
+**Over**: Adding billing as a section inside `ui-settings.js` (ux-strategy-minion recommendation)
+**Why**: Issue #170 explicitly requests a "Billing tab"; settings is already 976 lines and adding billing would push it past maintainable size; separate module follows the established per-view pattern (ui-schedules.js, ui-settings.js). The ux-strategy-minion's argument (billing is "manage my account" not a distinct job) was considered but outweighed by the explicit issue scope and file size concern.
+
+## D2: Stripe portal opens in same tab (redirect) vs. new tab
+
+**Chosen**: Same-tab redirect via `window.location.href`
+**Over**: `target="_blank"` new tab
+**Why**: Stripe portal is designed as a redirect flow with `returnUrl` already configured to `/ui#/billing`; same-tab maintains the "managing my billing" mental model. The `aria-describedby` warning pattern still applies (user is leaving WRL), but the navigation is a redirect not a new tab.
+
+## D3: Tier table collapsed by default vs. always visible
+
+**Chosen**: Collapsed with "View all tiers" disclosure toggle using `<details>`/`<summary>`
+**Over**: Always-visible full tier table
+**Why**: ux-strategy-minion correctly identified tiers as reference information, not operational information. Most users are on Free or Standard tier -- showing all four tiers by default is noise for the majority. Progressive disclosure reduces cognitive load. Current tier is always visible inline.
+
+## D4: eIDAS section -- defensive absence handling vs. blocking on backend
+
+**Chosen**: Ship billing tab with defensive checks for eIDAS data absence; show "View in Stripe" fallback
+**Over**: Blocking the billing tab on a backend change to add eIDAS counts to `/v1/account/usage`
+**Why**: The eIDAS data gap is a known limitation (eidas_capture_count exists in usage_counters but isn't in the API response yet). Shipping the tab without blocking on backend work is pragmatic -- the eIDAS section will auto-activate when the backend is extended later.
+
+## D5: Code review fixes
+
+Two issues found during code review and auto-fixed:
+1. **DOM leak in eIDAS portal link**: Click handler appended a temporary button to the DOM on every click without cleanup. Fixed by not appending to DOM (handlePortalRedirect only needs textContent + disabled).
+2. **Dead CSS class**: Tier table used `className = 'table'` (design system class) instead of `'billing-tier-table'` (billing-specific class). Mobile responsive styles were unreachable. Fixed to use `billing-tier-table`.

--- a/docs/evolution/0076-billing-ui-panel/outcome.md
+++ b/docs/evolution/0076-billing-ui-panel/outcome.md
@@ -1,0 +1,72 @@
+# Phase 0076: Billing UI Panel -- Outcome
+
+## What was built
+
+A "Billing" tab in the WRL web UI at `#/billing` showing:
+
+- **Status banner** -- conditional warning (grace_period) or error (blocked) with "Update payment method" CTA
+- **Current period summary** -- capture count, current charges in EUR, pricing tier with sr-only tier description
+- **Invoice threshold progress** -- progressbar showing EUR X.XX of EUR 5.00 with anxiety-reducing copy
+- **Graduated pricing tiers** -- collapsed by default, expandable table with active tier highlight
+- **eIDAS add-on usage** -- conditional section when qualified timestamps enabled, with graceful fallback for missing API data
+- **Payment and portal** -- payment method status with Stripe Customer Portal redirect (checkout for new users, portal for existing)
+
+## Files changed
+
+| File | Action | Lines |
+|------|--------|-------|
+| `src/ui/ui-billing.js` | Created | 930 |
+| `src/ui/ui-css.js` | Modified | +70 |
+| `src/ui/ui-shell.js` | Modified | +15 |
+| `src/ui/ui-auth.js` | Modified | +6 |
+| `test/ui-billing.test.js` | Created | 234 |
+
+Total: 2 new files, 3 modified files, ~1,255 lines added.
+
+## Test coverage
+
+35 tests across 8 partitions:
+- A: Billing status labels (4 tests)
+- B: Payment CTA logic (2 tests)
+- C: eIDAS section visibility (2 tests)
+- D: Pure helper logic -- formatCurrency, thresholdPercent, thresholdClass (11 tests)
+- E: Structural smoke checks (10 tests)
+- F: Security scan -- no innerHTML (1 test)
+- G: CSS class presence (4 tests)
+- H: Module separation guard (1 test)
+
+Full test suite: 1215 passed, 0 failed, 50 test files.
+
+## Security measures
+
+- Stripe URL prefix validation before `window.location.href` assignment (both checkout and portal flows)
+- Zero `innerHTML` with variable data -- all dynamic content via `textContent` and DOM construction
+- Button disabled on click with "Redirecting..." text to prevent double-submission
+- `aria-describedby` warning on all portal/checkout buttons: "Opens Stripe's secure billing portal. You will leave this site."
+
+## Accessibility
+
+- `role="status"` for grace_period banner, `role="alert"` for blocked banner
+- `role="progressbar"` with `aria-valuetext` for invoice threshold (prevents raw cents announcement)
+- Short `aria-label="Invoice threshold"` separate from valuetext to avoid double-announcement
+- `data-label` attributes on tier table cells for mobile CSS `::before` content
+- Proper heading hierarchy: h1 > h2 for all sections
+- `aria-live="polite"` region for billing status announcements
+
+## Code review findings
+
+2 issues found and auto-fixed:
+1. DOM leak in eIDAS portal link click handler (temporary button appended without cleanup)
+2. Dead CSS class -- tier table using wrong className, making mobile responsive styles unreachable
+
+## Known limitations
+
+- eIDAS capture count not in API response yet -- billing tab shows "View in Stripe" fallback
+- `formatPeriod` is an implicit cross-module dependency (defined in settings, used in billing via shared IIFE scope)
+- No E2E browser tests for the billing tab (existing pattern -- other tabs also lack E2E tests)
+
+## Backlog changes
+
+- #170 resolved by this phase
+- Updated parking lot: `[consider] Stripe Checkout returnUrl from client config` -- now partially addressed (returnUrl uses `window.location.origin + '/ui#/billing'`)
+- Deferred: billing tab user documentation (SHOULD priority, no user docs exist for any UI tab)

--- a/docs/evolution/0076-billing-ui-panel/process.md
+++ b/docs/evolution/0076-billing-ui-panel/process.md
@@ -1,0 +1,82 @@
+# Phase 0076: Billing UI Panel -- Process
+
+## TL;DR
+
+Five specialists planned, six reviewers validated, four execution tasks produced a billing UI tab in ~20 minutes of agent time. The main conflict -- separate tab vs. inside Settings -- was resolved by issue scope and file size evidence. Code review caught two bugs (DOM leak, dead CSS class) that were auto-fixed before merge. 35 new tests, full suite green at 1215/1215.
+
+## Planning Phase
+
+### Specialists consulted (Phase 2)
+
+1. **frontend-minion** -- Analyzed codebase patterns (ui-settings.js at 976 lines, IIFE module pattern, hash router). Recommended separate `ui-billing.js` module with dedicated route. Proposed 4 tasks.
+
+2. **ux-strategy-minion** -- Argued billing should go INSIDE Settings as a section, not a 4th tab. Rationale: billing is "manage my account" not a distinct job; 4th tab increases cognitive load at 420px mobile. Proposed 3 tasks.
+
+3. **accessibility-minion** -- Specified ARIA patterns: `role="progressbar"` with `aria-valuetext` for threshold bar (not raw cents), `role="status"` for grace_period vs `role="alert"` for blocked, `aria-describedby` for external Stripe link warning. Flagged potential aria-live pollution on refresh.
+
+4. **security-minion** -- Confirmed `window.location.href` redirect is safe for Stripe portal. Recommended URL prefix validation (check for `billing.stripe.com` or `checkout.stripe.com` before redirect). Confirmed no CSP changes needed, existing rate limiting covers billing endpoints.
+
+5. **test-minion** -- Designed test strategy: 6 partitions covering status display, CTA logic, eIDAS visibility, pure helpers, structural smoke, and security scan. Recommended `evalFromSource` pattern from existing `ui-settings-usage.test.js`.
+
+### The main conflict
+
+**frontend-minion** wanted a separate Billing tab with dedicated route. **ux-strategy-minion** wanted billing as a section inside Settings. Both had valid points:
+
+- **For separate tab**: Issue #170 explicitly says "Billing tab"; settings already 976 lines and growing; separation of concerns matches existing pattern (each view is its own module).
+- **For inside Settings**: Billing is account management, not a distinct user job; 4th tab adds cognitive load; mobile layout concern at 420px.
+
+**Resolution**: Separate tab won. The issue scope was the tiebreaker -- when the product owner says "Billing tab", that's the deliverable shape. The file size argument (976 lines would become 1900+) made the engineering case. The ux-strategy-minion's information hierarchy recommendations (charges primary, tier secondary, payment status proportional to urgency) were still applied to the content within the tab.
+
+## Architecture Review (Phase 3.5)
+
+Six reviewers, all in parallel:
+
+- **test-minion**: APPROVE
+- **accessibility-minion**: ADVISE -- two items: (1) split aria-label and aria-valuetext to avoid double-announcement on progressbar, (2) add data-label attributes to tier table `<td>` for mobile responsive layout. Both incorporated into Task 1 prompt.
+- **ux-strategy-minion**: APPROVE -- accepted the separate tab decision
+- **margo**: APPROVE -- confirmed 4 tasks is proportional, no over-engineering
+- **security-minion**: ADVISE -- three items: (1) document Stripe URL prefixes in validation, (2) smoke test CSP form-action compatibility with Stripe return, (3) handle NaN in formatCurrency. All incorporated.
+- **lucy**: ADVISE -- three findings, all minor/informational: (1) verify evolution log handled at orchestration level, (2) IIFE insertion point wording is correct, (3) formatPeriod reuse across IIFE boundary is existing pattern. No plan changes needed.
+
+Final tally: 3 APPROVE, 3 ADVISE, 0 BLOCK. Five advisories incorporated into task prompts.
+
+## Execution (Phase 4)
+
+### Batch 1 (parallel)
+
+- **Task 1**: frontend-minion created `src/ui/ui-billing.js` (931 lines). Module exports `BILLING_JS` string constant with 6 pure helper functions, 6 section builders, Stripe redirect with URL prefix validation, full ARIA support. Gated -- Lucy approved after verifying all 5 criteria (export pattern, pure helpers, URL validation, ARIA roles, no innerHTML).
+
+- **Task 2**: frontend-minion added billing CSS to `ui-css.js` (+70 lines). Stats row grid, tier table, status badges, responsive overrides at 640px with data-label mobile stacking.
+
+### Batch 2 (parallel, after gate)
+
+- **Task 3**: frontend-minion wired `#/billing` route into `ui-shell.js` and nav link into `ui-auth.js`. Import, IIFE section (after SETTINGS, before SCHEDULES), route with session-gate, nav link between Schedules and Settings.
+
+- **Task 4**: test-minion created `test/ui-billing.test.js` (234 lines, 35 tests). 8 partitions covering all specified test areas plus additional thresholdClass coverage.
+
+## Code Review (Phase 5)
+
+Code reviewer found two issues:
+
+1. **DOM leak**: eIDAS portal link click handler created a temporary button and appended it to the DOM on every click. `handlePortalRedirect` only reads `textContent` and `disabled`, so DOM insertion was unnecessary. Fix: don't append to DOM.
+
+2. **Dead CSS class**: Tier table used `className = 'table'` (design system class) instead of `'billing-tier-table'`. This meant the billing-specific mobile responsive styles (hide thead, block display for td, data-label ::before) were unreachable. Fix: use `billing-tier-table`.
+
+Both auto-fixed. Full test suite confirmed green (1215/1215).
+
+## Human interventions
+
+This was an autonomous execution. Lucy (governance agent) made all gate decisions:
+- Team approval: APPROVE (5 specialists)
+- Reviewer approval: auto-approved (no discretionary reviewers beyond accessibility-minion)
+- Execution plan: APPROVE
+- Task 1 gate: APPROVE
+- Post-execution: "Run all"
+
+No human overrides or adjustments.
+
+## Where to read more
+
+- Specialist discussions: `docs/history/nefario-reports/` (companion directory for this run)
+- Full synthesis plan: scratch files preserved in report companion directory
+- Issue: #170

--- a/docs/evolution/0076-billing-ui-panel/prompt.md
+++ b/docs/evolution/0076-billing-ui-panel/prompt.md
@@ -1,0 +1,31 @@
+# Phase 0076: Billing UI Panel
+
+## Source
+
+GitHub Issue: #170 — Billing UI panel (usage dashboard, payment method, invoices)
+
+## Task Description
+
+Phase 0058 built the billing API endpoints (checkout, portal, webhook) but no UI.
+The web UI at `/ui` has three tabs (Captures, Settings, Schedules) but no Billing tab.
+The only billing-related UI element is a small "Add a payment method" link in Settings
+that points to a non-existent `/billing` page.
+
+### What's needed
+
+A "Billing" tab in the web UI navigation showing:
+
+- Current period capture count and estimated charges
+- Applicable pricing tier (free / volume discount bracket)
+- EUR 5 invoice threshold progress
+- Payment method status (none / active / failed)
+- Link to Stripe Customer Portal for payment method management and invoice history
+- eIDAS add-on usage if enabled
+
+Data source: `GET /v1/account/usage` already returns billing sub-object with
+all needed fields (captures, charges, tier, threshold progress).
+
+### Scope
+
+- In: Navigation tab, usage dashboard panel, Stripe portal link, responsive layout
+- Out: Inline payment form (#147), invoice PDF rendering (Stripe handles this)

--- a/docs/evolution/README.md
+++ b/docs/evolution/README.md
@@ -74,3 +74,4 @@ software development.
 | [0062-capture-auth-gate](0062-capture-auth-gate/) | Capture auth gate for multi-tenant: tenant auth on retrieval endpoints, share tokens for delegated access, CLI token propagation (Issue #110) |
 | [0063-eidas-qualified-timestamps](0063-eidas-qualified-timestamps/) | eIDAS qualified timestamps: account-level opt-in, dual-TSA WACZ assembly, verification, Stripe billing, settings UI (Issue #138) |
 | [0059b-capture-quality](0059b-capture-quality/) | Capture quality improvements: error page detection, subresource limit 200→500, autoconsent v14.63.0, lazy-load scrolling, test battery |
+| [0076-billing-ui-panel](0076-billing-ui-panel/) | Billing UI panel: usage dashboard with charges, pricing tiers, invoice threshold, payment status, Stripe portal link, eIDAS add-on (Issue #170) |

--- a/src/ui/ui-auth.js
+++ b/src/ui/ui-auth.js
@@ -158,6 +158,12 @@ function renderAppShell() {
     schedulesLink.textContent = 'Schedules';
     navLinks.appendChild(schedulesLink);
 
+    var billingLink = document.createElement('a');
+    billingLink.href = '#/billing';
+    billingLink.className = 'nav-link';
+    billingLink.textContent = 'Billing';
+    navLinks.appendChild(billingLink);
+
     var settingsLink = document.createElement('a');
     settingsLink.href = '#/settings';
     settingsLink.className = 'nav-link';

--- a/src/ui/ui-billing.js
+++ b/src/ui/ui-billing.js
@@ -487,7 +487,7 @@ function buildPricingSection(usageData) {
     tableWrap.style.overflowX = 'auto';
 
     var table = document.createElement('table');
-    table.className = 'table';
+    table.className = 'billing-tier-table';
     table.setAttribute('aria-label', 'Pricing tiers');
 
     var thead = document.createElement('thead');
@@ -581,7 +581,6 @@ function buildEidasSection(usageData) {
       // Create a temporary button element to satisfy handlePortalRedirect signature
       var tmpBtn = document.createElement('button');
       tmpBtn.textContent = 'View usage details in Stripe.';
-      note.appendChild(tmpBtn);
       handlePortalRedirect(tmpBtn);
     });
     note.appendChild(portalLink);

--- a/src/ui/ui-billing.js
+++ b/src/ui/ui-billing.js
@@ -1,0 +1,931 @@
+// tva
+// Billing dashboard view for WRL.
+// Exports a JS string constant for inline use in the HTML shell.
+
+export const BILLING_JS = `
+// ---------------------------------------------------------------------------
+// Billing module state
+// ---------------------------------------------------------------------------
+
+var _billingLiveEl = null;
+var _lastBillingStatus = null;
+
+// ---------------------------------------------------------------------------
+// Pure helper functions (extracted for testability via evalFromSource)
+// ---------------------------------------------------------------------------
+
+function formatCurrency(amount) {
+  var n = parseFloat(amount);
+  if (!isFinite(n)) return 'EUR 0.00';
+  return 'EUR ' + n.toFixed(2);
+}
+
+function billingStatusLabel(status) {
+  if (status === 'free') return 'Free';
+  if (status === 'active') return 'Active';
+  if (status === 'grace_period') return 'Grace period';
+  if (status === 'blocked') return 'Blocked';
+  return status || 'Unknown';
+}
+
+function tierDescription(tier) {
+  if (!tier) return '';
+  if (tier.unitPrice === 0) {
+    var toStr = tier.to ? 'up to ' + tier.to.toLocaleString() + ' captures per month at no charge' : 'free';
+    return ' \u2014 ' + toStr;
+  }
+  return ' \u2014 EUR ' + tier.unitPrice.toFixed(3).replace(/0+$/, '').replace(/\\.$/, '') + ' per capture';
+}
+
+function shouldShowCheckout(hasPaymentMethod, billingStatus) {
+  return !hasPaymentMethod && (billingStatus === 'free' || !billingStatus);
+}
+
+function thresholdPercent(amount, threshold) {
+  if (!threshold || threshold <= 0) return 0;
+  var pct = Math.round((amount / threshold) * 100);
+  return Math.min(100, Math.max(0, pct));
+}
+
+function thresholdClass(pct) {
+  if (pct >= 95) return 'usage-bar-fill--critical';
+  if (pct >= 80) return 'usage-bar-fill--warning';
+  return '';
+}
+
+// ---------------------------------------------------------------------------
+// Announce helper
+// ---------------------------------------------------------------------------
+
+function billingAnnounce(message) {
+  if (!_billingLiveEl) return;
+  _billingLiveEl.textContent = '';
+  setTimeout(function() { _billingLiveEl.textContent = message; }, 50);
+}
+
+// ---------------------------------------------------------------------------
+// renderBilling() -- builds DOM skeleton for the billing view
+// ---------------------------------------------------------------------------
+
+function renderBilling() {
+  document.title = 'Billing \u2014 WRL';
+
+  var view = document.getElementById('view');
+  // Safe: clearing the static view container; no user or API data involved
+  view.textContent = '';
+
+  // aria-live region for status announcements (sr-only, not visible)
+  var liveEl = document.createElement('div');
+  liveEl.setAttribute('aria-live', 'polite');
+  liveEl.setAttribute('aria-atomic', 'true');
+  liveEl.className = 'sr-only';
+  liveEl.id = 'billing-live';
+  view.appendChild(liveEl);
+  _billingLiveEl = liveEl;
+
+  var h1 = document.createElement('h1');
+  h1.className = 'captures-heading';
+  h1.tabIndex = -1;
+  h1.textContent = 'Billing';
+  view.appendChild(h1);
+
+  // Loading state for initial data fetch
+  var loadingEl = document.createElement('p');
+  loadingEl.id = 'billing-loading';
+  loadingEl.className = 'view-placeholder';
+  loadingEl.textContent = 'Loading billing information...';
+  view.appendChild(loadingEl);
+
+  h1.focus();
+}
+
+// ---------------------------------------------------------------------------
+// mountBilling() -- fetch data and build full content
+// ---------------------------------------------------------------------------
+
+function mountBilling() {
+  var view = document.getElementById('view');
+  var loadingEl = document.getElementById('billing-loading');
+  if (!view) return;
+
+  var usagePromise = apiFetch('/v1/account/usage', { credentials: 'same-origin' })
+    .then(function(res) {
+      if (!res || !res.ok) return null;
+      return res.json();
+    })
+    .catch(function() { return null; });
+
+  var settingsPromise = apiFetch('/v1/account/settings', { credentials: 'same-origin' })
+    .then(function(res) {
+      if (!res || !res.ok) return null;
+      return res.json();
+    })
+    .catch(function() { return null; });
+
+  Promise.all([usagePromise, settingsPromise])
+    .then(function(results) {
+      var usageData = results[0];
+      var settingsData = results[1];
+
+      if (loadingEl) loadingEl.remove();
+
+      if (!usageData) {
+        var errEl = document.createElement('div');
+        errEl.className = 'alert alert--error';
+        errEl.setAttribute('role', 'alert');
+        errEl.textContent = 'Could not load billing information. Please try refreshing.';
+        view.appendChild(errEl);
+        return;
+      }
+
+      _lastBillingStatus = usageData.billingStatus || null;
+      buildBillingContent(usageData, settingsData);
+    })
+    .catch(function() {
+      if (loadingEl) loadingEl.remove();
+      var netErrEl = document.createElement('div');
+      netErrEl.className = 'alert alert--error';
+      netErrEl.setAttribute('role', 'alert');
+      netErrEl.textContent = 'Connection failed loading billing information. Check your network.';
+      view.appendChild(netErrEl);
+    });
+}
+
+// ---------------------------------------------------------------------------
+// buildBillingContent -- orchestrates section builders (pure of side effects)
+// ---------------------------------------------------------------------------
+
+function buildBillingContent(usageData, settingsData) {
+  var view = document.getElementById('view');
+  if (!view) return;
+
+  // Remove any previous content sections (keep live region + h1)
+  var existing = view.querySelectorAll('section, .billing-status-banner, .billing-refresh-row');
+  for (var i = 0; i < existing.length; i++) {
+    existing[i].remove();
+  }
+
+  // Section A: Status banner (conditional)
+  var banner = buildStatusBanner(usageData);
+  if (banner) view.appendChild(banner);
+
+  // Refresh row (below banner, above sections)
+  view.appendChild(buildRefreshRow(usageData));
+
+  // Section B: Current period summary
+  view.appendChild(buildPeriodSummary(usageData));
+
+  // Section C: Invoice threshold progress
+  var thresholdSection = buildThresholdSection(usageData);
+  if (thresholdSection) view.appendChild(thresholdSection);
+
+  // Section D: Graduated pricing tiers
+  view.appendChild(buildPricingSection(usageData));
+
+  // Section E: eIDAS add-on (conditional)
+  if (settingsData && settingsData.qualifiedTimestamps) {
+    view.appendChild(buildEidasSection(usageData));
+  }
+
+  // Section F: Payment and portal
+  view.appendChild(buildPaymentSection(usageData));
+}
+
+// ---------------------------------------------------------------------------
+// Section A: Status banner
+// ---------------------------------------------------------------------------
+
+function buildStatusBanner(usageData) {
+  var status = usageData.billingStatus;
+  if (status !== 'grace_period' && status !== 'blocked') return null;
+
+  var banner = document.createElement('div');
+  banner.className = 'billing-status-banner alert';
+
+  var msg = document.createElement('p');
+
+  if (status === 'grace_period') {
+    banner.setAttribute('role', 'status');
+    banner.classList.add('alert--warning');
+
+    var graceDateStr = '';
+    if (usageData.gracePeriodEnd) {
+      try {
+        graceDateStr = new Date(usageData.gracePeriodEnd).toLocaleDateString(undefined, {
+          year: 'numeric', month: 'long', day: 'numeric'
+        });
+      } catch (e) {
+        graceDateStr = usageData.gracePeriodEnd;
+      }
+    }
+
+    msg.textContent = 'Payment issue detected. Please update your payment method' +
+      (graceDateStr ? ' by ' + graceDateStr : '') + '.';
+
+  } else if (status === 'blocked') {
+    banner.setAttribute('role', 'alert');
+    banner.classList.add('alert--error');
+    msg.textContent = 'Captures paused due to payment failure. Update your payment method to resume.';
+  }
+
+  banner.appendChild(msg);
+
+  var updateBtn = document.createElement('button');
+  updateBtn.type = 'button';
+  updateBtn.className = 'btn btn--primary btn--sm';
+  updateBtn.style.marginTop = 'var(--space-2)';
+  updateBtn.textContent = 'Update payment method';
+  updateBtn.addEventListener('click', function() {
+    handlePortalRedirect(updateBtn);
+  });
+  banner.appendChild(updateBtn);
+
+  return banner;
+}
+
+// ---------------------------------------------------------------------------
+// Section B: Current period summary
+// ---------------------------------------------------------------------------
+
+function buildPeriodSummary(usageData) {
+  var billing = usageData.billing || {};
+  var section = document.createElement('section');
+  section.className = 'settings-section card';
+  section.setAttribute('aria-labelledby', 'billing-period-heading');
+
+  var inner = document.createElement('div');
+  inner.style.padding = 'var(--space-4) var(--space-5)';
+
+  var h2 = document.createElement('h2');
+  h2.id = 'billing-period-heading';
+  h2.className = 'settings-section-heading';
+  h2.textContent = formatPeriod(usageData.period) || 'Current Period';
+  inner.appendChild(h2);
+
+  // Three-stat row
+  var statsRow = document.createElement('div');
+  statsRow.className = 'billing-stats-row';
+
+  // Stat 1: Capture count
+  var captureCount = (usageData.captures && usageData.captures.used != null)
+    ? usageData.captures.used : 0;
+  statsRow.appendChild(buildStatCell(String(captureCount), 'Captures'));
+
+  // Stat 2: Current charges
+  var charges = billing.currentCharges || {};
+  statsRow.appendChild(buildStatCell(
+    formatCurrency(charges.amount != null ? charges.amount : 0),
+    'Current charges'
+  ));
+
+  // Stat 3: Current tier with sr-only description
+  var tier = billing.tier || null;
+  var tierName = tier ? tier.name : 'Free';
+
+  var tierCell = document.createElement('div');
+  tierCell.className = 'billing-stat';
+
+  var tierValueEl = document.createElement('span');
+  tierValueEl.className = 'billing-stat-value';
+  tierValueEl.textContent = tierName;
+
+  var tierDescSpan = document.createElement('span');
+  tierDescSpan.className = 'sr-only';
+  tierDescSpan.textContent = tierDescription(tier);
+  tierValueEl.appendChild(tierDescSpan);
+
+  var tierLabelEl = document.createElement('span');
+  tierLabelEl.className = 'billing-stat-label';
+  tierLabelEl.textContent = 'Pricing tier';
+
+  tierCell.appendChild(tierValueEl);
+  tierCell.appendChild(tierLabelEl);
+  statsRow.appendChild(tierCell);
+
+  inner.appendChild(statsRow);
+
+  // Reset date note
+  if (usageData.resetsAt) {
+    var resetNote = document.createElement('p');
+    resetNote.className = 'text-muted';
+    resetNote.style.fontSize = 'var(--text-sm)';
+    resetNote.style.marginTop = 'var(--space-3)';
+    try {
+      var resetDate = new Date(usageData.resetsAt).toLocaleDateString(undefined, {
+        year: 'numeric', month: 'short', day: 'numeric'
+      });
+      resetNote.textContent = 'Period resets ' + resetDate;
+    } catch (e) {
+      resetNote.textContent = 'Period resets ' + usageData.resetsAt;
+    }
+    inner.appendChild(resetNote);
+  }
+
+  section.appendChild(inner);
+  return section;
+}
+
+function buildStatCell(value, label) {
+  var cell = document.createElement('div');
+  cell.className = 'billing-stat';
+
+  var valueEl = document.createElement('span');
+  valueEl.className = 'billing-stat-value';
+  valueEl.textContent = value;
+  cell.appendChild(valueEl);
+
+  var labelEl = document.createElement('span');
+  labelEl.className = 'billing-stat-label';
+  labelEl.textContent = label;
+  cell.appendChild(labelEl);
+
+  return cell;
+}
+
+// ---------------------------------------------------------------------------
+// Section C: Invoice threshold progress
+// ---------------------------------------------------------------------------
+
+function buildThresholdSection(usageData) {
+  var billing = usageData.billing || {};
+  var invoiceThreshold = billing.invoiceThreshold;
+  var billingStatus = usageData.billingStatus;
+
+  // Hide for free users with no payment method (irrelevant -- won't be invoiced)
+  if (billingStatus === 'free' && !usageData.hasPaymentMethod) return null;
+  if (!invoiceThreshold) return null;
+
+  var thresholdAmount = invoiceThreshold.amount || 5.00;
+  var thresholdCents = Math.round(thresholdAmount * 100);
+  var currentAmount = (billing.currentCharges && billing.currentCharges.amount != null)
+    ? billing.currentCharges.amount : 0;
+  var currentCents = Math.round(currentAmount * 100);
+  var pct = thresholdPercent(currentAmount, thresholdAmount);
+  var fillCls = thresholdClass(pct);
+
+  var section = document.createElement('section');
+  section.className = 'settings-section card';
+  section.setAttribute('aria-labelledby', 'billing-threshold-heading');
+
+  var inner = document.createElement('div');
+  inner.style.padding = 'var(--space-4) var(--space-5)';
+
+  var h2 = document.createElement('h2');
+  h2.id = 'billing-threshold-heading';
+  h2.className = 'settings-section-heading';
+  h2.textContent = 'Invoice Threshold';
+  inner.appendChild(h2);
+
+  var metric = document.createElement('div');
+  metric.className = 'usage-metric';
+
+  var header = document.createElement('div');
+  header.className = 'usage-metric-header';
+
+  var labelEl = document.createElement('span');
+  labelEl.className = 'usage-metric-label';
+  labelEl.textContent = formatCurrency(currentAmount) + ' of ' + formatCurrency(thresholdAmount) + ' invoice threshold';
+  header.appendChild(labelEl);
+  metric.appendChild(header);
+
+  var bar = document.createElement('div');
+  bar.className = 'usage-bar';
+  bar.setAttribute('role', 'progressbar');
+  bar.setAttribute('aria-valuenow', String(currentCents));
+  bar.setAttribute('aria-valuemin', '0');
+  bar.setAttribute('aria-valuemax', String(thresholdCents));
+  // SHORT label -- do not repeat valuetext to avoid double-announcement
+  bar.setAttribute('aria-label', 'Invoice threshold');
+  bar.setAttribute('aria-valuetext', formatCurrency(currentAmount) + ' of ' + formatCurrency(thresholdAmount));
+
+  var fill = document.createElement('div');
+  fill.className = 'usage-bar-fill' + (fillCls ? ' ' + fillCls : '');
+  fill.style.width = pct + '%';
+  bar.appendChild(fill);
+  metric.appendChild(bar);
+  inner.appendChild(metric);
+
+  if (invoiceThreshold.met) {
+    var metNote = document.createElement('p');
+    metNote.style.fontSize = 'var(--text-sm)';
+    metNote.style.marginTop = 'var(--space-2)';
+    metNote.style.color = 'var(--color-success-text)';
+    metNote.textContent = 'Invoice will be issued at period end.';
+    inner.appendChild(metNote);
+  } else {
+    var deferNote = document.createElement('p');
+    deferNote.className = 'text-muted';
+    deferNote.style.fontSize = 'var(--text-sm)';
+    deferNote.style.marginTop = 'var(--space-2)';
+    deferNote.textContent = 'Charges under ' + formatCurrency(thresholdAmount) + ' are deferred to next period.';
+    inner.appendChild(deferNote);
+  }
+
+  section.appendChild(inner);
+  return section;
+}
+
+// ---------------------------------------------------------------------------
+// Section D: Graduated pricing tiers
+// ---------------------------------------------------------------------------
+
+function buildPricingSection(usageData) {
+  var billing = usageData.billing || {};
+  var tiers = billing.tiers || [];
+  var activeTier = billing.tier || null;
+
+  var section = document.createElement('section');
+  section.className = 'settings-section card';
+  section.setAttribute('aria-labelledby', 'billing-pricing-heading');
+
+  var inner = document.createElement('div');
+  inner.style.padding = 'var(--space-4) var(--space-5)';
+
+  var h2 = document.createElement('h2');
+  h2.id = 'billing-pricing-heading';
+  h2.className = 'settings-section-heading';
+  h2.textContent = 'Pricing';
+  inner.appendChild(h2);
+
+  // Current tier inline summary as dl
+  if (activeTier) {
+    var dl = document.createElement('dl');
+    dl.style.marginBottom = 'var(--space-3)';
+    dl.style.display = 'flex';
+    dl.style.gap = 'var(--space-2)';
+    dl.style.flexWrap = 'wrap';
+    dl.style.alignItems = 'baseline';
+
+    var dt = document.createElement('dt');
+    dt.className = 'text-muted';
+    dt.style.fontSize = 'var(--text-sm)';
+    dt.textContent = 'Current tier:';
+    dl.appendChild(dt);
+
+    var dd = document.createElement('dd');
+    dd.style.fontSize = 'var(--text-sm)';
+    dd.style.fontWeight = 'var(--weight-medium)';
+    var priceStr = activeTier.unitPrice === 0 ? 'free'
+      : 'EUR ' + activeTier.unitPrice.toFixed(3).replace(/0+$/, '').replace(/\\.$/, '') + '/capture';
+    dd.textContent = activeTier.name + ' (' + priceStr + ')';
+    dl.appendChild(dd);
+
+    inner.appendChild(dl);
+  }
+
+  // Tiers disclosure (collapsed by default)
+  if (tiers.length > 0) {
+    var details = document.createElement('details');
+    details.className = 'disclosure';
+
+    var summary = document.createElement('summary');
+    summary.textContent = 'View all tiers';
+    details.appendChild(summary);
+
+    var tableWrap = document.createElement('div');
+    tableWrap.style.padding = 'var(--space-3) var(--space-4) var(--space-4)';
+    tableWrap.style.overflowX = 'auto';
+
+    var table = document.createElement('table');
+    table.className = 'table';
+    table.setAttribute('aria-label', 'Pricing tiers');
+
+    var thead = document.createElement('thead');
+    var headRow = document.createElement('tr');
+    ['Tier', 'Range', 'Price per capture'].forEach(function(colName) {
+      var th = document.createElement('th');
+      th.setAttribute('scope', 'col');
+      th.textContent = colName;
+      headRow.appendChild(th);
+    });
+    thead.appendChild(headRow);
+    table.appendChild(thead);
+
+    var tbody = document.createElement('tbody');
+    for (var i = 0; i < tiers.length; i++) {
+      var tier = tiers[i];
+      var isActive = activeTier && activeTier.id === tier.id;
+
+      var fromStr = tier.from != null ? tier.from.toLocaleString() : '1';
+      var toStr = tier.to != null ? tier.to.toLocaleString() : '';
+      var rangeStr = tier.to != null ? (fromStr + '\u2013' + toStr) : (fromStr + '+');
+      var priceStr = tier.unitPrice === 0 ? 'Free'
+        : ('EUR ' + tier.unitPrice.toFixed(3).replace(/0+$/, '').replace(/\\.$/, ''));
+
+      var tr = document.createElement('tr');
+      if (isActive) {
+        tr.className = 'billing-tier-active';
+        tr.setAttribute('aria-current', 'true');
+      }
+
+      var tdName = document.createElement('td');
+      tdName.setAttribute('data-label', 'Tier');
+      tdName.textContent = tier.name || '';
+      tr.appendChild(tdName);
+
+      var tdRange = document.createElement('td');
+      tdRange.setAttribute('data-label', 'Range');
+      tdRange.textContent = rangeStr;
+      tr.appendChild(tdRange);
+
+      var tdPrice = document.createElement('td');
+      tdPrice.setAttribute('data-label', 'Price per capture');
+      tdPrice.textContent = priceStr;
+      tr.appendChild(tdPrice);
+
+      tbody.appendChild(tr);
+    }
+    table.appendChild(tbody);
+    tableWrap.appendChild(table);
+    details.appendChild(tableWrap);
+    inner.appendChild(details);
+  }
+
+  section.appendChild(inner);
+  return section;
+}
+
+// ---------------------------------------------------------------------------
+// Section E: eIDAS add-on usage
+// ---------------------------------------------------------------------------
+
+function buildEidasSection(usageData) {
+  var billing = usageData.billing || {};
+  var eidasData = billing.eidas || null;
+
+  var section = document.createElement('section');
+  section.className = 'settings-section card';
+  section.setAttribute('aria-labelledby', 'billing-eidas-heading');
+
+  var inner = document.createElement('div');
+  inner.style.padding = 'var(--space-4) var(--space-5)';
+
+  var h2 = document.createElement('h2');
+  h2.id = 'billing-eidas-heading';
+  h2.className = 'settings-section-heading';
+  h2.textContent = 'Qualified Timestamps';
+  inner.appendChild(h2);
+
+  if (!eidasData) {
+    // API does not yet return eIDAS usage data -- degrade gracefully
+    var note = document.createElement('p');
+    note.style.fontSize = 'var(--text-sm)';
+    note.textContent = 'Qualified Timestamps enabled. ';
+
+    var portalLink = document.createElement('a');
+    portalLink.href = '#';
+    portalLink.style.color = 'var(--color-accent)';
+    portalLink.textContent = 'View usage details in Stripe.';
+    portalLink.addEventListener('click', function(e) {
+      e.preventDefault();
+      // Create a temporary button element to satisfy handlePortalRedirect signature
+      var tmpBtn = document.createElement('button');
+      tmpBtn.textContent = 'View usage details in Stripe.';
+      note.appendChild(tmpBtn);
+      handlePortalRedirect(tmpBtn);
+    });
+    note.appendChild(portalLink);
+    inner.appendChild(note);
+  } else {
+    // Future: eIDAS data present in API response
+    var count = eidasData.count != null ? eidasData.count : 0;
+    var eidasCharges = eidasData.charges != null ? eidasData.charges : 0;
+
+    var dl = document.createElement('dl');
+    dl.style.display = 'flex';
+    dl.style.flexDirection = 'column';
+    dl.style.gap = 'var(--space-2)';
+
+    var dtCount = document.createElement('dt');
+    dtCount.className = 'text-muted';
+    dtCount.style.fontSize = 'var(--text-sm)';
+    dtCount.textContent = 'Qualified timestamps this period';
+    dl.appendChild(dtCount);
+
+    var ddCount = document.createElement('dd');
+    ddCount.style.fontWeight = 'var(--weight-medium)';
+    ddCount.textContent = count.toLocaleString();
+    dl.appendChild(ddCount);
+
+    var dtCharges = document.createElement('dt');
+    dtCharges.className = 'text-muted';
+    dtCharges.style.fontSize = 'var(--text-sm)';
+    dtCharges.textContent = 'Charges';
+    dl.appendChild(dtCharges);
+
+    var ddCharges = document.createElement('dd');
+    ddCharges.style.fontWeight = 'var(--weight-medium)';
+    ddCharges.textContent = formatCurrency(eidasCharges);
+    dl.appendChild(ddCharges);
+
+    inner.appendChild(dl);
+
+    var pricing = document.createElement('p');
+    pricing.className = 'text-muted';
+    pricing.style.fontSize = 'var(--text-sm)';
+    pricing.style.marginTop = 'var(--space-2)';
+    pricing.textContent = 'First 50 free, then EUR 0.10 each.';
+    inner.appendChild(pricing);
+  }
+
+  section.appendChild(inner);
+  return section;
+}
+
+// ---------------------------------------------------------------------------
+// Section F: Payment and portal
+// ---------------------------------------------------------------------------
+
+function buildPaymentSection(usageData) {
+  var status = usageData.billingStatus;
+  var hasPaymentMethod = !!usageData.hasPaymentMethod;
+
+  var section = document.createElement('section');
+  section.className = 'settings-section card';
+  section.setAttribute('aria-labelledby', 'billing-payment-heading');
+
+  var inner = document.createElement('div');
+  inner.style.padding = 'var(--space-4) var(--space-5)';
+
+  var h2 = document.createElement('h2');
+  h2.id = 'billing-payment-heading';
+  h2.className = 'settings-section-heading';
+  h2.textContent = 'Payment';
+  inner.appendChild(h2);
+
+  // sr-only portal description for aria-describedby
+  var portalDesc = document.createElement('span');
+  portalDesc.id = 'billing-portal-desc';
+  portalDesc.className = 'sr-only';
+  portalDesc.textContent = "Opens Stripe's secure billing portal. You will leave this site.";
+  inner.appendChild(portalDesc);
+
+  if (status === 'free' && !hasPaymentMethod) {
+    var infoBox = document.createElement('div');
+    infoBox.className = 'alert alert--info';
+    infoBox.setAttribute('role', 'status');
+    infoBox.style.marginBottom = 'var(--space-4)';
+    infoBox.textContent = 'No payment method required. First 200 captures/month are free.';
+    inner.appendChild(infoBox);
+
+    var setupBtn = document.createElement('button');
+    setupBtn.type = 'button';
+    setupBtn.className = 'btn btn--primary';
+    setupBtn.textContent = 'Set up billing';
+    setupBtn.setAttribute('aria-describedby', 'billing-portal-desc');
+    setupBtn.addEventListener('click', function() {
+      handleCheckoutRedirect(setupBtn);
+    });
+    inner.appendChild(setupBtn);
+
+  } else if (status === 'active' && hasPaymentMethod) {
+    var activeRow = document.createElement('div');
+    activeRow.style.display = 'flex';
+    activeRow.style.alignItems = 'center';
+    activeRow.style.gap = 'var(--space-4)';
+    activeRow.style.flexWrap = 'wrap';
+
+    var activeBadge = document.createElement('span');
+    activeBadge.className = 'badge badge--pass';
+    activeBadge.textContent = 'Payment method active';
+    activeRow.appendChild(activeBadge);
+
+    var manageBtn = document.createElement('button');
+    manageBtn.type = 'button';
+    manageBtn.className = 'btn btn--ghost btn--sm';
+    manageBtn.textContent = 'Manage billing';
+    manageBtn.setAttribute('aria-describedby', 'billing-portal-desc');
+    manageBtn.addEventListener('click', function() {
+      handlePortalRedirect(manageBtn);
+    });
+    activeRow.appendChild(manageBtn);
+
+    inner.appendChild(activeRow);
+
+  } else if (status === 'grace_period') {
+    var graceNote = document.createElement('p');
+    graceNote.style.fontSize = 'var(--text-sm)';
+    graceNote.style.marginBottom = 'var(--space-3)';
+    graceNote.textContent = 'See the notice above to update your payment method.';
+    inner.appendChild(graceNote);
+
+    var graceBtn = document.createElement('button');
+    graceBtn.type = 'button';
+    graceBtn.className = 'btn btn--secondary';
+    graceBtn.textContent = 'Update payment method';
+    graceBtn.setAttribute('aria-describedby', 'billing-portal-desc');
+    graceBtn.addEventListener('click', function() {
+      handlePortalRedirect(graceBtn);
+    });
+    inner.appendChild(graceBtn);
+
+  } else if (status === 'blocked') {
+    var blockedNote = document.createElement('p');
+    blockedNote.style.fontSize = 'var(--text-sm)';
+    blockedNote.style.marginBottom = 'var(--space-3)';
+    blockedNote.textContent = 'Captures are paused. Update your payment method to resume.';
+    inner.appendChild(blockedNote);
+
+    var blockedBtn = document.createElement('button');
+    blockedBtn.type = 'button';
+    blockedBtn.className = 'btn btn--primary';
+    blockedBtn.textContent = 'Update payment method';
+    blockedBtn.setAttribute('aria-describedby', 'billing-portal-desc');
+    blockedBtn.addEventListener('click', function() {
+      handlePortalRedirect(blockedBtn);
+    });
+    inner.appendChild(blockedBtn);
+
+  } else {
+    // Fallback for unexpected or transitional status values
+    var fallbackNote = document.createElement('p');
+    fallbackNote.className = 'text-muted';
+    fallbackNote.style.fontSize = 'var(--text-sm)';
+    fallbackNote.style.marginBottom = 'var(--space-3)';
+    fallbackNote.textContent = billingStatusLabel(status);
+    inner.appendChild(fallbackNote);
+
+    if (shouldShowCheckout(hasPaymentMethod, status)) {
+      var fallbackCheckoutBtn = document.createElement('button');
+      fallbackCheckoutBtn.type = 'button';
+      fallbackCheckoutBtn.className = 'btn btn--primary';
+      fallbackCheckoutBtn.textContent = 'Set up billing';
+      fallbackCheckoutBtn.setAttribute('aria-describedby', 'billing-portal-desc');
+      fallbackCheckoutBtn.addEventListener('click', function() {
+        handleCheckoutRedirect(fallbackCheckoutBtn);
+      });
+      inner.appendChild(fallbackCheckoutBtn);
+    } else {
+      var fallbackPortalBtn = document.createElement('button');
+      fallbackPortalBtn.type = 'button';
+      fallbackPortalBtn.className = 'btn btn--ghost';
+      fallbackPortalBtn.textContent = 'Manage billing';
+      fallbackPortalBtn.setAttribute('aria-describedby', 'billing-portal-desc');
+      fallbackPortalBtn.addEventListener('click', function() {
+        handlePortalRedirect(fallbackPortalBtn);
+      });
+      inner.appendChild(fallbackPortalBtn);
+    }
+  }
+
+  section.appendChild(inner);
+  return section;
+}
+
+// ---------------------------------------------------------------------------
+// Refresh row
+// ---------------------------------------------------------------------------
+
+function buildRefreshRow(usageData) {
+  var row = document.createElement('div');
+  row.className = 'billing-refresh-row usage-footer';
+  row.style.marginBottom = 'var(--space-4)';
+
+  var leftEl = document.createElement('span');
+  leftEl.className = 'text-muted';
+  leftEl.style.fontSize = 'var(--text-sm)';
+  leftEl.textContent = 'Status: ' + billingStatusLabel(usageData.billingStatus);
+  row.appendChild(leftEl);
+
+  var refreshBtn = document.createElement('button');
+  refreshBtn.type = 'button';
+  refreshBtn.className = 'usage-refresh-btn';
+  refreshBtn.textContent = '\u21bb';
+  refreshBtn.setAttribute('aria-label', 'Refresh billing data');
+  refreshBtn.addEventListener('click', function() {
+    refreshBillingData();
+  });
+  row.appendChild(refreshBtn);
+
+  return row;
+}
+
+// ---------------------------------------------------------------------------
+// refreshBillingData -- re-fetch and rebuild billing content
+// ---------------------------------------------------------------------------
+
+function refreshBillingData() {
+  var usagePromise = apiFetch('/v1/account/usage', { credentials: 'same-origin' })
+    .then(function(res) {
+      if (!res || !res.ok) return null;
+      return res.json();
+    })
+    .catch(function() { return null; });
+
+  var settingsPromise = apiFetch('/v1/account/settings', { credentials: 'same-origin' })
+    .then(function(res) {
+      if (!res || !res.ok) return null;
+      return res.json();
+    })
+    .catch(function() { return null; });
+
+  Promise.all([usagePromise, settingsPromise])
+    .then(function(results) {
+      var usageData = results[0];
+      var settingsData = results[1];
+
+      if (!usageData) {
+        billingAnnounce('Could not refresh billing data.');
+        return;
+      }
+
+      var newStatus = usageData.billingStatus || null;
+      var statusChanged = newStatus !== _lastBillingStatus;
+      _lastBillingStatus = newStatus;
+
+      buildBillingContent(usageData, settingsData);
+
+      if (statusChanged) {
+        billingAnnounce('Billing status updated: ' + billingStatusLabel(newStatus));
+      }
+    })
+    .catch(function() {
+      billingAnnounce('Connection failed refreshing billing data.');
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Stripe redirect handlers
+// ---------------------------------------------------------------------------
+
+function handleCheckoutRedirect(btn) {
+  btn.disabled = true;
+  btn.textContent = 'Redirecting...';
+
+  var returnUrl = window.location.origin + '/ui#/billing';
+
+  apiFetch('/v1/billing/checkout', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ returnUrl: returnUrl }),
+  }).then(function(res) {
+    if (!res) {
+      btn.disabled = false;
+      btn.textContent = 'Set up billing';
+      return;
+    }
+    if (!res.ok) {
+      btn.disabled = false;
+      btn.textContent = 'Set up billing';
+      billingAnnounce('Could not start billing setup (HTTP ' + res.status + '). Please try again.');
+      return;
+    }
+    return res.json().then(function(data) {
+      var url = data && data.url;
+      if (typeof url !== 'string' ||
+          !(url.startsWith('https://billing.stripe.com/') || url.startsWith('https://checkout.stripe.com/'))) {
+        btn.disabled = false;
+        btn.textContent = 'Set up billing';
+        billingAnnounce('Invalid redirect URL received. Please try again.');
+        return;
+      }
+      window.location.href = url;
+    });
+  }).catch(function() {
+    btn.disabled = false;
+    btn.textContent = 'Set up billing';
+    billingAnnounce('Connection failed. Check your network and try again.');
+  });
+}
+
+function handlePortalRedirect(btn) {
+  var originalText = btn.textContent;
+  btn.disabled = true;
+  btn.textContent = 'Redirecting...';
+
+  var returnUrl = window.location.origin + '/ui#/billing';
+
+  apiFetch('/v1/billing/portal', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ returnUrl: returnUrl }),
+  }).then(function(res) {
+    if (!res) {
+      btn.disabled = false;
+      btn.textContent = originalText;
+      return;
+    }
+    if (!res.ok) {
+      btn.disabled = false;
+      btn.textContent = originalText;
+      billingAnnounce('Could not open billing portal (HTTP ' + res.status + '). Please try again.');
+      return;
+    }
+    return res.json().then(function(data) {
+      var url = data && data.url;
+      if (typeof url !== 'string' ||
+          !(url.startsWith('https://billing.stripe.com/') || url.startsWith('https://checkout.stripe.com/'))) {
+        btn.disabled = false;
+        btn.textContent = originalText;
+        billingAnnounce('Invalid redirect URL received. Please try again.');
+        return;
+      }
+      window.location.href = url;
+    });
+  }).catch(function() {
+    btn.disabled = false;
+    btn.textContent = originalText;
+    billingAnnounce('Connection failed. Check your network and try again.');
+  });
+}
+`;

--- a/src/ui/ui-css.js
+++ b/src/ui/ui-css.js
@@ -1357,4 +1357,94 @@ input, select, textarea {
     padding: var(--space-4) var(--space-4);
   }
 }
+
+/* ---------------------------------------------------------------------------
+   Billing tab
+--------------------------------------------------------------------------- */
+
+.billing-stats-row {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--space-4);
+  margin-bottom: var(--space-4);
+}
+.billing-stat {
+  text-align: center;
+}
+.billing-stat-value {
+  font-size: var(--text-xl);
+  font-weight: var(--weight-bold);
+  color: var(--color-text);
+}
+.billing-stat-label {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  margin-top: var(--space-1);
+}
+
+.billing-tier-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--text-sm);
+}
+.billing-tier-table th {
+  text-align: left;
+  font-weight: var(--weight-medium);
+  padding: var(--space-1) var(--space-2);
+  border-bottom: 1px solid var(--color-border);
+  color: var(--color-text-muted);
+}
+.billing-tier-table td {
+  padding: var(--space-1) var(--space-2);
+}
+.billing-tier-active {
+  background: var(--color-info-bg);
+}
+
+.billing-status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  font-size: var(--text-sm);
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-sm);
+}
+.billing-status-badge--active {
+  background: var(--color-success-bg);
+  color: var(--color-success-text);
+}
+.billing-status-badge--none {
+  background: var(--color-info-bg);
+  color: var(--color-info-text);
+}
+
+/* Billing: mobile layout */
+@media (max-width: 640px) {
+  .billing-stats-row {
+    grid-template-columns: 1fr;
+    gap: var(--space-2);
+  }
+  .billing-stat {
+    text-align: left;
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+  }
+  .billing-tier-table thead { display: none; }
+  .billing-tier-table tr {
+    display: block;
+    padding: var(--space-2) 0;
+    border-bottom: 1px solid var(--color-border);
+  }
+  .billing-tier-table td {
+    display: block;
+    padding: var(--space-1) 0;
+  }
+  .billing-tier-table td::before {
+    content: attr(data-label);
+    font-weight: var(--weight-medium);
+    color: var(--color-text-muted);
+    margin-right: var(--space-2);
+  }
+}
 `;

--- a/src/ui/ui-shell.js
+++ b/src/ui/ui-shell.js
@@ -7,6 +7,7 @@ import { WELCOME_JS } from './ui-welcome.js';
 import { TOS_JS } from './ui-tos.js';
 import { SETTINGS_JS } from './ui-settings.js';
 import { SCHEDULES_JS } from './ui-schedules.js';
+import { BILLING_JS } from './ui-billing.js';
 import { SUBMIT_VIEW_JS } from './ui-submit.js';
 import { DETAIL_VIEW_JS } from './ui-detail.js';
 import { POLL_JS } from './ui-poll.js';
@@ -51,6 +52,9 @@ ${TOS_JS}
 
 // === SETTINGS ===
 ${SETTINGS_JS}
+
+// === BILLING ===
+${BILLING_JS}
 
 // === SCHEDULES ===
 ${SCHEDULES_JS}
@@ -107,6 +111,17 @@ function route() {
       updateNavCurrent('/settings');
       renderSettings();
       mountSettings();
+    } else {
+      location.replace('#/captures');
+    }
+    return;
+  }
+
+  if (path === '/billing') {
+    if (_authMethod === 'session') {
+      updateNavCurrent('/billing');
+      renderBilling();
+      mountBilling();
     } else {
       location.replace('#/captures');
     }

--- a/test/ui-billing.test.js
+++ b/test/ui-billing.test.js
@@ -1,0 +1,234 @@
+// tva
+// Unit tests for ui-billing.js.
+// Tests operate on the exported BILLING_JS string constant and on extracted
+// pure-logic helpers (formatCurrency, billingStatusLabel, shouldShowCheckout,
+// thresholdPercent, thresholdClass) evaluated via the Function constructor.
+// No DOM environment, no fetch, no document -- all assertions target string
+// content or the return values of extracted helper logic.
+
+import { describe, it, expect } from 'vitest';
+import { BILLING_JS } from '../src/ui/ui-billing.js';
+import { UI_CSS } from '../src/ui/ui-css.js';
+import { SETTINGS_JS } from '../src/ui/ui-settings.js';
+
+// ---------------------------------------------------------------------------
+// evalFromSource -- extract and return a named function from a JS source string
+// ---------------------------------------------------------------------------
+
+function evalFromSource(source, functionName) {
+  // eslint-disable-next-line no-new-func
+  const fn = new Function(source + '\nreturn ' + functionName + ';');
+  return fn();
+}
+
+const formatCurrency    = evalFromSource(BILLING_JS, 'formatCurrency');
+const billingStatusLabel  = evalFromSource(BILLING_JS, 'billingStatusLabel');
+const shouldShowCheckout  = evalFromSource(BILLING_JS, 'shouldShowCheckout');
+const thresholdPercent  = evalFromSource(BILLING_JS, 'thresholdPercent');
+const thresholdClass    = evalFromSource(BILLING_JS, 'thresholdClass');
+
+// ---------------------------------------------------------------------------
+// Partition A -- billingStatusLabel display variants
+// ---------------------------------------------------------------------------
+
+describe('billingStatusLabel -- status display variants', () => {
+  it('A1: "free" returns a non-empty human label', () => {
+    const result = billingStatusLabel('free');
+    expect(result).toBeTruthy();
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  it('A2: "active" returns a distinct label from "free"', () => {
+    expect(billingStatusLabel('active')).not.toBe(billingStatusLabel('free'));
+  });
+
+  it('A3: "grace_period" returns a label containing "grace" or "Grace"', () => {
+    const result = billingStatusLabel('grace_period');
+    expect(result.toLowerCase()).toContain('grace');
+  });
+
+  it('A4: "blocked" returns a label containing "blocked" or "Blocked"', () => {
+    const result = billingStatusLabel('blocked');
+    expect(result.toLowerCase()).toContain('blocked');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Partition B -- shouldShowCheckout CTA logic
+// ---------------------------------------------------------------------------
+
+describe('shouldShowCheckout -- payment method CTA routing', () => {
+  it('B1: no payment method + free status returns true (needs checkout)', () => {
+    expect(shouldShowCheckout(false, 'free')).toBe(true);
+  });
+
+  it('B2: has payment method + active status returns false (use portal)', () => {
+    expect(shouldShowCheckout(true, 'active')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Partition C -- eIDAS section visibility (string assertions)
+// ---------------------------------------------------------------------------
+
+describe('BILLING_JS -- eIDAS section visibility', () => {
+  it('C1: source contains qualifiedTimestamps conditional rendering check', () => {
+    expect(BILLING_JS).toContain('qualifiedTimestamps');
+  });
+
+  it('C2: source handles missing eIDAS data gracefully (billing.eidas guard)', () => {
+    expect(BILLING_JS).toContain('billing.eidas');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Partition D -- formatCurrency pure helper
+// ---------------------------------------------------------------------------
+
+describe('formatCurrency -- currency formatting', () => {
+  it('D1: formatCurrency(0) returns string containing "0.00"', () => {
+    expect(formatCurrency(0)).toContain('0.00');
+  });
+
+  it('D2: formatCurrency(11.15) returns string containing "11.15"', () => {
+    expect(formatCurrency(11.15)).toContain('11.15');
+  });
+
+  it('D3: formatCurrency(null) returns string containing "0.00" (defensive)', () => {
+    expect(formatCurrency(null)).toContain('0.00');
+  });
+
+  it('D4: formatCurrency(1234.5) returns string containing "1234.50" or "1,234.50"', () => {
+    const result = formatCurrency(1234.5);
+    expect(result).toMatch(/1[,.]?234\.50/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Partition D -- thresholdPercent pure helper
+// ---------------------------------------------------------------------------
+
+describe('thresholdPercent -- threshold bar percentage', () => {
+  it('D5: thresholdPercent(0, 5) returns 0', () => {
+    expect(thresholdPercent(0, 5)).toBe(0);
+  });
+
+  it('D6: thresholdPercent(2.5, 5) returns 50', () => {
+    expect(thresholdPercent(2.5, 5)).toBe(50);
+  });
+
+  it('D7: thresholdPercent(5, 5) returns 100', () => {
+    expect(thresholdPercent(5, 5)).toBe(100);
+  });
+
+  it('D8: thresholdPercent(7, 5) returns 100 (capped at maximum)', () => {
+    expect(thresholdPercent(7, 5)).toBe(100);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Partition D -- thresholdClass pure helper
+// ---------------------------------------------------------------------------
+
+describe('thresholdClass -- threshold bar CSS class', () => {
+  it('D9: thresholdClass(50) returns empty string (no warning)', () => {
+    expect(thresholdClass(50)).toBe('');
+  });
+
+  it('D10: thresholdClass(85) returns string containing "warning"', () => {
+    expect(thresholdClass(85)).toContain('warning');
+  });
+
+  it('D11: thresholdClass(96) returns string containing "critical"', () => {
+    expect(thresholdClass(96)).toContain('critical');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Partition E -- BILLING_JS structural smoke checks
+// ---------------------------------------------------------------------------
+
+describe('BILLING_JS -- structural function presence', () => {
+  it('E1: contains function renderBilling', () => {
+    expect(BILLING_JS).toContain('function renderBilling');
+  });
+
+  it('E2: contains function mountBilling', () => {
+    expect(BILLING_JS).toContain('function mountBilling');
+  });
+
+  it('E3: contains function buildBillingContent', () => {
+    expect(BILLING_JS).toContain('function buildBillingContent');
+  });
+
+  it('E4: contains function formatCurrency', () => {
+    expect(BILLING_JS).toContain('function formatCurrency');
+  });
+
+  it('E5: contains function billingStatusLabel', () => {
+    expect(BILLING_JS).toContain('function billingStatusLabel');
+  });
+
+  it('E6: fetches /v1/account/usage endpoint', () => {
+    expect(BILLING_JS).toContain('/v1/account/usage');
+  });
+
+  it('E7: references billing-stats-row CSS class', () => {
+    expect(BILLING_JS).toContain('billing-stats-row');
+  });
+
+  it('E8: sets role="progressbar" on the threshold bar', () => {
+    expect(BILLING_JS).toContain('progressbar');
+    expect(BILLING_JS).toContain('role');
+  });
+
+  it('E9: sets aria-valuetext on the threshold bar', () => {
+    expect(BILLING_JS).toContain('aria-valuetext');
+  });
+
+  it('E10: sets aria-describedby on Stripe portal and checkout links', () => {
+    expect(BILLING_JS).toContain('aria-describedby');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Partition F -- Security: no innerHTML assignments
+// ---------------------------------------------------------------------------
+
+describe('BILLING_JS -- security: no innerHTML assignments', () => {
+  it('F1: source contains no innerHTML assignments at all', () => {
+    expect(BILLING_JS).not.toContain('innerHTML');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Partition G -- UI_CSS billing class presence
+// ---------------------------------------------------------------------------
+
+describe('UI_CSS -- billing section styles', () => {
+  it('G1: contains .billing-stats-row class', () => {
+    expect(UI_CSS).toContain('.billing-stats-row');
+  });
+
+  it('G2: contains .billing-stat-value class', () => {
+    expect(UI_CSS).toContain('.billing-stat-value');
+  });
+
+  it('G3: contains .billing-tier-table class', () => {
+    expect(UI_CSS).toContain('.billing-tier-table');
+  });
+
+  it('G4: contains .billing-tier-active class', () => {
+    expect(UI_CSS).toContain('.billing-tier-active');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Partition H -- Separation guard: billing logic must not leak into settings
+// ---------------------------------------------------------------------------
+
+describe('SETTINGS_JS -- separation guard', () => {
+  it('H1: SETTINGS_JS does not contain billingStatusLabel (billing logic stays in billing module)', () => {
+    expect(SETTINGS_JS).not.toContain('billingStatusLabel');
+  });
+});


### PR DESCRIPTION
## Summary

Add a "Billing" tab to the WRL web UI at `#/billing` showing current period charges, pricing tiers, invoice threshold progress, payment method status, Stripe Customer Portal link, and eIDAS add-on usage.

- **New module**: `src/ui/ui-billing.js` (930 lines) — BILLING_JS string constant with render/mount pattern matching existing ui-settings.js and ui-schedules.js
- **CSS**: Stats row grid, tier table, status badges, responsive at 640px
- **Routing**: `#/billing` route in hash router, nav link between Schedules and Settings
- **Tests**: 35 tests across 8 partitions (status labels, CTA logic, helpers, structural smoke, security, CSS, separation)

### Key features
- Four billing states with distinct UI: free, active, grace_period, blocked
- Invoice threshold progressbar with ARIA valuetext (prevents raw cents announcement)
- Collapsed pricing tier table with active tier highlight
- Stripe URL prefix validation before redirect (security hardening)
- Defensive eIDAS section (graceful fallback when API data absent)
- Zero innerHTML — all dynamic content via textContent and DOM construction

### Verification
- Code review: 2 findings auto-fixed (DOM leak in eIDAS portal link, dead CSS class on tier table)
- Tests: 1215 passed, 0 failed (full suite)

Resolves #170

## Test plan

- [ ] Navigate to `#/billing` — billing tab renders with current period data
- [ ] Free-tier account: shows minimal billing info, "Set up billing" CTA
- [ ] Paid account: shows charges, tier, threshold progress, "Manage billing" CTA
- [ ] Grace period: warning banner with date, portal button
- [ ] Blocked: error banner, portal button with urgent styling
- [ ] Click "Manage billing" — redirects to Stripe portal, returns to `#/billing`
- [ ] Mobile viewport (420px): stats stack, tier table adapts, nav stacks cleanly
- [ ] Screen reader: threshold bar announces "EUR X.XX of EUR 5.00"
- [ ] `npx vitest run` — all 1215 tests pass
