### PR TITLE
fix(ui): auto-prepend https://, correct eIDAS text, fix billing spacing

### DIFF
--- a/docs/evolution/0078-ui-fixes-batch/decisions.md
+++ b/docs/evolution/0078-ui-fixes-batch/decisions.md
@@ -1,0 +1,24 @@
+# Decisions — 0078 UI Fixes Batch
+
+## D1: Inline safeUrl() modification vs. separate normalizeUrl()
+
+**Chosen**: Modify safeUrl() inline to include the https:// prepend logic.
+**Rejected**: Adding a separate normalizeUrl() called before safeUrl() in handleSubmit().
+**Rationale**: safeUrl() is a 7-line function with a single caller. Two coordinated functions would be more code with no additional clarity. The normalization is logically part of "parse this string as a safe URL."
+
+## D2: display: block on child spans vs. flexbox on parent
+
+**Chosen**: Add `display: block` to `.billing-stat-value` and `.billing-stat-label` spans.
+**Rejected**: Adding `display: flex; flex-direction: column; align-items: center` to `.billing-stat` parent.
+**Rationale**: The spans already have the right styling (font-size, margin-top) — they just need to be blocks for those styles to work. Flexbox on the parent changes more properties than needed for two stacked elements.
+
+## D3: Drop urlInput.value visual feedback
+
+**Chosen**: Do not set `urlInput.value = safe` after normalization.
+**Rejected**: Updating the input field to show the normalized URL before submission.
+**Rationale**: ux-strategy-minion advisory — the field clears in the same async cycle as the submit response, making the update invisible. A false affordance is worse than no affordance. The success state (capture appearing in the list) is sufficient signal.
+
+## D4: :// guard for prepend behavior
+
+**Chosen**: Only prepend `https://` when input does NOT contain `://`.
+**Rationale**: Prevents mangling inputs like `htt://example.com` where the user intended a scheme but got it wrong. If `://` is present, the user already expressed intent about the scheme — we should not silently rewrite it.

--- a/docs/evolution/0078-ui-fixes-batch/outcome.md
+++ b/docs/evolution/0078-ui-fixes-batch/outcome.md
@@ -1,0 +1,38 @@
+# Outcome — 0078 UI Fixes Batch
+
+## What was built
+
+Three small UI fixes shipped together:
+
+1. **URL auto-prepend** (#179): `safeUrl()` in `src/ui/ui-submit.js` now tries prepending `https://` when the URL constructor throws and the input contains no `://`. Error message updated to reflect that bare hostnames are accepted.
+
+2. **Verify page text** (#180): "eIDAS Art. 41" → "eIDAS Article 41" in `src/verify-page.js` line 344.
+
+3. **Billing page spacing** (#183): Added `display: block` to `.billing-stat-value` and `.billing-stat-label` in `src/ui/ui-css.js`, enabling the existing `margin-top` to create visible spacing between number and label.
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `src/ui/ui-submit.js` | safeUrl() expanded with https:// prepend fallback; error message updated |
+| `src/verify-page.js` | "Art. 41" → "Article 41" |
+| `src/ui/ui-css.js` | display: block on billing stat value and label spans |
+| `test/ui-submit.test.js` | New file, 11 test cases for safeUrl() URL normalization |
+| `test/verify-page.test.js` | Regression assertion: no "Art." in verify page HTML |
+| `test/ui-billing.test.js` | Regression assertions: display: block on billing stat spans |
+
+## Test results
+
+- 1444 tests pass (56 files), 2 skipped (pre-existing)
+- 14 new tests added (11 safeUrl, 1 verify page, 2 billing CSS)
+- No regressions
+
+## Surprises
+
+- `example.com:8080` (bare hostname with port) returns null from safeUrl() because the URL constructor parses `example.com:` as a scheme without throwing, so the prepend path is never reached. Documented as a known edge case in the test suite (A11). Not worth fixing — users who know about ports will include the scheme.
+
+- The `://` guard also means protocol-relative URLs (`//example.com`) get prepended to `https://example.com/` — a reasonable and documented behavior.
+
+## Backlog changes
+
+No backlog changes. All three issues (#179, #180, #183) resolved. No new items deferred.

--- a/docs/evolution/0078-ui-fixes-batch/process.md
+++ b/docs/evolution/0078-ui-fixes-batch/process.md
@@ -1,0 +1,74 @@
+# Process — 0078 UI Fixes Batch
+
+## TL;DR
+
+Three small UI fixes (#179 URL auto-prepend, #180 verify page text, #183 billing spacing) planned by 1 specialist, reviewed by 5 mandatory reviewers, executed by frontend-minion in 2 tasks. All 1444 tests pass with 14 new. Code review APPROVE. Total orchestration: ~15 minutes wall clock.
+
+## Planning Phase
+
+### Team Selection (Phase 1)
+
+Nefario selected only **frontend-minion** for planning consultation — the minimum viable team for three localized UI fixes. The meta-plan explicitly excluded security-minion (client-side prepend is UX sugar, server SSRF boundary untouched), accessibility-minion (no interaction pattern changes), and software-docs-minion (bug fixes with no API surface changes). Lucy approved this team without adjustment.
+
+### Specialist Contribution (Phase 2)
+
+frontend-minion read all five files involved (`ui-submit.js`, `url-validation.js`, `verify-page.js`, `ui-css.js`, `format.js`) before recommending:
+
+- **URL prepend**: Modify `safeUrl()` inline rather than adding a separate `normalizeUrl()`. The `!urlStr.includes('://')` guard prevents mangling partial schemes. Visual feedback via `urlInput.value = safe` was proposed.
+- **Verify text**: Single string replacement, confirmed no "Art." in CLI formatter.
+- **Billing CSS**: Root cause identified as `<span>` elements being inline by default, making `margin-top` ineffective. `display: block` on both spans is the minimal fix.
+
+### Synthesis (Phase 3)
+
+Nefario consolidated into 2 tasks with 0 gates — appropriate for low-risk, well-specified fixes with no competing approaches requiring user judgment.
+
+## Architecture Review (Phase 3.5)
+
+5 mandatory reviewers ran in parallel:
+
+- **security-minion**: APPROVE. Verified `javascript:alert(1)` returns null, `urlInput.value = safe` writes to `.value` not `.innerHTML`, server SSRF boundary untouched.
+- **test-minion**: ADVISE with 3 concerns — protocol-relative `//example.com` untested, `example.com:8080` edge case undocumented, Fix 2/3 lack automated regression assertions. All incorporated.
+- **ux-strategy-minion**: ADVISE — drop `urlInput.value = safe` because the field clears too fast for the update to be visible. Incorporated.
+- **lucy**: APPROVE. Every success criterion traced to a plan element.
+- **margo**: APPROVE. "Each fix is the minimal change that solves the stated problem."
+
+### Where Reviewers Disagreed
+
+No disagreements. The only substantive change from review was ux-strategy-minion's advisory to drop the visual feedback line, which was accepted without contention.
+
+## Execution (Phase 4)
+
+Two tasks ran sequentially (Task 2 blocked by Task 1):
+
+**Task 1**: frontend-minion applied all three code fixes in a single pass. The `safeUrl()` expansion went from 7 to 12 lines. The `://` guard and try/catch structure matched the planning recommendation exactly.
+
+**Task 2**: frontend-minion created `test/ui-submit.test.js` with 11 test cases (9 planned + 2 from test-minion advisory: `//example.com` and `example.com:8080`). Also added regression assertions in `test/verify-page.test.js` and `test/ui-billing.test.js`.
+
+### Interesting Edge Case Discovered
+
+`example.com:8080` (bare hostname with port) returns null from `safeUrl()`. The URL constructor parses `example.com:` as a scheme (without throwing), so it hits the protocol check and gets rejected. Since it doesn't contain `://`, the prepend path should fire — but it doesn't because the first parse succeeded. This was documented as test case A11 with a comment explaining the behavior. The team decided this is acceptable: users who know about ports will include the scheme.
+
+## Post-Execution Verification (Phases 5-8)
+
+- **Code review**: APPROVE with 3 NITs (billing test assertions could be tighter, safeUrl comment could be more descriptive, `example.com:8080` gap could be closed or made explicit). All non-blocking.
+- **Tests**: 1444 pass, 2 skipped (pre-existing), 0 failures.
+- **Documentation**: 0 MUST items. Release notes (SHOULD) and stale doc scan (COULD) noted but not blocking.
+
+## Human Interventions
+
+None — autonomous mode. Lucy served as the gate decision-maker throughout:
+- Team approval: APPROVE (1 specialist is proportional)
+- Execution plan approval: APPROVE (all success criteria traced)
+
+## What Was Deliberately Left Alone
+
+- **`safeUrl()` in `ui-detail.js` and `verify-page.js`**: These are display validators for server-provided URLs. Changing them would mask API bugs.
+- **Server-side URL normalization**: Out of scope per the issue. The server's `validateUrl()` remains the real security boundary.
+- **`example.com:8080` edge case fix**: Documented but not fixed. The cost of a fix (more complex scheme detection) outweighs the benefit (rare user pattern).
+- **Code review NITs**: Accepted as non-blocking. The billing test assertions work correctly; they could be more specific but aren't wrong.
+
+## Where to Read More
+
+- Specialist planning: `docs/history/nefario-reports/2026-03-24-203932-ui-fixes-url-prepend-verify-text-billing-spacing/phase2-frontend-minion.md`
+- Full execution plan: `docs/history/nefario-reports/2026-03-24-203932-ui-fixes-url-prepend-verify-text-billing-spacing/phase3-synthesis.md`
+- Review verdicts: `docs/history/nefario-reports/2026-03-24-203932-ui-fixes-url-prepend-verify-text-billing-spacing/phase3.5-*.md`

--- a/docs/evolution/0078-ui-fixes-batch/prompt.md
+++ b/docs/evolution/0078-ui-fixes-batch/prompt.md
@@ -1,0 +1,29 @@
+Batch of three small UI fixes shipped as a single phase.
+
+## Fix 1 — Auto-prepend https:// (#179)
+
+The captures UI URL input field automatically prepends `https://` when a user enters a bare hostname (e.g., `example.com` → `https://example.com`). Entries that already have `http://` or `https://` are left unchanged. Partial schemes like `htt://` are not "fixed".
+
+## Fix 2 — Verify page German text (#180)
+
+All eIDAS references on the verify page use "Article" instead of the German abbreviation "Art." (e.g., "Article 42" not "Art. 42"). Check both the verify page HTML template (`src/verify-page.js`) and the `@w-r-l/verify` CLI formatter (`packages/verify/lib/format.js`).
+
+## Fix 3 — Billing page spacing (#183)
+
+Add visible spacing between numeric count values and their unit labels on the billing page (e.g., "14 Captures" not "14Captures"). CSS or template fix.
+
+## Success criteria
+
+- Entering `example.com` in capture URL field submits `https://example.com`
+- Entering `https://example.com` or `http://example.com` is unchanged
+- All "Art." references on verify page replaced with "Article"
+- Billing page shows space between numbers and units
+- No regressions on other pages
+- Existing tests pass; add/update tests for URL prepend logic
+
+## Scope
+
+- **In**: UI URL input normalization, verify page text, billing page CSS
+- **Out**: API-level URL normalization, i18n infrastructure, billing logic changes
+
+Closes #179, closes #180, closes #183

--- a/docs/evolution/README.md
+++ b/docs/evolution/README.md
@@ -80,3 +80,4 @@ software development.
 | [0073-fre-902-13-certificate](0073-fre-902-13-certificate/) | FRE 902(13) certification PDF: deterministic Ed25519-signed document, API endpoint, web UI download button, 42 tests (Issue #141) |
 | [0077-settings-schedules-ui-polish](0077-settings-schedules-ui-polish/) | Settings & schedules UI polish: 18+ missing CSS selectors, card padding, mobile breakpoints, billing DOM cleanup (Issue #161) |
 | [0072-email-notifications](0072-email-notifications/) | Email notifications: 6 transactional types, Resend delivery via queue, RFC 8058 unsubscribe, preferences API + UI, OAuth email auto-population (Issue #111) |
+| [0078-ui-fixes-batch](0078-ui-fixes-batch/) | UI fixes batch: URL auto-prepend in capture form, "Art." → "Article" on verify page, billing stat spacing (Issues #179, #180, #183) |

--- a/docs/history/nefario-reports/2026-03-24-203932-ui-fixes-url-prepend-verify-text-billing-spacing.md
+++ b/docs/history/nefario-reports/2026-03-24-203932-ui-fixes-url-prepend-verify-text-billing-spacing.md
@@ -1,0 +1,100 @@
+---
+task: "UI fixes batch — URL prepend, verify page text, billing spacing"
+date: 2026-03-24
+source-issue: 185
+status: complete
+task-count: 2
+gate-count: 0
+agents: [frontend-minion]
+reviewers: [security-minion, test-minion, ux-strategy-minion, lucy, margo, code-review-minion]
+mode: execution
+---
+
+## Summary
+
+Three small UI bug fixes shipped as a single phase: (1) `safeUrl()` in the capture form now auto-prepends `https://` to bare hostnames, guarded by a `://` check to avoid mangling partial schemes; (2) "Art. 41" corrected to "Article 41" on the verify page; (3) `display: block` added to billing stat spans so the existing `margin-top` creates visible spacing. 1444 tests pass (14 new). Code review APPROVE with 3 NITs. No regressions.
+
+## Original Prompt
+
+Batch of three small UI fixes shipped as a single phase.
+
+Fix 1 — Auto-prepend https:// (#179): The captures UI URL input field automatically prepends `https://` when a user enters a bare hostname (e.g., `example.com` → `https://example.com`). Entries that already have `http://` or `https://` are left unchanged. Partial schemes like `htt://` are not "fixed".
+
+Fix 2 — Verify page German text (#180): All eIDAS references on the verify page use "Article" instead of the German abbreviation "Art." (e.g., "Article 42" not "Art. 42").
+
+Fix 3 — Billing page spacing (#183): Add visible spacing between numeric count values and their unit labels on the billing page (e.g., "14 Captures" not "14Captures"). CSS or template fix.
+
+Closes #179, closes #180, closes #183
+
+## Key Design Decisions
+
+### D1: Inline safeUrl() modification vs. separate normalizeUrl()
+Modify safeUrl() inline. A 7-line function with a single caller doesn't warrant extraction into a separate normalizer.
+
+### D2: display: block vs. flexbox
+Add `display: block` to the two child spans. Flexbox on the parent changes more properties than needed for two stacked elements.
+
+### D3: Drop urlInput.value visual feedback
+Per ux-strategy-minion: the field clears in the same async cycle, making the update invisible. A false affordance is worse than no affordance.
+
+### D4: :// guard for prepend
+Only prepend when input does NOT contain `://`. Prevents mangling partial schemes where the user intended a scheme but got it wrong.
+
+## Phases
+
+### Phase 1-2: Planning
+1 specialist consulted: frontend-minion (URL normalization approach, CSS fix strategy, verify page scope).
+
+### Phase 3: Synthesis
+2 execution tasks, 0 approval gates. All three code changes in one task, tests in a second blocked task.
+
+### Phase 3.5: Architecture Review
+5 mandatory reviewers. 3 APPROVE (security-minion, lucy, margo), 2 ADVISE (ux-strategy-minion, test-minion). Key advisories: drop urlInput.value feedback (ux-strategy), add protocol-relative and port edge case tests (test-minion), add regression assertions for Fix 2/3 (test-minion).
+
+### Phase 4: Execution
+2 tasks in 1 sequential batch. Task 1: all three code fixes. Task 2: 11 safeUrl tests + 3 regression assertions. All completed successfully.
+
+### Phase 5: Code Review
+APPROVE with 3 NITs (billing test specificity, safeUrl comment clarity, example.com:8080 edge case documentation). No blocking findings.
+
+### Phase 6: Tests
+1444 pass, 2 skipped, 0 failures. 14 new tests (11 safeUrl, 1 verify page, 2 billing CSS).
+
+### Phase 7: Deployment
+Skipped (not requested).
+
+### Phase 8: Documentation
+8a assessment: 0 MUST items. 2 items total (SHOULD: release notes, COULD: scan for stale URL validation docs). No documentation debt requiring immediate action.
+
+## Agent Contributions
+
+| Agent | Phase | Role |
+|-------|-------|------|
+| frontend-minion | planning, execution | URL normalization design, CSS fix, all code changes, tests |
+| security-minion | review | Verified no XSS/SSRF/injection from URL prepend |
+| test-minion | review | Protocol-relative URL edge case, port edge case, regression assertions |
+| ux-strategy-minion | review | Flagged invisible urlInput.value feedback |
+| lucy | review | Convention adherence, scope validation |
+| margo | review | Simplicity validation, YAGNI compliance |
+| code-review-minion | review | Code quality, test specificity NITs |
+
+## Verification
+
+Code review: APPROVE (3 NITs, non-blocking). Tests: 1444 passed, 2 skipped, 0 failures. No regressions.
+
+## Working Files
+
+Companion directory: `docs/history/nefario-reports/2026-03-24-203932-ui-fixes-url-prepend-verify-text-billing-spacing/`
+
+Files: prompt.md, phase1-metaplan-prompt.md, phase1-metaplan.md, phase2-frontend-minion-prompt.md, phase2-frontend-minion.md, phase3-synthesis-prompt.md, phase3-synthesis.md, phase3.5-security-minion.md, phase3.5-test-minion.md, phase3.5-ux-strategy-minion.md, phase3.5-lucy.md, phase3.5-margo.md, phase4-frontend-minion-task1-prompt.md, phase4-frontend-minion-task2-prompt.md, phase8-checklist.md
+
+## Session Resources
+
+<details>
+<summary>Skills Invoked</summary>
+
+- /nefario — orchestration
+
+</details>
+
+Compaction events: 0

--- a/docs/history/nefario-reports/2026-03-24-203932-ui-fixes-url-prepend-verify-text-billing-spacing/phase1-metaplan-prompt.md
+++ b/docs/history/nefario-reports/2026-03-24-203932-ui-fixes-url-prepend-verify-text-billing-spacing/phase1-metaplan-prompt.md
@@ -1,0 +1,62 @@
+MODE: META-PLAN
+
+You are creating a meta-plan — a plan for who should help plan.
+
+## Task
+<github-issue>
+Batch of three small UI fixes shipped as a single phase.
+
+## Fix 1 — Auto-prepend https:// (#179)
+
+The captures UI URL input field automatically prepends `https://` when a user enters a bare hostname (e.g., `example.com` → `https://example.com`). Entries that already have `http://` or `https://` are left unchanged. Partial schemes like `htt://` are not "fixed".
+
+## Fix 2 — Verify page German text (#180)
+
+All eIDAS references on the verify page use "Article" instead of the German abbreviation "Art." (e.g., "Article 42" not "Art. 42"). Check both the verify page HTML template (`src/verify-page.js`) and the `@w-r-l/verify` CLI formatter (`packages/verify/lib/format.js`).
+
+## Fix 3 — Billing page spacing (#183)
+
+Add visible spacing between numeric count values and their unit labels on the billing page (e.g., "14 Captures" not "14Captures"). CSS or template fix.
+
+## Success criteria
+
+- Entering `example.com` in capture URL field submits `https://example.com`
+- Entering `https://example.com` or `http://example.com` is unchanged
+- All "Art." references on verify page replaced with "Article"
+- Billing page shows space between numbers and units
+- No regressions on other pages
+- Existing tests pass; add/update tests for URL prepend logic
+
+## Scope
+
+- **In**: UI URL input normalization, verify page text, billing page CSS
+- **Out**: API-level URL normalization, i18n infrastructure, billing logic changes
+
+Closes #179, closes #180, closes #183
+</github-issue>
+
+## Working Directory
+/Users/ben/github/benpeter/web-resource-ledger/.claude/worktrees/iridescent-purring-lagoon
+
+## External Skill Discovery
+Before analyzing the task, scan for project-local skills. If skills are
+discovered, include an "External Skill Integration" section in your meta-plan
+(see your Core Knowledge for the output format).
+
+## Instructions
+1. Read relevant files to understand the codebase context
+2. Discover external skills:
+   a. Scan .claude/skills/ and .skills/ in the working directory for SKILL.md files
+   b. Read frontmatter (name, description) for each discovered skill
+   c. For skills whose description matches the task domain, classify as
+      ORCHESTRATION or LEAF (see External Skill Integration in your Core Knowledge)
+   d. Check the project's CLAUDE.md for explicit skill preferences
+   e. Include discovered skills in your meta-plan output
+3. Analyze the task against your delegation table
+4. Identify which specialists should be CONSULTED FOR PLANNING
+   (not execution — planning). These are agents whose domain
+   expertise is needed to create a good plan.
+5. For each specialist, write a specific planning question that
+   draws on their unique expertise.
+6. Return the meta-plan in the structured format.
+7. Write your complete meta-plan to `/var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-Ua2lf1/ui-fixes-url-prepend-verify-text-billing-spacing/phase1-metaplan.md`

--- a/docs/history/nefario-reports/2026-03-24-203932-ui-fixes-url-prepend-verify-text-billing-spacing/phase1-metaplan.md
+++ b/docs/history/nefario-reports/2026-03-24-203932-ui-fixes-url-prepend-verify-text-billing-spacing/phase1-metaplan.md
@@ -1,0 +1,63 @@
+## Meta-Plan
+
+### Task Summary
+
+Three small, independent UI fixes shipped as a single phase (evolution log 0078):
+
+1. **URL auto-prepend** (#179): Add `https://` to bare hostnames in the capture form's `safeUrl()` helper (`src/ui/ui-submit.js`), plus tests.
+2. **Verify page text** (#180): Replace "Art." with "Article" in eIDAS reference on the verify page (`src/verify-page.js` line 344). The CLI formatter (`packages/verify/lib/format.js`) has no "Art." references -- no changes needed there.
+3. **Billing page spacing** (#183): The `.billing-stat` CSS lacks `display: flex; flex-direction: column` on desktop, so the value `<span>` and label `<span>` render inline without spacing. Fix in `src/ui/ui-css.js` around line 1504.
+
+All three fixes are localized, low-risk, and touch different files with no overlap.
+
+### Planning Consultations
+
+#### Consultation 1: URL normalization UX
+
+- **Agent**: frontend-minion
+- **Planning question**: The `safeUrl()` function in `ui-submit.js` currently rejects bare hostnames (no scheme). The fix should auto-prepend `https://` when no scheme is present, but leave `http://` and `https://` URLs untouched, and not "fix" partial schemes like `htt://`. What is the cleanest approach -- modify `safeUrl()` to try prepending before failing, or add a separate `normalizeUrl()` step before `safeUrl()` in `handleSubmit()`? Also: should the input field visually update to show the normalized URL, or should normalization be silent? Consider the existing `url-validation.js` (server-side SSRF boundary) -- the client-side normalization must NOT conflict with server-side validation.
+- **Context to provide**: `src/ui/ui-submit.js` (full file, especially `safeUrl()` at line 10-17 and `handleSubmit()` at line 363-433), `src/url-validation.js` (server-side validation for context on what the API expects).
+- **Why this agent**: Frontend DOM manipulation expertise and understanding of form UX patterns. The fix is simple but the interaction between client normalization and server validation needs careful thought.
+
+### Cross-Cutting Checklist
+
+- **Testing**: INCLUDE test-minion for planning. The issue explicitly requires "add/update tests for URL prepend logic." The existing test pattern (`evalFromSource` in `test/ui-billing.test.js`) should be followed for extracting and testing the `safeUrl()` function. Test-minion should advise on test cases for the URL normalization (bare hostname, with scheme, partial scheme, edge cases).
+- **Security**: EXCLUDE from planning. The URL normalization is client-side convenience only -- the server-side SSRF boundary (`url-validation.js`) is unchanged. No new attack surface is created. The text replacement and CSS fix are inert from a security perspective.
+- **Usability -- Strategy**: INCLUDE (mandatory). Planning question: Are there any user journey coherence concerns with auto-prepending `https://`? Specifically: should the user see the normalized URL before submission (input field updates) or should it be silent? What about the error message ("Enter a valid http:// or https:// URL") -- does it need updating if we now auto-fix bare hostnames?
+- **Usability -- Design**: EXCLUDE from planning. No new UI components, layouts, or interaction patterns. The fixes are corrections to existing behavior (text content, spacing CSS, input normalization).
+- **Documentation**: EXCLUDE from planning. These are small bug fixes. The evolution log (0078) already has `prompt.md`. `decisions.md` and `outcome.md` will be written during/after execution per project rules. No user-facing documentation changes needed.
+- **Observability**: EXCLUDE from planning. No runtime components, APIs, or background processes are being modified. These are pure UI presentation fixes.
+
+### Notable Exclusions
+
+- **security-minion**: Client-side `https://` prepend is UX sugar only; the server-side SSRF boundary (`url-validation.js`) remains the trust boundary and is not modified. No new attack surface.
+- **accessibility-minion**: The billing CSS fix improves readability (spacing between value and label), but this is a straightforward CSS property addition, not a pattern that needs a11y review. The existing `aria-live` regions and semantic structure are unchanged.
+- **software-docs-minion**: Bug fixes with no API surface changes. Evolution log documentation is handled by project rules, not doc-minion planning.
+
+### Anticipated Approval Gates
+
+None. All three fixes are:
+- **Easy to reverse** (additive CSS, text replacement, small function modification)
+- **Low blast radius** (each fix is self-contained, no downstream dependents)
+- **Clear best-practice** (no judgment calls between competing approaches)
+
+This falls squarely in the "NO GATE" quadrant. The only minor judgment call is the URL normalization approach (modify `safeUrl` vs. separate normalizer), which frontend-minion will advise on during planning.
+
+### Rationale
+
+This is a batch of three isolated, low-risk UI fixes. Only one (URL normalization) has any design nuance worth consulting a specialist about. The other two (text replacement, CSS spacing) are mechanical corrections. The planning consultations are deliberately lightweight:
+
+- **frontend-minion** covers the one fix with a design decision (normalization approach).
+- **test-minion** advises on test coverage, which the issue explicitly requires.
+- **ux-strategy-minion** is included per mandatory checklist to validate the URL normalization UX.
+
+The remaining fixes (text replacement, CSS) need no planning input -- they are direct edits with no ambiguity.
+
+### Scope
+
+- **In scope**: Modifying `safeUrl()` or `handleSubmit()` in `src/ui/ui-submit.js` for URL normalization; replacing "Art. 41" with "Article 41" in `src/verify-page.js` line 344; fixing `.billing-stat` CSS in `src/ui/ui-css.js` for proper vertical layout; adding tests for URL normalization.
+- **Out of scope**: Server-side URL normalization (`url-validation.js`, `capture.js`), i18n infrastructure, billing logic changes, privacy page "Art." references (those are correct GDPR citations), `ip-hash.js` comment (internal documentation, not user-facing).
+
+### External Skill Integration
+
+No external skills detected in project.

--- a/docs/history/nefario-reports/2026-03-24-203932-ui-fixes-url-prepend-verify-text-billing-spacing/phase2-frontend-minion-prompt.md
+++ b/docs/history/nefario-reports/2026-03-24-203932-ui-fixes-url-prepend-verify-text-billing-spacing/phase2-frontend-minion-prompt.md
@@ -1,0 +1,47 @@
+You are contributing to the PLANNING phase of a multi-agent project.
+You are NOT executing yet — you are providing your domain expertise
+to help build a comprehensive plan.
+
+## Project Task
+Batch of three small UI fixes shipped as a single phase:
+
+1. **URL auto-prepend** (#179): Add `https://` to bare hostnames in the capture form's `safeUrl()` helper (`src/ui/ui-submit.js`), plus tests.
+2. **Verify page text** (#180): Replace "Art." with "Article" in the eIDAS reference on the verify page (`src/verify-page.js` line 344). The CLI formatter (`packages/verify/lib/format.js`) has no "Art." references -- no change needed there.
+3. **Billing page spacing** (#183): The `.billing-stat` CSS lacks spacing between value and label spans. Fix in `src/ui/ui-css.js` around line 1504.
+
+## Your Planning Question
+The `safeUrl()` function in `ui-submit.js` currently rejects bare hostnames (no scheme). The fix should auto-prepend `https://` when no scheme is present, but leave `http://` and `https://` URLs untouched, and not "fix" partial schemes like `htt://`. What is the cleanest approach -- modify `safeUrl()` to try prepending before failing, or add a separate `normalizeUrl()` step before `safeUrl()` in `handleSubmit()`? Should the input field visually update to show the normalized URL, or should normalization be silent? Consider that the server-side SSRF boundary (`url-validation.js`) expects a full URL with scheme -- client-side normalization must produce valid input for that.
+
+## Context
+Read these files for context:
+- `src/ui/ui-submit.js` (especially `safeUrl()` and `handleSubmit()`)
+- `src/url-validation.js` (server-side expectations)
+- `src/verify-page.js` (line ~344 for "Art." reference)
+- `src/ui/ui-css.js` (line ~1504 for billing stat CSS)
+- `packages/verify/lib/format.js` (confirm no "Art." references)
+
+## Instructions
+1. Read relevant files to understand the current state
+2. Apply your domain expertise to the planning question
+3. Identify risks, dependencies, and requirements from your perspective
+4. If you believe additional specialists should be involved that
+   aren't already part of the planning, say so and explain why
+5. Return your contribution in this format:
+
+## Domain Plan Contribution: frontend-minion
+
+### Recommendations
+Your expert recommendations for this aspect of the task
+
+### Proposed Tasks
+Specific tasks that should be in the execution plan.
+For each task: what to do, deliverables, dependencies
+
+### Risks and Concerns
+Things that could go wrong from your domain perspective
+
+### Additional Agents Needed
+Any specialists not yet involved who should be, and why
+(or "None" if the current team is sufficient)
+
+6. Write your complete contribution to `/var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-Ua2lf1/ui-fixes-url-prepend-verify-text-billing-spacing/phase2-frontend-minion.md`

--- a/docs/history/nefario-reports/2026-03-24-203932-ui-fixes-url-prepend-verify-text-billing-spacing/phase2-frontend-minion.md
+++ b/docs/history/nefario-reports/2026-03-24-203932-ui-fixes-url-prepend-verify-text-billing-spacing/phase2-frontend-minion.md
@@ -1,0 +1,140 @@
+## Domain Plan Contribution: frontend-minion
+
+### Recommendations
+
+#### Fix 1: URL auto-prepend (`safeUrl()` in `ui-submit.js`)
+
+**Modify `safeUrl()` inline rather than adding a separate `normalizeUrl()`.** Rationale:
+
+1. `safeUrl()` is a 7-line function with a single caller in `handleSubmit()`. Adding a separate normalization step before calling it creates two functions that must stay coordinated. The logic is simple enough to inline: try parsing, and if the URL constructor throws, try again with `https://` prepended.
+
+2. A separate `normalizeUrl()` in `handleSubmit()` would mean the error message path (`'Enter a valid http:// or https:// URL.'`) triggers only after normalization already failed -- the message would need updating anyway. Keeping it in one place is cleaner.
+
+**Proposed implementation for `safeUrl()`:**
+
+```js
+function safeUrl(urlStr) {
+  try {
+    var u = new URL(urlStr);
+    if (u.protocol === 'http:' || u.protocol === 'https:') return u.href;
+  } catch (e) {
+    // Bare hostname? Try prepending https://
+    if (urlStr && !urlStr.includes('://')) {
+      try {
+        var u2 = new URL('https://' + urlStr);
+        if (u2.protocol === 'https:') return u2.href;
+      } catch (e2) {
+        // Still invalid -- fall through to return null
+      }
+    }
+  }
+  return null;
+}
+```
+
+**Key design decisions:**
+
+- **Guard with `!urlStr.includes('://')`.** This prevents "fixing" partial schemes like `htt://foo.com` (which would become `https://htt://foo.com` -- nonsensical). If the input already has `://` in it, the user intended a scheme and got it wrong; we should not silently rewrite that. Only truly bare hostnames (like `example.com`, `example.com/page`) get the prepend.
+
+- **The input field should visually update** to show the normalized URL. After `safeUrl()` returns a non-null value, `handleSubmit()` should set `urlInput.value = safe;` before clearing it on success. This provides immediate feedback -- the user sees what was actually submitted. If we normalize silently, the user types `example.com`, the input clears, and they see "Capturing..." on `https://example.com/` in the list. That is acceptable too, but showing the corrected URL briefly in the input before clearing is slightly better UX. However, since the input is cleared immediately on success (line 397), the visual update would be near-instantaneous. **Recommendation: update the input value to the normalized URL before submission, so the user can see what they're submitting.** This is a single line: `urlInput.value = safe;` inserted between the validation check and the `submitBtn.disabled = true` line.
+
+- **Update the error message** from `'Enter a valid http:// or https:// URL.'` to something like `'Enter a valid URL (e.g. example.com or https://example.com).'` to reflect that bare hostnames are now accepted.
+
+- **The `safeUrl()` in `ui-detail.js`** (line ~90) should NOT be changed. That function validates URLs from the server response for rendering links -- those URLs already have schemes. Changing it would mask bad data from the API.
+
+- **The `safeUrl()` in `verify-page.js`** (line ~348) is also a display-only validator and should NOT be changed. It validates URLs embedded in capture metadata.
+
+**Server-side compatibility:** The server's `validateUrl()` in `url-validation.js` expects a full URL with scheme (line 331: the URL constructor would throw on `example.com`). Client-side normalization in `safeUrl()` ensures the POST body always contains `https://example.com/...`, so no server changes are needed.
+
+#### Fix 2: Verify page text (`verify-page.js` line 344)
+
+Single string replacement: `'eIDAS Art. 41'` to `'eIDAS Article 41'`. No other files reference `Art. 41`. The CLI formatter `format.js` uses `'Qualified timestamp'` without any eIDAS reference -- no change needed.
+
+No tests currently assert on this exact string (confirmed via grep), so the change is purely cosmetic with zero test impact.
+
+#### Fix 3: Billing page spacing (`ui-css.js` ~line 1504)
+
+The `.billing-stat` rule (line 1504-1506) only sets `text-align: center`. The value span (`.billing-stat-value`) and label span (`.billing-stat-label`) are stacked as block-level elements but the `.billing-stat` container has no `display` property. Since `<div>` defaults to `display: block`, the children stack vertically by default -- but there is no explicit gap or padding between the value and label.
+
+Looking at `buildStatCell()` in `ui-billing.js` (line 324-338): it creates a `div.billing-stat` containing a `span.billing-stat-value` followed by a `span.billing-stat-label`. Spans are inline by default. The `.billing-stat-label` already has `margin-top: var(--space-1)` but since spans are inline, `margin-top` has no effect on inline elements in standard flow.
+
+**Fix:** The `.billing-stat-value` and `.billing-stat-label` should be `display: block` (or the parent should use flex column). The simplest fix is adding `display: block` to both `.billing-stat-value` and `.billing-stat-label`. This makes the spans render as blocks, allowing the existing `margin-top: var(--space-1)` on `.billing-stat-label` to create visible spacing.
+
+Alternatively, make `.billing-stat` a flex column container, which also gives block formatting to children:
+
+```css
+.billing-stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+}
+```
+
+**Recommendation: use `display: block` on the two child spans.** It is the minimal change and makes the existing `margin-top` work as intended. Adding flexbox to the parent is overkill for two stacked elements.
+
+### Proposed Tasks
+
+#### Task 1: URL auto-prepend in `safeUrl()`
+
+**What to do:**
+1. Modify `safeUrl()` in `src/ui/ui-submit.js` to try prepending `https://` when no `://` is present in input and initial URL parse throws
+2. Add `urlInput.value = safe;` in `handleSubmit()` after validation succeeds (before disabling the button) so the input briefly reflects the normalized URL
+3. Update the error message to `'Enter a valid URL (e.g. example.com or https://example.com).'`
+
+**Deliverables:** Modified `src/ui/ui-submit.js`
+
+**Dependencies:** None
+
+#### Task 2: Tests for URL auto-prepend
+
+**What to do:**
+Add tests for the `safeUrl()` function. The project uses an `evalFromSource()` pattern (seen in `test/ui-billing.test.js`) to extract functions from the JS string constants and test them in isolation. Create `test/ui-submit.test.js` following the same pattern:
+
+- `safeUrl('https://example.com')` returns `'https://example.com/'`
+- `safeUrl('http://example.com')` returns `'http://example.com/'`
+- `safeUrl('example.com')` returns `'https://example.com/'` (auto-prepend)
+- `safeUrl('example.com/page?q=1')` returns `'https://example.com/page?q=1'`
+- `safeUrl('htt://example.com')` returns `null` (has `://`, don't fix)
+- `safeUrl('ftp://example.com')` returns `null` (wrong scheme)
+- `safeUrl('javascript:alert(1)')` returns `null`
+- `safeUrl('')` returns `null`
+- `safeUrl('not a url at all')` returns `null` (even with prepend, `https://not a url at all` is invalid)
+
+**Deliverables:** New `test/ui-submit.test.js`
+
+**Dependencies:** Task 1 (needs the modified `safeUrl`)
+
+#### Task 3: Verify page text fix
+
+**What to do:**
+In `src/verify-page.js` line 344, replace `'eIDAS Art. 41'` with `'eIDAS Article 41'`.
+
+**Deliverables:** Modified `src/verify-page.js` (single line change)
+
+**Dependencies:** None
+
+#### Task 4: Billing stat spacing fix
+
+**What to do:**
+In `src/ui/ui-css.js`, add `display: block;` to both `.billing-stat-value` and `.billing-stat-label` rules. This makes the spans render as blocks, allowing the existing `margin-top: var(--space-1)` on `.billing-stat-label` to create visible spacing.
+
+**Deliverables:** Modified `src/ui/ui-css.js` (two lines added)
+
+**Dependencies:** None
+
+### Risks and Concerns
+
+1. **Auto-prepend could mask user errors.** If a user types `example` intending to type `example.com`, `safeUrl('example')` with prepend would try `https://example` -- which is a valid URL per the WHATWG spec (no TLD required). The server's SSRF validation will catch nonsensical hostnames that don't resolve, but the client will silently submit. This is acceptable: the server is the real validation boundary, and the UX improvement for the common case (bare hostnames) outweighs the edge case. The form error is for obvious syntax issues, not hostname validity.
+
+2. **`safeUrl()` exists in three files with slightly different behavior.** The change MUST be scoped to `ui-submit.js` only. The `safeUrl()` in `ui-detail.js` and `verify-page.js` are display validators for server-provided URLs (which always have schemes). Changing those would hide API bugs. The issue ticket (#179) correctly scopes this to the capture form only.
+
+3. **The billing spacing fix relies on spans defaulting to inline.** Verified: `buildStatCell()` creates `<span>` elements. Adding `display: block` is correct. If someone later changes these to `<div>`, the `display: block` becomes redundant but harmless.
+
+4. **No existing test file for `ui-submit.js` helpers.** A new test file needs to be created, following the `evalFromSource()` pattern from `test/ui-billing.test.js`. The `SUBMIT_VIEW_JS` is a template literal string constant (not a module with imports), so function extraction via the same technique works correctly.
+
+5. **The `handleSubmit` function trims input** (`urlInput.value.trim()` on line 364) before passing to `safeUrl()`. This means leading/trailing whitespace is already handled -- `safeUrl()` does not need to trim.
+
+### Additional Agents Needed
+
+None. All three fixes are straightforward frontend changes within the existing codebase patterns. The test-minion may want to review the `ui-submit.test.js` scope, but the frontend-minion can write these tests directly following the established `evalFromSource()` pattern.

--- a/docs/history/nefario-reports/2026-03-24-203932-ui-fixes-url-prepend-verify-text-billing-spacing/phase3-synthesis-prompt.md
+++ b/docs/history/nefario-reports/2026-03-24-203932-ui-fixes-url-prepend-verify-text-billing-spacing/phase3-synthesis-prompt.md
@@ -1,0 +1,51 @@
+MODE: SYNTHESIS
+
+You are synthesizing specialist planning contributions into a
+final execution plan.
+
+## Original Task
+Batch of three small UI fixes shipped as a single phase:
+
+1. **URL auto-prepend** (#179): Add `https://` to bare hostnames in the capture form's `safeUrl()` helper (`src/ui/ui-submit.js`), plus tests.
+2. **Verify page text** (#180): Replace "Art." with "Article" in the eIDAS reference on the verify page (`src/verify-page.js` line 344). The CLI formatter (`packages/verify/lib/format.js`) has no "Art." references -- no change needed there.
+3. **Billing page spacing** (#183): The `.billing-stat` CSS lacks spacing between value and label spans. Fix in `src/ui/ui-css.js` around line 1504.
+
+Success criteria:
+- Entering `example.com` in capture URL field submits `https://example.com`
+- Entering `https://example.com` or `http://example.com` is unchanged
+- All "Art." references on verify page replaced with "Article"
+- Billing page shows space between numbers and units
+- No regressions on other pages
+- Existing tests pass; add/update tests for URL prepend logic
+
+Scope: UI URL input normalization, verify page text, billing page CSS
+Out: API-level URL normalization, i18n infrastructure, billing logic changes
+
+## Specialist Contributions
+
+Read the following scratch file for the full specialist contribution:
+/var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-Ua2lf1/ui-fixes-url-prepend-verify-text-billing-spacing/phase2-frontend-minion.md
+
+## Key consensus across specialists:
+
+## Summary: frontend-minion
+Phase: planning
+Recommendation: Modify `safeUrl()` inline with `!urlStr.includes('://')` guard; update input value to show normalized URL; add `display: block` to billing stat spans; single string replacement for verify page.
+Tasks: 4 -- Modify safeUrl() in ui-submit.js; Create test/ui-submit.test.js with 9 test cases; Replace "Art. 41" with "Article 41" in verify-page.js; Add display:block to billing stat value/label spans
+Risks: Auto-prepend could mask typos (server catches); safeUrl() exists in 3 files, only modify ui-submit.js; no existing test file for ui-submit.js
+Conflicts: none
+
+## External Skills Context
+No external skills detected.
+
+## Instructions
+1. Review all specialist contributions
+2. Resolve any conflicts between recommendations
+3. Incorporate risks and concerns into the plan
+4. Create the final execution plan in structured format
+5. Ensure every task has a complete, self-contained prompt
+6. If external skills were discovered, include them in the execution plan:
+   - ORCHESTRATION skills: create DEFERRED macro-tasks (see Core Knowledge)
+   - LEAF skills: list in the Available Skills section of relevant task prompts
+   - Apply precedence rules when skills overlap with internal specialists
+7. Write your complete delegation plan to `/var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-Ua2lf1/ui-fixes-url-prepend-verify-text-billing-spacing/phase3-synthesis.md`

--- a/docs/history/nefario-reports/2026-03-24-203932-ui-fixes-url-prepend-verify-text-billing-spacing/phase3-synthesis.md
+++ b/docs/history/nefario-reports/2026-03-24-203932-ui-fixes-url-prepend-verify-text-billing-spacing/phase3-synthesis.md
@@ -1,0 +1,164 @@
+## Delegation Plan
+
+**Team name**: ui-fixes-batch
+**Description**: Three small UI fixes shipped as a single phase: URL auto-prepend in capture form, verify page text correction, billing page CSS spacing.
+
+### Task 1: URL auto-prepend, verify page text, and billing CSS fixes
+- **Agent**: frontend-minion
+- **Delegation type**: standard
+- **Model**: sonnet
+- **Mode**: bypassPermissions
+- **Blocked by**: none
+- **Approval gate**: no
+- **Prompt**: |
+    You are making three small UI fixes in a single pass. All changes are scoped to client-side UI code only -- no server/API changes.
+
+    ## Fix 1: URL auto-prepend in safeUrl() (issue #179)
+
+    **File**: src/ui/ui-submit.js
+
+    The safeUrl() function (lines 10-17) currently rejects bare hostnames like example.com because the URL constructor throws on them. Users expect to type example.com and have it work.
+
+    **What to do:**
+
+    1. Modify safeUrl() to try prepending "https://" when the initial URL parse throws AND the input does not contain "://". The "://" guard prevents mangling inputs like "htt://example.com" where the user intended a scheme but got it wrong. Structure:
+       - First try: parse urlStr as-is. If protocol is http: or https:, return u.href.
+       - Catch: if urlStr is truthy and does not include "://", try parsing "https://" + urlStr. If that succeeds and protocol is https:, return u2.href. Otherwise fall through.
+       - Default: return null.
+
+    2. In handleSubmit() (line 380, after validation succeeds and before submitBtn.disabled = true), add urlInput.value = safe; so the input briefly reflects the normalized URL before it clears on success. This gives the user immediate visual feedback of what was submitted.
+
+    3. Update the error message on line 373 from "Enter a valid http:// or https:// URL." to "Enter a valid URL (e.g. example.com or https://example.com)." to reflect that bare hostnames are now accepted.
+
+    **What NOT to do:**
+    - Do NOT modify safeUrl() in src/ui/ui-detail.js or src/verify-page.js. Those are display validators for server-provided URLs that already have schemes. Changing them would mask API bugs.
+    - Do NOT add a separate normalizeUrl() function. The logic belongs inline in safeUrl().
+
+    ## Fix 2: Verify page text (issue #180)
+
+    **File**: src/verify-page.js
+
+    On line 344, replace "eIDAS Art. 41" with "eIDAS Article 41". This is the only occurrence. The CLI formatter (packages/verify/lib/format.js) has no "Art." references -- confirmed, no change needed there.
+
+    ## Fix 3: Billing page spacing (issue #183)
+
+    **File**: src/ui/ui-css.js
+
+    The .billing-stat container (line 1504-1506) contains two span children: .billing-stat-value and .billing-stat-label. Spans are inline by default, so the margin-top: var(--space-1) on .billing-stat-label (line 1515) has no effect -- inline elements ignore vertical margins.
+
+    **What to do:** Add "display: block;" to both the .billing-stat-value rule (after line 1511, before the closing bracket) and the .billing-stat-label rule (after line 1514, before margin-top). This makes the spans render as blocks, allowing the existing margin-top to create visible spacing.
+
+    Do NOT use flexbox on the parent -- display: block on the children is the minimal fix.
+
+    ## Constraints
+    - This codebase uses var (not let/const) in the inline JS string constants (SUBMIT_VIEW_JS etc.) because the JS is embedded as template literal strings, not modules.
+    - The code signature comment already exists at line 1 of ui-submit.js -- do not add another.
+    - Follow the project's engineering philosophy: KISS, minimal changes, no over-engineering.
+
+- **Deliverables**: Modified src/ui/ui-submit.js, modified src/verify-page.js, modified src/ui/ui-css.js
+- **Success criteria**: safeUrl("example.com") returns "https://example.com/"; safeUrl("https://example.com") unchanged; safeUrl("htt://example.com") returns null; verify page shows "Article 41"; billing stat spans are block-level with visible spacing.
+
+### Task 2: Tests for URL auto-prepend
+- **Agent**: frontend-minion
+- **Delegation type**: standard
+- **Model**: sonnet
+- **Mode**: bypassPermissions
+- **Blocked by**: Task 1
+- **Approval gate**: no
+- **Prompt**: |
+    Create test/ui-submit.test.js with unit tests for the safeUrl() function in src/ui/ui-submit.js.
+
+    ## Pattern to follow
+
+    This project uses an evalFromSource() pattern to extract functions from JS string constants. See test/ui-billing.test.js for the exact pattern -- copy the evalFromSource helper from there and adapt it. Import SUBMIT_VIEW_JS from "../src/ui/ui-submit.js" and extract the safeUrl function.
+
+    ## Test cases
+
+    Write a single describe("safeUrl -- URL normalization") block with these cases:
+
+    1. safeUrl("https://example.com") returns "https://example.com/" -- full https URL unchanged
+    2. safeUrl("http://example.com") returns "http://example.com/" -- full http URL unchanged
+    3. safeUrl("example.com") returns "https://example.com/" -- bare hostname gets https prepended
+    4. safeUrl("example.com/page?q=1") returns "https://example.com/page?q=1" -- bare hostname with path
+    5. safeUrl("htt://example.com") returns null -- has "://" so we don't "fix" it
+    6. safeUrl("ftp://example.com") returns null -- wrong scheme
+    7. safeUrl("javascript:alert(1)") returns null -- dangerous scheme
+    8. safeUrl("") returns null -- empty string
+    9. safeUrl("not a url at all") returns null -- gibberish (even with prepend, spaces make it invalid)
+
+    Use the naming convention from ui-billing.test.js: prefix test names with a partition letter and number (e.g., A1:, A2:, etc.).
+
+    ## Constraints
+    - Import SUBMIT_VIEW_JS from "../src/ui/ui-submit.js"
+    - File: test/ui-submit.test.js
+    - Use vitest (describe, it, expect)
+    - No DOM, no fetch, no document -- pure function tests only
+
+- **Deliverables**: New test/ui-submit.test.js
+- **Success criteria**: All 9 test cases pass with "npx vitest run test/ui-submit.test.js"
+
+### Cross-Cutting Coverage
+
+- **Testing**: Covered by Task 2 (new test file for safeUrl). Post-execution Phase 6 will run the full test suite.
+- **Security**: Not needed. The URL auto-prepend does not create new attack surface -- it only adds "https://" to bare hostnames, and the server's validateUrl() remains the real security boundary. XSS via safeUrl is already guarded by protocol check (http: or https: only). javascript: scheme returns null.
+- **Usability -- Strategy**: Not needed for this batch. These are bug fixes to existing UI elements, not new features or journey changes. The UX improvement (accepting bare hostnames) is well-established convention and was specified in the issue.
+- **Usability -- Design**: Not applicable -- no new UI components or visual layouts. The billing fix restores intended spacing; the URL fix updates an error message.
+- **Documentation**: Not needed. No API surface changes, no architectural changes. The fixes are self-explanatory from the code and issue descriptions.
+- **Observability**: Not applicable -- all changes are client-side UI with no runtime services, logging, or metrics impact.
+
+### Architecture Review Agents
+
+- **Mandatory** (5): security-minion, test-minion, ux-strategy-minion, lucy, margo
+- **Discretionary picks**: none
+  - ux-design-minion: No -- fixes restore intended behavior, no new UI components or interaction patterns
+  - accessibility-minion: No -- no HTML structure changes; the billing fix adds display: block to spans (no accessibility impact); the error message update is an improvement
+  - sitespeed-minion: No -- no new runtime code, assets, or pages
+  - observability-minion: No -- client-side only, no services or APIs
+  - user-docs-minion: No -- the changes are invisible to documentation (URL field now accepts bare hostnames, which is self-discoverable; the error message update is the documentation)
+- **Not selected**:
+  - ux-design-minion: Fixes restore intended behavior, no new visual design decisions
+  - accessibility-minion: No HTML structure changes, no WCAG-relevant modifications
+  - sitespeed-minion: No new pages, assets, or runtime code paths
+
+### Decisions
+
+- **Inline modification vs. separate normalizeUrl()**
+  Chosen: Modify safeUrl() inline to include the prepend logic
+  Over: Adding a separate normalizeUrl() called before safeUrl() in handleSubmit()
+  Why: safeUrl() is a 7-line function with a single caller. Two coordinated functions would be more code with no additional clarity. The normalization is logically part of "parse this string as a safe URL."
+
+- **display: block on children vs. flexbox on parent**
+  Chosen: display: block on .billing-stat-value and .billing-stat-label spans
+  Over: Adding display: flex; flex-direction: column; align-items: center to .billing-stat parent
+  Why: The spans already have the right styling (font-size, margin-top) -- they just need to be blocks for those styles to work. Adding flexbox is overkill for two stacked elements and changes more properties than needed.
+
+### Risks and Mitigations
+
+1. **Auto-prepend on ambiguous input**: safeUrl("example") will try "https://example" which is technically a valid URL (no TLD required per WHATWG spec). The server's validateUrl() and SSRF protection will reject hostnames that don't resolve, so this is acceptable. The client form catches obvious syntax errors; hostname validity is the server's job.
+
+2. **safeUrl() exists in 3 files**: Only ui-submit.js is modified. The safeUrl() in ui-detail.js and verify-page.js are display validators for server-provided data. Task 1 prompt explicitly forbids modifying them.
+
+3. **No existing tests for ui-submit.js**: Task 2 creates the test file from scratch, following the established evalFromSource() pattern from ui-billing.test.js. Risk is low since the pattern is proven.
+
+### Execution Order
+
+```
+Batch 1 (sequential):
+  Task 1: Code changes (safeUrl, verify text, billing CSS)  [no gate]
+  Task 2: Tests for safeUrl                                  [no gate, blocked by Task 1]
+
+Post-execution:
+  Phase 5: Code review (code-review-minion, lucy, margo)
+  Phase 6: Test execution (full suite)
+```
+
+### External Skills
+No external skills detected in project.
+
+### Verification Steps
+
+1. Run "npx vitest run test/ui-submit.test.js" -- all 9 cases pass
+2. Run "npx vitest run" -- full suite passes, no regressions
+3. Manual spot-check: grep for "://" in safeUrl to confirm guard logic is present
+4. Manual spot-check: grep for "Art." in src/verify-page.js returns zero results
+5. Manual spot-check: grep for "display: block" in billing-stat CSS rules confirms both spans are block-level

--- a/docs/history/nefario-reports/2026-03-24-203932-ui-fixes-url-prepend-verify-text-billing-spacing/phase3.5-lucy.md
+++ b/docs/history/nefario-reports/2026-03-24-203932-ui-fixes-url-prepend-verify-text-billing-spacing/phase3.5-lucy.md
@@ -1,0 +1,49 @@
+# Lucy Review -- ui-fixes-batch
+
+## Verdict: APPROVE
+
+## Traceability Matrix
+
+| Requirement (from prompt.md) | Plan Element | Status |
+|---|---|---|
+| Auto-prepend https:// on bare hostname | Task 1 Fix 1: safeUrl() modification in ui-submit.js | Covered |
+| Leave http:// and https:// URLs unchanged | Task 1 Fix 1: first-try parse path in safeUrl() | Covered |
+| Do not "fix" partial schemes like htt:// | Task 1 Fix 1: "://" guard prevents mangling | Covered |
+| Replace "Art." with "Article" on verify page | Task 1 Fix 2: line 344 in verify-page.js | Covered |
+| Check CLI formatter for "Art." references | Plan confirms zero matches in packages/verify/lib/format.js | Covered |
+| Add visible spacing between billing numbers and labels | Task 1 Fix 3: display: block on both spans in ui-css.js | Covered |
+| No regressions | Phase 6 full suite run | Covered |
+| Add/update tests for URL prepend logic | Task 2: 9 test cases in test/ui-submit.test.js | Covered |
+| Scope exclusions: no API changes, no i18n, no billing logic | Plan is client-side UI only, two tasks, three files modified | Covered |
+
+## Findings
+
+No blocking or advisory findings.
+
+### Alignment
+
+- The plan restates all three fixes correctly. Success criteria match the prompt verbatim.
+- Scope is contained: three source files modified, one test file created, no API or backend changes.
+- The "Out" scope boundaries (no API-level URL normalization, no i18n, no billing logic) are respected.
+
+### CLAUDE.md Compliance
+
+- **Evolution log**: Not part of the delegation plan itself, but the plan references post-execution phases (Phase 5, Phase 6). The calling session is responsible for creating the evolution log directory with prompt.md, decisions.md, outcome.md, and process.md per CLAUDE.md rules. This is the orchestrator's responsibility, not a gap in the delegation plan.
+- **Engineering philosophy**: KISS and YAGNI are respected. The plan explicitly chose inline modification over a separate normalizeUrl() function, and display: block over flexbox -- both are minimal-change approaches with documented rationale.
+- **Fail loudly**: The safeUrl() catch block returns null (not silently swallowing). This is appropriate -- it is a parser, not an error handler. The null propagates to the caller which shows a user-facing error message.
+
+### Scope Creep Check
+
+- Two tasks total for three fixes. No inflation.
+- No new dependencies, no abstraction layers, no adjacent features.
+- The urlInput.value = safe feedback line (Task 1 step 2) is the only element not explicitly in the prompt, but it is a single line of UX polish directly tied to the auto-prepend feature (showing the user what was actually submitted). Proportional and justified.
+
+### Convention Consistency
+
+- Test file follows the established evalFromSource() pattern from ui-billing.test.js. Verified the pattern exists at the referenced location.
+- Plan correctly notes that safeUrl() exists in three files and forbids modifying the other two (ui-detail.js, verify-page.js). Verified: ui-detail.js uses safeUrl() as a display validator for server-provided data at line 90.
+- The plan uses var (not let/const) for inline JS, matching the existing codebase convention for template literal JS strings.
+
+### Risk Assessment
+
+The auto-prepend-on-ambiguous-input risk (e.g., safeUrl("example") yielding "https://example") is correctly identified and mitigated: server-side validateUrl() is the real security boundary. Client-side normalization is a convenience layer.

--- a/docs/history/nefario-reports/2026-03-24-203932-ui-fixes-url-prepend-verify-text-billing-spacing/phase3.5-margo.md
+++ b/docs/history/nefario-reports/2026-03-24-203932-ui-fixes-url-prepend-verify-text-billing-spacing/phase3.5-margo.md
@@ -1,0 +1,17 @@
+# Margo Review — Simplicity / YAGNI / KISS
+
+## Verdict: APPROVE
+
+This plan is well-proportioned to the problem. Three small bug fixes, two tasks, no new dependencies, no new abstractions, no infrastructure changes. Specific observations:
+
+**Scope alignment**: The user requested three UI fixes. The plan delivers exactly three UI fixes plus one test file. Task count (2) is appropriate -- one for code, one for tests. No scope creep.
+
+**Complexity budget**: Zero. No new technologies, no new services, no new abstraction layers, no new dependencies. This is the ideal complexity spend for a bug-fix batch.
+
+**YAGNI compliance**: The plan explicitly forbids creating a separate normalizeUrl() function, forbids flexbox where display:block suffices, and forbids modifying the other two safeUrl() copies. All three "what NOT to do" sections prevent accidental complexity from creeping in. Good discipline.
+
+**KISS compliance**: Each fix is the minimal change that addresses the problem. The billing CSS fix adds one property to two rules rather than restructuring the parent. The URL prepend extends an existing 7-line function rather than introducing a new abstraction. The verify page fix is a single string replacement.
+
+**Decisions are sound**: Both documented decisions (inline modification over separate function; display:block over flexbox) choose the simpler path with clear rationale. No objections.
+
+No concerns from the simplicity domain.

--- a/docs/history/nefario-reports/2026-03-24-203932-ui-fixes-url-prepend-verify-text-billing-spacing/phase3.5-security-minion.md
+++ b/docs/history/nefario-reports/2026-03-24-203932-ui-fixes-url-prepend-verify-text-billing-spacing/phase3.5-security-minion.md
@@ -1,0 +1,25 @@
+APPROVE
+
+The proposed safeUrl() modification is safe. Verified against the actual source.
+
+**Scheme injection analysis (Fix 1):**
+
+- `javascript:alert(1)` -- no `://` substring, so prepend fires. `new URL("https://javascript:alert(1)")` throws (`:alert(1)` is an invalid port), falls through to `return null`. The test suite (Task 2, case A7) explicitly covers this.
+- `data:text/html,...` -- no `://`, prepend fires. `new URL("https://data:text/...")` throws on invalid port, returns null.
+- `file:///etc/passwd` -- contains `://`, guard prevents prepend. First-try parse succeeds (`file:` protocol), protocol check (`http:` or `https:` only) returns null. Safe.
+- `ftp://...` -- contains `://`, guard prevents prepend. First-try parse succeeds, protocol check returns null.
+
+**XSS analysis:**
+
+- `urlInput.value = safe` writes to the DOM `.value` property of an input element, not `.innerHTML` or `.href`. No XSS vector.
+- The updated error message is a static string literal, not interpolated from user input.
+
+**SSRF boundary:**
+
+The server-side `validateUrl()` in `src/url-validation.js` is the real SSRF boundary. It enforces: WHATWG URL parsing, `http:`/`https:` scheme allowlist, credential rejection, DNS resolution of all A/AAAA records, private IP range blocking (RFC 1918, loopback, link-local, CGNAT, IPv6 ULA, IPv4-mapped IPv6), and double-encoding detection. This boundary is independent of and unaffected by the client-side safeUrl() change. The synthesis plan's claim that "the server's validateUrl() remains the real security boundary" is accurate and verified.
+
+**Open redirect:**
+
+`safeUrl()` normalizes URLs through the WHATWG URL constructor and returns `u.href` (re-serialized canonical form). It is not used as a redirect target -- it feeds into a POST body (`JSON.stringify({ url: safe })`). No open redirect.
+
+No concerns from security domain.

--- a/docs/history/nefario-reports/2026-03-24-203932-ui-fixes-url-prepend-verify-text-billing-spacing/phase3.5-test-minion.md
+++ b/docs/history/nefario-reports/2026-03-24-203932-ui-fixes-url-prepend-verify-text-billing-spacing/phase3.5-test-minion.md
@@ -1,0 +1,29 @@
+ADVISE
+
+---
+
+- [testing]: Protocol-relative URL `//example.com` is not covered and silently passes as valid
+  SCOPE: test/ui-submit.test.js, safeUrl() in src/ui/ui-submit.js
+  CHANGE: Add a test case for `safeUrl("//example.com")`. Under the planned implementation, `//example.com` does not contain `://` so the prepend path fires, producing `https://example.com/`. Whether that is the intended behavior should be an explicit decision — if it is intentional, add a passing test; if not, the guard needs to handle it and the test should assert null.
+  WHY: Protocol-relative URLs are a known input pattern. A user who pastes `//example.com` (e.g., copied from HTML source) will silently get `https://example.com` submitted, which may surprise them. The behavior is deterministic but undocumented in the test suite. Verified by running the proposed logic: `new URL("https://" + "//example.com")` produces `https://example.com/`.
+  TASK: Task 2
+
+- [testing]: Bare hostname with port (`example.com:8080`) returns null even though `https://example.com:8080` is valid — this behavior is unspecified and untested
+  SCOPE: test/ui-submit.test.js, safeUrl() in src/ui/ui-submit.js
+  CHANGE: Add a test case for `safeUrl("example.com:8080")` asserting the actual return value (null). Document why: `new URL("example.com:8080")` succeeds but parses `example.com` as the scheme, so the catch branch is never reached and no prepend occurs. If ports on bare hostnames should be supported, the implementation needs a more sophisticated detection heuristic. If null is acceptable, the test documents it explicitly.
+  WHY: Users who type `example.com:8080` (a common developer input pattern) will get a validation error rather than auto-prepend. This is a meaningful UX gap that the 9 planned cases don't surface. Confirmed by running proposed logic: first parse succeeds with `protocol: "example.com:"`, which fails the http/https check, returning null before entering the catch block.
+  TASK: Task 2
+
+- [testing]: The verify page text fix (Fix 2) and billing CSS fix (Fix 3) have no test coverage — the plan leaves them to manual spot-check only
+  SCOPE: test/ui-submit.test.js (missing), src/verify-page.js, src/ui/ui-css.js
+  CHANGE: Add at minimum two string-assertion tests: (1) in the existing test/verify-page.test.js, assert that the HTML output does not contain `"Art. 41"` and does contain `"Article 41"`; (2) in test/ui-billing.test.js (which already imports UI_CSS), assert that `.billing-stat-value` and `.billing-stat-label` rules contain `display: block`. These are one-line additions to existing test files.
+  WHY: The plan's stated success criteria include "verify page shows 'Article 41'" and "billing stat spans are block-level" but neither has an automated assertion — both rely on grep spot-checks. The existing test infrastructure already imports `BILLING_JS`/`UI_CSS` and `htmlVerifyResponse`, so adding assertions is trivial. Without them, a future refactor could silently revert Fix 2 or Fix 3 without breaking CI.
+  TASK: Task 1 (these assertions should accompany the code changes, not wait for Task 2)
+
+---
+
+Notes:
+
+The evalFromSource() pattern is appropriate for this use case. The existing ui-billing.test.js proves it works for extracting helpers from embedded JS string constants, and the constraints (no DOM, no fetch, var not let/const) are correctly accounted for in the Task 2 prompt. The 9 planned cases cover the core branches adequately; the two ADVISE items above are gaps worth closing, not blockers.
+
+The absence of tests for Fix 2 and Fix 3 is the most important ADVISE item. The verify-page and UI_CSS test files already exist and already import the relevant exports — adding two assertions is minutes of work and protects against silent regression.

--- a/docs/history/nefario-reports/2026-03-24-203932-ui-fixes-url-prepend-verify-text-billing-spacing/phase3.5-ux-strategy-minion.md
+++ b/docs/history/nefario-reports/2026-03-24-203932-ui-fixes-url-prepend-verify-text-billing-spacing/phase3.5-ux-strategy-minion.md
@@ -1,0 +1,11 @@
+## Verdict: ADVISE
+
+All three fixes address real user friction. Journey coherence is intact. No cognitive load concerns with the core changes. One advisory on the URL normalization feedback pattern.
+
+---
+
+- [usability]: The `urlInput.value = safe` update gives feedback that may be imperceptible if the success path clears the field quickly or after a short async delay.
+  SCOPE: src/ui/ui-submit.js — handleSubmit(), the `urlInput.value = safe` line and the subsequent field-clear logic
+  CHANGE: Confirm that the normalized URL is visible for a meaningful duration before the field clears. If the field clears within the same tick or within milliseconds (e.g., on a fast network response), the update provides no real feedback. Either (a) ensure the field is cleared only on confirmed success and the normalized URL is readable in that window, or (b) skip the `urlInput.value = safe` line entirely — the success state already confirms submission, and the value update adds noise without signal if it vanishes immediately. Do not keep the line "just in case."
+  WHY: Krug's Law — don't make users wonder what happened. A value that flickers in and out is worse than no value update: it creates a moment of confusion without delivering the intended reassurance. If the feedback isn't visible long enough to register, it's a false affordance.
+  TASK: Task 1

--- a/docs/history/nefario-reports/2026-03-24-203932-ui-fixes-url-prepend-verify-text-billing-spacing/phase4-frontend-minion-task1-prompt.md
+++ b/docs/history/nefario-reports/2026-03-24-203932-ui-fixes-url-prepend-verify-text-billing-spacing/phase4-frontend-minion-task1-prompt.md
@@ -1,0 +1,50 @@
+You are making three small UI fixes in a single pass. All changes are scoped to client-side UI code only -- no server/API changes.
+
+## Fix 1: URL auto-prepend in safeUrl() (issue #179)
+
+**File**: src/ui/ui-submit.js
+
+The safeUrl() function (lines 10-17) currently rejects bare hostnames like example.com because the URL constructor throws on them. Users expect to type example.com and have it work.
+
+**What to do:**
+
+1. Modify safeUrl() to try prepending "https://" when the initial URL parse throws AND the input does not contain "://". The "://" guard prevents mangling inputs like "htt://example.com" where the user intended a scheme but got it wrong. Structure:
+   - First try: parse urlStr as-is. If protocol is http: or https:, return u.href.
+   - Catch: if urlStr is truthy and does not include "://", try parsing "https://" + urlStr. If that succeeds and protocol is https:, return u2.href. Otherwise fall through.
+   - Default: return null.
+
+2. Update the error message from "Enter a valid http:// or https:// URL." to "Enter a valid URL (e.g. example.com or https://example.com)." to reflect that bare hostnames are now accepted.
+
+3. Do NOT add urlInput.value = safe — per UX review, the field clears too fast for the update to be visible, creating a false affordance.
+
+**What NOT to do:**
+- Do NOT modify safeUrl() in src/ui/ui-detail.js or src/verify-page.js. Those are display validators for server-provided URLs that already have schemes.
+- Do NOT add a separate normalizeUrl() function. The logic belongs inline in safeUrl().
+
+## Fix 2: Verify page text (issue #180)
+
+**File**: src/verify-page.js
+
+On line 344, replace "eIDAS Art. 41" with "eIDAS Article 41". This is the only occurrence. The CLI formatter (packages/verify/lib/format.js) has no "Art." references -- no change needed there.
+
+Also search for any other "Art." references in verify-page.js and replace with "Article" if found.
+
+## Fix 3: Billing page spacing (issue #183)
+
+**File**: src/ui/ui-css.js
+
+The .billing-stat container contains two span children: .billing-stat-value and .billing-stat-label. Spans are inline by default, so the margin-top: var(--space-1) on .billing-stat-label has no effect.
+
+**What to do:** Add "display: block;" to both the .billing-stat-value rule and the .billing-stat-label rule. This makes the spans render as blocks, allowing the existing margin-top to create visible spacing.
+
+Do NOT use flexbox on the parent -- display: block on the children is the minimal fix.
+
+## Constraints
+- This codebase uses var (not let/const) in the inline JS string constants (SUBMIT_VIEW_JS etc.) because the JS is embedded as template literal strings, not modules.
+- Follow the project's engineering philosophy: KISS, minimal changes, no over-engineering.
+
+## Deliverables
+Modified src/ui/ui-submit.js, modified src/verify-page.js, modified src/ui/ui-css.js
+
+## Success criteria
+safeUrl("example.com") returns "https://example.com/"; safeUrl("https://example.com") unchanged; safeUrl("htt://example.com") returns null; verify page shows "Article 41"; billing stat spans are block-level with visible spacing.

--- a/docs/history/nefario-reports/2026-03-24-203932-ui-fixes-url-prepend-verify-text-billing-spacing/phase4-frontend-minion-task2-prompt.md
+++ b/docs/history/nefario-reports/2026-03-24-203932-ui-fixes-url-prepend-verify-text-billing-spacing/phase4-frontend-minion-task2-prompt.md
@@ -1,0 +1,75 @@
+Create test/ui-submit.test.js with unit tests for the safeUrl() function in src/ui/ui-submit.js, plus regression assertions for Fix 2 and Fix 3 in existing test files.
+
+Working directory: /Users/ben/github/benpeter/web-resource-ledger/.claude/worktrees/iridescent-purring-lagoon
+
+## Part A: New test file for safeUrl()
+
+### Pattern to follow
+
+This project uses an evalFromSource() pattern to extract functions from JS string constants. See test/ui-billing.test.js for the exact pattern -- copy the evalFromSource helper from there and adapt it. Import SUBMIT_VIEW_JS from "../src/ui/ui-submit.js" and extract the safeUrl function.
+
+### Test cases
+
+Write a single describe("safeUrl -- URL normalization") block with these cases:
+
+1. safeUrl("https://example.com") returns "https://example.com/" -- full https URL unchanged
+2. safeUrl("http://example.com") returns "http://example.com/" -- full http URL unchanged
+3. safeUrl("example.com") returns "https://example.com/" -- bare hostname gets https prepended
+4. safeUrl("example.com/page?q=1") returns "https://example.com/page?q=1" -- bare hostname with path
+5. safeUrl("htt://example.com") returns null -- has "://" so we don't "fix" it
+6. safeUrl("ftp://example.com") returns null -- wrong scheme
+7. safeUrl("javascript:alert(1)") returns null -- dangerous scheme
+8. safeUrl("") returns null -- empty string
+9. safeUrl("not a url at all") returns null -- gibberish (even with prepend, spaces make it invalid)
+10. safeUrl("//example.com") returns "https://example.com/" -- protocol-relative URL gets https prepended (no "://" present)
+11. safeUrl("example.com:8080") returns null -- bare hostname with port: first parse succeeds with "example.com:" as scheme, protocol check rejects it; prepend not attempted because "://" is absent... actually test what the actual behavior is and document it
+
+For case 11 (example.com:8080): run the actual safeUrl function to determine the real behavior, then write the test to match. The test documents the behavior, whatever it is.
+
+Use the naming convention from ui-billing.test.js: prefix test names with a partition letter and number (e.g., A1:, A2:, etc.).
+
+### Constraints
+- Import SUBMIT_VIEW_JS from "../src/ui/ui-submit.js"
+- File: test/ui-submit.test.js
+- Use vitest (describe, it, expect)
+- No DOM, no fetch, no document -- pure function tests only
+
+## Part B: Regression assertions for Fix 2 and Fix 3
+
+### verify-page.test.js
+
+Add a test assertion that the verify page HTML does NOT contain "Art." (the German abbreviation). Find the existing test file test/verify-page.test.js, look at how it imports and generates HTML, and add a test like:
+
+```js
+it('uses "Article" not "Art." for eIDAS references', () => {
+  // generate the HTML however the existing tests do
+  expect(html).not.toContain('Art. 41');
+  expect(html).toContain('Article 41');
+});
+```
+
+### ui-billing.test.js
+
+Add a test assertion that the billing CSS contains "display: block" for the billing stat spans. Look at test/ui-billing.test.js and add:
+
+```js
+it('billing stat value and label are display: block', () => {
+  // import UI_CSS however existing tests do
+  expect(css).toContain('display: block');
+  // or more specific assertions
+});
+```
+
+## Verification
+
+After creating/modifying all test files, run the tests to make sure they pass:
+```
+npx vitest run test/ui-submit.test.js
+npx vitest run test/verify-page.test.js
+npx vitest run test/ui-billing.test.js
+```
+
+When you finish, report:
+- File paths with change scope and line counts
+- 1-2 sentence summary of what was produced
+- Whether all tests pass

--- a/docs/history/nefario-reports/2026-03-24-203932-ui-fixes-url-prepend-verify-text-billing-spacing/phase8-checklist.md
+++ b/docs/history/nefario-reports/2026-03-24-203932-ui-fixes-url-prepend-verify-text-billing-spacing/phase8-checklist.md
@@ -1,0 +1,16 @@
+# Phase 8a: Documentation Checklist
+
+## Items
+
+1. [SHOULD] [user-docs] Release notes entry for three UI bug fixes
+   - URL auto-prepend: capture form now accepts bare hostnames
+   - Verify page: "Art." corrected to "Article"
+   - Billing page: spacing between numbers and labels
+
+2. [COULD] [software-docs] Scan for stale references to URL validation behavior
+   - The error message changed from "Enter a valid http:// or https:// URL" to "Enter a valid URL (e.g. example.com or https://example.com)"
+   - No known docs reference this error message
+
+## Assessment
+
+0 MUST items. 2 items total (1 SHOULD, 1 COULD). These are small bug fixes with no API surface changes. No documentation is stale — the error message is internal to the UI and not referenced in any documentation.

--- a/docs/history/nefario-reports/2026-03-24-203932-ui-fixes-url-prepend-verify-text-billing-spacing/prompt.md
+++ b/docs/history/nefario-reports/2026-03-24-203932-ui-fixes-url-prepend-verify-text-billing-spacing/prompt.md
@@ -1,0 +1,29 @@
+Batch of three small UI fixes shipped as a single phase.
+
+## Fix 1 — Auto-prepend https:// (#179)
+
+The captures UI URL input field automatically prepends `https://` when a user enters a bare hostname (e.g., `example.com` → `https://example.com`). Entries that already have `http://` or `https://` are left unchanged. Partial schemes like `htt://` are not "fixed".
+
+## Fix 2 — Verify page German text (#180)
+
+All eIDAS references on the verify page use "Article" instead of the German abbreviation "Art." (e.g., "Article 42" not "Art. 42"). Check both the verify page HTML template (`src/verify-page.js`) and the `@w-r-l/verify` CLI formatter (`packages/verify/lib/format.js`).
+
+## Fix 3 — Billing page spacing (#183)
+
+Add visible spacing between numeric count values and their unit labels on the billing page (e.g., "14 Captures" not "14Captures"). CSS or template fix.
+
+## Success criteria
+
+- Entering `example.com` in capture URL field submits `https://example.com`
+- Entering `https://example.com` or `http://example.com` is unchanged
+- All "Art." references on verify page replaced with "Article"
+- Billing page shows space between numbers and units
+- No regressions on other pages
+- Existing tests pass; add/update tests for URL prepend logic
+
+## Scope
+
+- **In**: UI URL input normalization, verify page text, billing page CSS
+- **Out**: API-level URL normalization, i18n infrastructure, billing logic changes
+
+Closes #179, closes #180, closes #183

--- a/src/ui/ui-css.js
+++ b/src/ui/ui-css.js
@@ -1505,11 +1505,13 @@ input, select, textarea {
   text-align: center;
 }
 .billing-stat-value {
+  display: block;
   font-size: var(--text-xl);
   font-weight: var(--weight-bold);
   color: var(--color-text);
 }
 .billing-stat-label {
+  display: block;
   font-size: var(--text-xs);
   color: var(--color-text-muted);
   margin-top: var(--space-1);

--- a/src/ui/ui-submit.js
+++ b/src/ui/ui-submit.js
@@ -10,10 +10,16 @@ export const SUBMIT_VIEW_JS = `
 function safeUrl(urlStr) {
   try {
     var u = new URL(urlStr);
-    return (u.protocol === 'http:' || u.protocol === 'https:') ? u.href : null;
+    if (u.protocol === 'http:' || u.protocol === 'https:') return u.href;
   } catch (e) {
-    return null;
+    if (urlStr && urlStr.indexOf('://') === -1) {
+      try {
+        var u2 = new URL('https://' + urlStr);
+        if (u2.protocol === 'https:') return u2.href;
+      } catch (e2) { /* fall through */ }
+    }
   }
+  return null;
 }
 
 function formatDate(isoStr) {
@@ -370,7 +376,7 @@ function handleSubmit(urlInput, submitBtn, formErrorEl) {
   // Validate URL
   var safe = safeUrl(raw);
   if (!raw || !safe) {
-    formErrorEl.textContent = 'Enter a valid http:// or https:// URL.';
+    formErrorEl.textContent = 'Enter a valid URL (e.g. example.com or https://example.com).';
     formErrorEl.style.display = '';
     urlInput.classList.add('input--error');
     urlInput.focus();

--- a/src/verify-page.js
+++ b/src/verify-page.js
@@ -341,7 +341,7 @@ footer a:focus-visible { outline: 2px solid var(--color-text); outline-offset: 2
     bundleHash:         'Confirms the overall archive bundle has not been altered.',
     signature:          'Confirms the bundle was signed by the capture service.',
     timestamp:          'Time was recorded by an independent authority (not verified cryptographically).',
-    qualifiedTimestamp: 'Qualified electronic timestamp from an EU Trusted List TSA (eIDAS Art. 41).',
+    qualifiedTimestamp: 'Qualified electronic timestamp from an EU Trusted List TSA (eIDAS Article 41).',
     consentHandling:    'The capture dismissed a cookie consent banner to reveal the page content.',
   };
 

--- a/test/ui-billing.test.js
+++ b/test/ui-billing.test.js
@@ -224,6 +224,28 @@ describe('UI_CSS -- billing section styles', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Partition G2 -- Regression: Fix 3 -- billing stat spans are display: block
+// ---------------------------------------------------------------------------
+
+describe('UI_CSS -- billing stat display (Fix 3 regression)', () => {
+  it('G5: billing stat value is display: block', () => {
+    // Regression guard: .billing-stat-value must use display:block so each
+    // value and label stack vertically in the billing stats row.
+    expect(UI_CSS).toContain('.billing-stat-value');
+    expect(UI_CSS).toContain('display: block');
+  });
+
+  it('G6: billing stat label is display: block', () => {
+    expect(UI_CSS).toContain('.billing-stat-label');
+    // Both value and label must be block-level; the CSS contains at least one
+    // "display: block" rule that applies to billing stat children.
+    const idx = UI_CSS.indexOf('.billing-stat-value');
+    const section = UI_CSS.slice(idx, idx + 200);
+    expect(section).toContain('display: block');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Partition H -- Separation guard: billing logic must not leak into settings
 // ---------------------------------------------------------------------------
 

--- a/test/ui-submit.test.js
+++ b/test/ui-submit.test.js
@@ -1,0 +1,71 @@
+// Unit tests for ui-submit.js -- safeUrl() URL normalization.
+// Tests extract the safeUrl function from the SUBMIT_VIEW_JS string constant
+// via the evalFromSource pattern. No DOM, no fetch, no document.
+
+import { describe, it, expect } from 'vitest';
+import { SUBMIT_VIEW_JS } from '../src/ui/ui-submit.js';
+
+// ---------------------------------------------------------------------------
+// evalFromSource -- extract and return a named function from a JS source string
+// ---------------------------------------------------------------------------
+
+function evalFromSource(source, functionName) {
+  // eslint-disable-next-line no-new-func
+  const fn = new Function(source + '\nreturn ' + functionName + ';');
+  return fn();
+}
+
+const safeUrl = evalFromSource(SUBMIT_VIEW_JS, 'safeUrl');
+
+// ---------------------------------------------------------------------------
+// Partition A -- safeUrl URL normalization
+// ---------------------------------------------------------------------------
+
+describe('safeUrl -- URL normalization', () => {
+  it('A1: full https URL is returned with trailing slash unchanged', () => {
+    expect(safeUrl('https://example.com')).toBe('https://example.com/');
+  });
+
+  it('A2: full http URL is returned with trailing slash unchanged', () => {
+    expect(safeUrl('http://example.com')).toBe('http://example.com/');
+  });
+
+  it('A3: bare hostname gets https prepended and trailing slash added', () => {
+    expect(safeUrl('example.com')).toBe('https://example.com/');
+  });
+
+  it('A4: bare hostname with path and query string gets https prepended', () => {
+    expect(safeUrl('example.com/page?q=1')).toBe('https://example.com/page?q=1');
+  });
+
+  it('A5: URL with unrecognized scheme ("htt://") returns null -- has "://" so prepend is skipped', () => {
+    expect(safeUrl('htt://example.com')).toBeNull();
+  });
+
+  it('A6: ftp:// URL returns null -- wrong scheme', () => {
+    expect(safeUrl('ftp://example.com')).toBeNull();
+  });
+
+  it('A7: javascript: URL returns null -- dangerous scheme', () => {
+    expect(safeUrl('javascript:alert(1)')).toBeNull();
+  });
+
+  it('A8: empty string returns null', () => {
+    expect(safeUrl('')).toBeNull();
+  });
+
+  it('A9: gibberish with spaces returns null -- URL constructor rejects even after https prepend', () => {
+    expect(safeUrl('not a url at all')).toBeNull();
+  });
+
+  it('A10: protocol-relative URL ("//example.com") gets https prepended -- no "://" present', () => {
+    expect(safeUrl('//example.com')).toBe('https://example.com/');
+  });
+
+  it('A11: "example.com:8080" returns null -- URL constructor parses scheme as "example.com:" without throwing, so prepend path is never reached', () => {
+    // new URL('example.com:8080') succeeds but yields protocol 'example.com:',
+    // which is not http: or https:. The catch block is not entered, so the
+    // prepend path is skipped and the function returns null.
+    expect(safeUrl('example.com:8080')).toBeNull();
+  });
+});

--- a/test/verify-page.test.js
+++ b/test/verify-page.test.js
@@ -190,6 +190,19 @@ describe('security', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Regression: Fix 2 -- eIDAS reference uses "Article 41" not "Art. 41"
+// ---------------------------------------------------------------------------
+
+describe('htmlVerifyResponse -- eIDAS reference wording (Fix 2 regression)', () => {
+  it('uses "Article 41" not "Art." for eIDAS references', async () => {
+    const res = htmlVerifyResponse(TEST_ID, TEST_ORIGIN, TEST_CC);
+    const html = await res.text();
+    expect(html).not.toContain('Art. 41');
+    expect(html).toContain('Article 41');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Design system tokens
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Three small UI bug fixes shipped as a single phase:

1. **URL auto-prepend** (#179): `safeUrl()` in the capture form now auto-prepends `https://` to bare hostnames (e.g., `example.com` → `https://example.com`). Guarded by `://` check to avoid mangling partial schemes like `htt://`.

2. **Verify page text** (#180): "eIDAS Art. 41" corrected to "eIDAS Article 41" on the verify page.

3. **Billing page spacing** (#183): Added `display: block` to `.billing-stat-value` and `.billing-stat-label` spans so the existing `margin-top` creates visible spacing between numbers and labels.

## Key Design Decisions

- **Inline modification over separate normalizeUrl()**: safeUrl() is a 7-line function with a single caller. Extraction adds complexity without clarity.
- **display: block over flexbox**: Minimal change that makes existing margin-top work. Flexbox on the parent changes more properties than needed.
- **Dropped urlInput.value visual feedback**: Per ux-strategy review, the field clears too fast for the update to be visible.

## Test Plan

- [x] 11 new safeUrl() test cases covering: valid URLs, bare hostnames, partial schemes, dangerous schemes, protocol-relative, port edge case
- [x] Regression assertion: verify page contains "Article 41", not "Art. 41"
- [x] Regression assertions: billing stat spans have `display: block`
- [x] Full test suite: 1444 pass, 2 skipped, 0 failures
- [x] Code review: APPROVE (3 NITs, non-blocking)

Resolves #185
Closes #179, closes #180, closes #183
