### PR TITLE
feat: change detection and visual diffing (R37)

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -197,7 +197,10 @@ Deferred items with explicit activation triggers. Revisit when condition is met.
 |------|-----------|--------|
 | ~~[consider] Scheduled captures (cron-style)~~ | ~~When a user requests recurring capture~~ -- DONE (Phase 0059): CRUD API, Cron Trigger fan-out, per-tenant limits, web UI panel, 55 tests (Issue #107) | MVP.md |
 | [consider] Watch lists / bulk monitoring | Requires scheduling (also parked) | MVP.md |
-| [consider] Change detection / diffing | Requires multiple captures over time; no demand | MVP.md |
+| ~~[consider] Change detection / diffing~~ | ~~Requires multiple captures over time~~ -- DONE (Phase 0067): Diff API endpoint, HTML text diff (diff-match-patch-es), screenshot hash comparison + client-side pixel diff, header diff, change badges on schedules/captures, visual diff UI with 3 comparison modes, webhook enrichment (Issue #115) | MVP.md |
+| [consider] Diff unit/integration tests | Add test/diff.test.js for diffHtml, diffHeaders, diffScreenshot, computeChangeSummary, plus integration test for handleDiffCaptures endpoint | Phase 0067, lucy |
+| [consider] Pipeline diff stats optimization | Extract stats-only diffHtml variant for capture completion pipeline where hunks are discarded | Phase 0067, margo |
+| [consider] Screenshot similarity score in API | Surface numeric similarity percentage (not just boolean changed) in diff API and webhook; may require Durable Object for memory | Phase 0067, prompt deviation |
 | ~~[consider] Notifications~~ | ~~When event-driven workflows needed~~ -- DONE (Phase 0072): 6 notification types (capture failure, approaching/reached free limit, invoice generated, payment failure, weekly digest), Resend email delivery, RFC 8058 unsubscribe, notification preferences API + UI tab, GitHub OAuth email auto-population (Issue #111) | MVP.md |
 | ~~[consider] Billing and quotas~~ | ~~When monetization actively planned~~ -- DONE (Phase 0056): usage-based free limit (100 captures/month without card, unlimited with card), pre-capture enforcement, usage dashboard, per-tenant D1 overrides (Issue #104). Pricing model: pure pay-per-capture, no subscriptions. | MVP.md |
 | ~~[consider] Capture ID recovery~~ | ~~Solved by R1; remove after R1 ships~~ -- Resolved: R1 shipped. | ux-strategy-minion, kickoff |

--- a/docs/evolution/0067-change-detection-diffing/decisions.md
+++ b/docs/evolution/0067-change-detection-diffing/decisions.md
@@ -1,0 +1,59 @@
+# Phase 0067: Decisions
+
+## D1: Screenshot diff approach — hash comparison over pixel diff
+
+**Chosen**: Server-side R2 etag hash comparison for API, client-side canvas pixel diff for UI only.
+
+**Over**: Server-side pixel comparison with pixelmatch (recommended by prompt).
+
+**Why**: Workers have ~128MB memory. Loading two full screenshots (potentially 5-10MB each) plus a pixelmatch diff buffer would risk OOM on large captures. R2 already computes etags for stored objects, so `head()` gives us change detection for free. The client-side canvas pixel diff in the UI gives users the visual comparison they need without server-side memory pressure. The tradeoff: the API returns a boolean `changed` instead of a `screenshotSimilarity: 0.97` numeric score. This was a deliberate constraint accepted during synthesis.
+
+**Impact**: Webhook consumers cannot threshold on similarity percentage — they get `changed: true/false` only. If numeric similarity is needed later, a separate endpoint using a Durable Object (with more memory) could compute it on demand.
+
+## D2: HTML diff library — diff-match-patch-es
+
+**Chosen**: `diff-match-patch-es@1.0.1` (ESM rewrite of Google's diff-match-patch).
+
+**Over**: Hand-rolling line-level diff, or using `fast-diff` (no semantic cleanup).
+
+**Why**: Character-level diff with semantic cleanup is non-trivial (~300 lines of algorithmic code). The library is 15KB minified, zero dependencies, Apache-2.0, and the underlying algorithm is 15+ years old (boring technology). The ESM variant is tree-shakeable. We use only 4 symbols: `diffMain`, `diffCleanupSemantic`, `DIFF_DELETE`, `DIFF_INSERT`. Version is pinned exactly (no caret).
+
+## D3: Change summary storage — JSON TEXT column on captures
+
+**Chosen**: `change_summary TEXT` column in D1 captures table, populated via `ctx.waitUntil()` after capture completion.
+
+**Over**: Separate diff_results table, or computing on-demand at read time.
+
+**Why**: The change summary is a small JSON blob (~100-200 bytes) tied 1:1 to a capture. A separate table adds join complexity for no benefit. Computing on-demand at list/read time would require fetching artifacts from R2 on every schedule list request — unacceptable latency. The `ctx.waitUntil()` pattern means the summary computation doesn't block the capture response.
+
+## D4: HTML diff size guard — 2MB limit with truncation flag
+
+**Chosen**: If either HTML artifact exceeds 2MB, skip diff and return `{ changed: true, truncated: true, stats: { additions: 0, deletions: 0 }, hunks: [] }`.
+
+**Over**: Streaming diff, or no limit (risk CPU timeout).
+
+**Why**: Workers have 60s CPU time. `diff-match-patch` on two 5MB HTML documents could easily exceed that. The 2MB guard provides a predictable upper bound. The `truncated` flag tells the consumer that the diff was not computed rather than silently returning incomplete results. Additionally, hunks are capped at 200 per diff to bound response size.
+
+## D5: UI diff view — three screenshot comparison modes
+
+**Chosen**: Tabbed interface with side-by-side, overlay slider, and canvas pixel diff.
+
+**Over**: Single comparison mode, or server-rendered diff image.
+
+**Why**: Different comparison modes serve different use cases. Side-by-side is good for layout changes, overlay slider reveals subtle pixel differences, and canvas pixel diff highlights the exact changed regions. All three are client-side only (no server resources needed). The ARIA tablist pattern ensures keyboard/screen-reader accessibility.
+
+## D6: Schedule list enrichment — LEFT JOIN for change badges
+
+**Chosen**: `LEFT JOIN captures c ON s.last_capture_id = c.id` in `listSchedules()` query.
+
+**Over**: Separate API call per schedule, or denormalizing change_summary onto schedules table.
+
+**Why**: The join is on `last_capture_id` (primary key), so performance cost is negligible. Denormalizing would create a data consistency problem (two places to update). A separate API call per schedule would be N+1 queries. The LEFT JOIN is the standard relational approach.
+
+## D7: API response design — include parameter for selective sections
+
+**Chosen**: `?include=html,screenshot,headers` query parameter controlling which diff sections are computed and returned.
+
+**Over**: Always computing all sections, or separate endpoints per section type.
+
+**Why**: The diff endpoint fetches artifacts from R2. If the consumer only needs header comparison, there's no reason to fetch and diff 2MB of HTML. Separate endpoints would fragment the API. The `include` parameter gives consumers control while keeping a single endpoint. The summary is always returned regardless of `include` selection.

--- a/docs/evolution/0067-change-detection-diffing/outcome.md
+++ b/docs/evolution/0067-change-detection-diffing/outcome.md
@@ -1,0 +1,65 @@
+# Phase 0067: Outcome
+
+## What was built
+
+Change detection and visual diffing for WRL captures — the ability to compare two captures of the same URL and surface structured differences across HTML content, screenshots, and HTTP headers.
+
+### New files
+- `src/diff.js` (244 lines) — Pure computation module: `diffHtml()`, `diffHeaders()`, `diffScreenshot()`, `computeChangeSummary()`
+- `src/ui/ui-diff.js` (908 lines) — Visual diff view with three screenshot comparison modes, HTML hunk display, and header comparison table
+- `migrations/0015_change_summary.sql` — Adds `change_summary TEXT` column to captures table
+
+### Modified files
+- `src/index.js` (+293 lines) — `handleDiffCaptures` endpoint handler, change summary computation in capture completion pipeline
+- `src/db.js` (+52 lines) — `getPreviousCaptureId()`, `setChangeSummary()`, change_summary in `rowToCapture`/`rowToSchedule`, LEFT JOIN in `listSchedules()`
+- `src/webhook-dispatch.js` (+16 lines) — `changeDetection` field in `capture.complete` webhook payload
+- `src/ui/ui-css.js` (+395 lines) — Diff-specific CSS (code blocks, gutters, overlay slider, header tables, change badges)
+- `src/ui/ui-detail.js` (+22 lines) — "Compare with previous capture" link
+- `src/ui/ui-schedules.js` (+18 lines) — Changed/Unchanged badges on schedule list
+- `src/ui/ui-shell.js` (+13 lines) — Diff view route
+- `src/ui/ui-submit.js` (+21 lines) — Change badges on capture list items
+- `openapi.yaml` — Full schema for `GET /v1/captures/{baseId}/diff/{targetId}`
+- `package.json` — Added `diff-match-patch-es@1.0.1`
+
+### Totals
+- 13 files changed, ~2000 lines added
+- 1 new dependency (zero transitive)
+- 1 D1 migration
+- All 1449 existing tests pass
+
+## Success criteria coverage
+
+| Criterion | Status | Notes |
+|-----------|--------|-------|
+| Diff endpoint returns structured response | Done | `GET /v1/captures/{id1}/diff/{id2}` |
+| HTML text-level diff with line context | Done | Character-level via diff-match-patch, grouped into hunks with context |
+| Screenshot visual diff | Done | Server: hash comparison. Client: canvas pixel diff with 8MP guard |
+| Header diff (add/remove/change) | Done | Key-value comparison with status code change detection |
+| Diff summary in response | Done | `{ changed, sections: { html, screenshot, headers } }` |
+| Changed badge on schedule list | Done | LEFT JOIN enrichment, links to diff view |
+| Visual diff view in web UI | Done | Three modes: side-by-side, overlay slider, pixel diff |
+| Webhook includes change flag | Done | `changeDetection: { changed, summary }` in `capture.complete` |
+| CPU-bounded diffing | Done | 2MB size limit, 200 hunk cap, 5s timeout guard |
+| Auth: read scope, tenant isolation | Done | 401 without auth, 404 for cross-tenant |
+
+## Deviations from prompt
+
+1. **screenshotSimilarity numeric score** — The prompt specified `screenshotSimilarity: 0.97` in the summary. The implementation returns a boolean `changed` field instead. This was a deliberate decision: server-side pixel comparison would exceed Workers memory limits. The client-side canvas diff does compute a percentage, but it's not surfaced in the API.
+
+2. **Screenshot diff method** — The prompt specified "pixel-level visual diff with highlighted regions, returned as image." The implementation does hash comparison server-side and pixel diff client-side only. No diff image is returned from the API — the visual diff is rendered in the browser.
+
+## What was not built (explicitly out of scope)
+
+- Semantic diffing (understanding what changed means)
+- DOM-level structural diff
+- CSS diff / JavaScript behavior diff
+- Diff history/timeline view
+- Configurable change thresholds
+- Diff-specific test file (documented as deferred — see backlog)
+
+## Backlog changes
+
+- ~~R37: Change detection and diffing~~ — **Done** (this phase)
+- **Added**: Diff unit/integration tests — `test/diff.test.js` covering `diffHtml`, `diffHeaders`, `diffScreenshot`, `computeChangeSummary`, and at least one integration test for `handleDiffCaptures` (flagged by lucy review)
+- **Added**: Pipeline diff optimization — Extract stats-only variant of `diffHtml` for the capture completion pipeline where hunks are discarded (flagged by margo review)
+- **Added**: Screenshot similarity score — Optional future enhancement to surface numeric similarity percentage in API/webhook responses, likely via Durable Object with more memory budget

--- a/docs/evolution/0067-change-detection-diffing/process.md
+++ b/docs/evolution/0067-change-detection-diffing/process.md
@@ -1,0 +1,90 @@
+# Phase 0067: Process
+
+## TL;DR
+
+Five-task nefario orchestration delivered change detection and visual diffing across 13 files (+2000 lines) in three execution batches. The most consequential design decision — server-side hash comparison instead of pixel-level screenshot diff — was driven by Worker memory constraints and survived all review phases. Three code review findings were auto-fixed. All 1449 existing tests pass. No new test file was written (deferred to backlog).
+
+## Team composition
+
+### Planning specialists (Phase 2)
+- **data-minion**: D1 schema design, migration strategy, query patterns for change summary storage
+- **api-design-minion**: Diff endpoint design, response schema, `include` parameter for selective sections
+- **frontend-minion**: Visual diff UI architecture, screenshot comparison modes, vanilla JS DOM patterns
+- **security-minion**: Auth model for diff endpoint, cross-tenant isolation, XSS prevention in diff rendering
+
+### Architecture reviewers (Phase 3.5)
+- **security-minion**: APPROVE — no new attack surface, textContent used throughout
+- **test-minion**: ADVISE — flagged missing test coverage for diff module
+- **ux-strategy-minion**: APPROVE — three comparison modes serve different user jobs-to-be-done
+- **lucy**: ADVISE — screenshotSimilarity descoped from prompt, missing tests
+- **margo**: ADVISE — pipeline optimization opportunity (computing full hunks when only stats needed)
+
+### Code reviewers (Phase 5)
+- **code-review-minion**: ADVISE — 5 advisory + 3 nit findings
+- **lucy**: ADVISE — requirements traceability verified, 2 compliance items
+- **margo**: ADVISE — complexity proportional, 1 pipeline optimization advisory
+
+## Execution structure
+
+Three batches with approval gates:
+
+1. **Batch 1** (data-minion): Migration `0015_change_summary.sql`, `src/diff.js` pure computation module, DB functions (`getPreviousCaptureId`, `setChangeSummary`)
+2. **Batch 2** (api-design-minion): `handleDiffCaptures` endpoint in `src/index.js`, change summary computation in queue consumer via `ctx.waitUntil`, webhook enrichment in `src/webhook-dispatch.js`
+3. **Batch 3** (frontend-minion): Visual diff view (`ui-diff.js`), CSS, routes, change badges on schedules/captures/detail views, schedule list enrichment via LEFT JOIN
+
+## Key conflicts and resolutions
+
+### Screenshot diff: pixel vs hash
+
+The prompt specified "pixel-level visual diff with highlighted regions, returned as image." The synthesis resolved this as:
+
+- **Server-side**: Hash comparison only (R2 etag, no image loading). Argued by security-minion and margo — loading two screenshots into Worker memory risks OOM.
+- **Client-side**: Canvas pixel diff in browser for the visual comparison. Argued by frontend-minion — the browser has ample memory and can display the result directly.
+- **API response**: Boolean `changed` instead of numeric `screenshotSimilarity`. This is a deliberate deviation from the prompt's example response shape.
+
+This decision survived all review phases. Lucy flagged the deviation but accepted the rationale.
+
+### diff-match-patch-es vs alternatives
+
+data-minion and api-design-minion both recommended `diff-match-patch-es`. margo reviewed the dependency and confirmed it justified: character-level diff with semantic cleanup cannot be done in 10 lines of vanilla code. The library is 15KB, zero dependencies, based on a 15-year-old algorithm.
+
+### HTML size guard and truncation
+
+api-design-minion proposed the 2MB guard with `truncated: true` flag. This was uncontested — everyone agreed that unbounded diffing in a Workers environment is untenable. The 200-hunk cap was added during synthesis as an additional safety valve for response size.
+
+## Human interventions
+
+This was an autonomous orchestration (no human at the gate). Lucy agents handled all approvals:
+
+- **Team approval**: Approved as proposed
+- **Reviewer approval**: 5 mandatory reviewers, no discretionary additions
+- **Execution plan**: Approved — 5 tasks, 2 gates, 3 batches
+- **Gate 1** (data layer): Auto-approved, "Run all" for post-execution
+- **Gate 2** (API + pipeline): Auto-approved, "Run all" for post-execution
+- **Gate 3** (UI): Auto-approved after fixing API response field mismatches
+
+## What was NOT intervened on
+
+- The screenshotSimilarity deviation was accepted without override
+- Lucy's test coverage advisory was accepted as deferred (backlog item, not blocking)
+- Margo's pipeline optimization advisory was accepted as deferred (backlog item)
+- The 908-line ui-diff.js was accepted — proportional to the most complex existing UI views
+
+## Code review auto-fixes
+
+Three findings from code-review-minion were fixed immediately:
+
+1. **etag inconsistency**: Queue consumer used `.httpEtag` (quoted) while API handler used `.etag` (unquoted). Standardized on `.etag`.
+2. **Overlay listener accumulation**: `initOverlaySlider()` attached document-level event listeners on every tab activation without cleanup. Added initialization guard.
+3. **Duplicate VERIFICATION_BASE_URL**: Webhook dispatch computed the URL base twice. Reused existing `base` variable.
+
+## Context challenges
+
+The session hit context compaction during Phase 4 Batch 3. The frontend-minion agent was spawned as a background task before compaction, and the agent reference was lost after compaction. The agent had partially completed — creating all UI files with routes, CSS, badges, and compare links — but `ui-diff.js` had API response field mismatches (the normaliser function existed but was never called in mountDiff, and some field names didn't match the API response structure). These were fixed directly in the main session rather than re-spawning the agent.
+
+## Where to read more
+
+- **Full specialist discussions**: Scratch files were in `/tmp/nefario-scratch-*/change-detection-diffing/` (cleaned up at wrap-up)
+- **Decisions with rationale**: `docs/evolution/0067-change-detection-diffing/decisions.md`
+- **Outcomes and deviations**: `docs/evolution/0067-change-detection-diffing/outcome.md`
+- **Backlog updates**: `docs/backlog.md` — 3 new deferred items from review findings

--- a/docs/evolution/0067-change-detection-diffing/prompt.md
+++ b/docs/evolution/0067-change-detection-diffing/prompt.md
@@ -1,0 +1,32 @@
+# Phase 0067: Change Detection and Diffing
+
+## Source
+
+GitHub Issue: #115 — R37: Change detection and diffing
+
+## Task Description
+
+**Outcome**: WRL can compare two captures of the same URL and surface what changed. A diff endpoint returns structured differences across HTML content, screenshots, and HTTP headers. Scheduled capture lists show changed/unchanged badges, the web UI renders visual diffs, and webhook payloads include change detection summaries.
+
+**Success criteria**:
+- Diff endpoint: `GET /v1/captures/{id1}/diff/{id2}` returns structured diff response
+- HTML diff: text-level diff (additions, deletions, modifications) with line context
+- Screenshot diff: pixel-level visual diff with highlighted regions, returned as image
+- Header diff: key-value comparison showing added, removed, and changed headers
+- Diff response includes summary: `{ changed: true, htmlChanges: 42, screenshotSimilarity: 0.97 }`
+- Capture list for scheduled URLs includes `changed` badge (compared to previous capture)
+- Web UI renders visual diff view: side-by-side screenshots with highlighted differences
+- Webhook payload includes `changed: true/false` and diff summary when capture is part of a schedule
+- Diff computation runs within Workers CPU limits (no unbounded diffing of large pages)
+- Auth: diff endpoint requires `read` scope, both captures must belong to the requesting tenant
+
+**Scope**:
+- In: Diff API endpoint, HTML text diff, screenshot visual diff, header diff, change badge in capture list, visual diff in web UI, change flag in webhooks
+- Out: Semantic diffing (understanding what changed means), DOM-level structural diff, CSS diff, JavaScript behavior diff, diff history/timeline view, configurable change thresholds
+
+**Constraints**:
+- Depends on R28 (scheduled captures provide the "compare to previous" use case)
+- Depends on R30 (D1 for efficient lookup of previous capture for same URL)
+- Screenshot diff must work within Workers memory limits -- consider server-side pixel comparison or client-side rendering
+- HTML diff library must be lightweight; evaluate `diff-match-patch` or similar
+- Large pages may need truncation with a `truncated: true` flag in the response

--- a/docs/evolution/README.md
+++ b/docs/evolution/README.md
@@ -84,3 +84,4 @@ software development.
 | [0079-homepage-pricing-screenshot-quality](0079-homepage-pricing-screenshot-quality/) | Homepage pricing update and screenshot quality: real graduated tier pricing, deviceScaleFactor 2→4 (Issues #182, #184) |
 | [0065-api-versioning](0065-api-versioning/) | API versioning and stability commitment: v1.0.0, CHANGELOG.md, DEPRECATION-POLICY.md, CI enforcement, WRL-API-Version header (Issue #113) |
 | [0066-mcp-directory-listings](0066-mcp-directory-listings/) | MCP directory listings and ecosystem: server.json registry update, Glama/MCP.so/awesome-lists submissions, doc bug fixes, 6 client integration examples (Issue #114) |
+| [0067-change-detection-diffing](0067-change-detection-diffing/) | Change detection and diffing: diff API endpoint, HTML text diff (diff-match-patch-es), screenshot hash + client pixel diff, header diff, change badges, visual diff UI with 3 modes, webhook enrichment (Issue #115) |

--- a/migrations/0015_change_summary.sql
+++ b/migrations/0015_change_summary.sql
@@ -1,0 +1,5 @@
+-- Add change summary for scheduled capture change detection.
+-- JSON column populated asynchronously at capture completion time.
+-- NULL for non-scheduled captures, first-in-schedule captures, or
+-- captures completed before this migration.
+ALTER TABLE captures ADD COLUMN change_summary TEXT;

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3068,6 +3068,234 @@ paths:
         '503':
           $ref: '#/components/responses/Problem503'
 
+  /v1/captures/{baseId}/diff/{targetId}:
+    get:
+      operationId: diffCaptures
+      summary: Compare two captures
+      description: >
+        Returns structured differences between two captures of the same URL.
+        Compares HTML content (text-level diff with line context), screenshots
+        (hash-based similarity), and HTTP response headers (added, removed, modified).
+        Both captures must belong to the requesting tenant. The `include` query
+        parameter controls which diff sections are computed; omitted sections
+        still appear in the summary with cached or default values.
+      tags: [captures]
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: baseId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/CaptureId'
+          description: ID of the base (older) capture.
+        - name: targetId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/CaptureId'
+          description: ID of the target (newer) capture.
+        - name: include
+          in: query
+          required: false
+          schema:
+            type: string
+            default: html,screenshot,headers
+          description: >
+            Comma-separated list of diff sections to compute. Valid values:
+            `html`, `screenshot`, `headers`. Sections not listed are omitted
+            from the response body but still reflected in the summary.
+      responses:
+        '200':
+          description: Structured diff response.
+          headers:
+            Strict-Transport-Security:
+              $ref: '#/components/headers/StrictTransportSecurity'
+            Link:
+              $ref: '#/components/headers/TermsLink'
+            WRL-API-Version:
+              $ref: '#/components/headers/WRLAPIVersion'
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [base, target, summary]
+                properties:
+                  base:
+                    type: object
+                    required: [id, url, createdAt]
+                    properties:
+                      id:
+                        $ref: '#/components/schemas/CaptureId'
+                      url:
+                        type: string
+                        format: uri
+                      createdAt:
+                        type: string
+                        format: date-time
+                  target:
+                    type: object
+                    required: [id, url, createdAt]
+                    properties:
+                      id:
+                        $ref: '#/components/schemas/CaptureId'
+                      url:
+                        type: string
+                        format: uri
+                      createdAt:
+                        type: string
+                        format: date-time
+                  summary:
+                    type: object
+                    required: [changed, sections]
+                    properties:
+                      changed:
+                        type: boolean
+                        description: True if any section detected changes.
+                      sections:
+                        type: object
+                        properties:
+                          html:
+                            type: object
+                            properties:
+                              changed:
+                                type: boolean
+                              additions:
+                                type: integer
+                              deletions:
+                                type: integer
+                          screenshot:
+                            type: object
+                            properties:
+                              changed:
+                                type: boolean
+                          headers:
+                            type: object
+                            properties:
+                              changed:
+                                type: boolean
+                              added:
+                                type: integer
+                              removed:
+                                type: integer
+                              modified:
+                                type: integer
+                  html:
+                    type: object
+                    description: Present only when `html` is in the `include` parameter.
+                    properties:
+                      changed:
+                        type: boolean
+                      truncated:
+                        type: boolean
+                        description: True if HTML was too large and diff was skipped.
+                      stats:
+                        type: object
+                        properties:
+                          additions:
+                            type: integer
+                          deletions:
+                            type: integer
+                      hunks:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            type:
+                              type: string
+                              enum: [addition, deletion]
+                            value:
+                              type: string
+                            context:
+                              type: object
+                              properties:
+                                before:
+                                  type: string
+                                after:
+                                  type: string
+                  screenshot:
+                    type: object
+                    description: Present only when `screenshot` is in the `include` parameter.
+                    properties:
+                      changed:
+                        type: boolean
+                      method:
+                        type: string
+                        enum: [hash]
+                        description: Always `hash` — server-side etag comparison.
+                  headers:
+                    type: object
+                    description: Present only when `headers` is in the `include` parameter.
+                    properties:
+                      changed:
+                        type: boolean
+                      added:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            targetValue:
+                              type: string
+                      removed:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            baseValue:
+                              type: string
+                      modified:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            baseValue:
+                              type: string
+                            targetValue:
+                              type: string
+                      unchanged:
+                        type: integer
+                        description: Count of headers present in both captures with identical values.
+                      statusChanged:
+                        type: boolean
+              examples:
+                changed:
+                  summary: Captures with detected changes
+                  value:
+                    base: {id: 'cap_a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6', url: 'https://example.com', createdAt: '2025-01-01T00:00:00.000Z'}
+                    target: {id: 'cap_b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7', url: 'https://example.com', createdAt: '2025-01-02T00:00:00.000Z'}
+                    summary: {changed: true, sections: {html: {changed: true, additions: 3, deletions: 1}, screenshot: {changed: true}, headers: {changed: false, added: 0, removed: 0, modified: 0}}}
+                    html: {changed: true, truncated: false, stats: {additions: 3, deletions: 1}, hunks: [{type: addition, value: '<p>New paragraph</p>', context: {before: '<div>', after: '</div>'}}]}
+                    screenshot: {changed: true, method: hash}
+                    headers: {changed: false, added: [], removed: [], modified: [], unchanged: 12, statusChanged: false}
+                unchanged:
+                  summary: Identical captures
+                  value:
+                    base: {id: 'cap_a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6', url: 'https://example.com', createdAt: '2025-01-01T00:00:00.000Z'}
+                    target: {id: 'cap_b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7', url: 'https://example.com', createdAt: '2025-01-02T00:00:00.000Z'}
+                    summary: {changed: false, sections: {html: {changed: false, additions: 0, deletions: 0}, screenshot: {changed: false}, headers: {changed: false, added: 0, removed: 0, modified: 0}}}
+        '401':
+          $ref: '#/components/responses/Problem401'
+        '404':
+          description: One or both captures not found, not yet complete, or not owned by the requesting tenant.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+              examples:
+                notFound:
+                  summary: Capture not found or cross-tenant
+                  value: {type: about:blank, status: 404, title: Not Found, detail: One or both captures not found.}
+        '429':
+          $ref: '#/components/responses/Problem429'
+        '503':
+          $ref: '#/components/responses/Problem503'
+
   /v1/verify/{captureId}:
     get:
       operationId: verifyCapture

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,19 @@
 {
   "name": "wrl",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wrl",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@cloudflare/playwright": "^1.1.2",
         "@duckduckgo/autoconsent": "^14.63.0",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "croner": "^10.0.1",
+        "diff-match-patch-es": "1.0.1",
         "pdf-lib": "1.17.1",
         "zod": "^4.3.6"
       },
@@ -3504,6 +3505,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/diff-match-patch-es": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/diff-match-patch-es/-/diff-match-patch-es-1.0.1.tgz",
+      "integrity": "sha512-KhSofrZDERg/NE6Nd+TK53knp2qz0o2Ix8rhkXd3Chfm7Wlo58Eq/juNmkyS6bS+3xS26L3Pstz3BdY/q+e9UQ==",
+      "license": "Apache-2.0",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/diff-sequences": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@duckduckgo/autoconsent": "^14.63.0",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "croner": "^10.0.1",
+    "diff-match-patch-es": "1.0.1",
     "pdf-lib": "1.17.1",
     "zod": "^4.3.6"
   }

--- a/src/db.js
+++ b/src/db.js
@@ -75,6 +75,7 @@ function rowToCapture(row) {
     quarantinedAt: row.quarantined_at ?? null,
     lastThreatCheckAt: row.last_threat_check_at ?? null,
     threatCheck: row.threat_check ?? null,
+    changeSummary: row.change_summary ? JSON.parse(row.change_summary) : null,
   };
 }
 
@@ -1776,4 +1777,48 @@ export async function listCapturesNeedingThreatCheck(db, olderThan, limit = 500)
     url: row.url,
     tenantId: row.tenant_id,
   }));
+}
+
+// ---------------------------------------------------------------------------
+// Change detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Find the most recent complete capture for a schedule created before the
+ * given capture. Uses two sequential queries to avoid OFFSET-based fragility
+ * with historical data.
+ *
+ * @param {D1Database} db
+ * @param {string} scheduleId
+ * @param {string} captureId  The current capture to look behind
+ * @returns {Promise<string|null>}  The previous capture's ID, or null if none
+ */
+export async function getPreviousCaptureId(db, scheduleId, captureId) {
+  const current = await db.prepare(
+    'SELECT created_at FROM captures WHERE id = ?',
+  ).bind(captureId).first();
+  if (!current) return null;
+
+  const previous = await db.prepare(
+    `SELECT id FROM captures
+     WHERE schedule_id = ? AND status = 'complete' AND created_at < ?
+     ORDER BY created_at DESC LIMIT 1`,
+  ).bind(scheduleId, current.created_at).first();
+
+  return previous?.id ?? null;
+}
+
+/**
+ * Persist a JSON change summary on a capture record. Called asynchronously
+ * after capture completion once the diff has been computed.
+ *
+ * @param {D1Database} db
+ * @param {string} captureId
+ * @param {object} summary  Plain JS object matching the change_summary JSON schema
+ * @returns {Promise<void>}
+ */
+export async function setChangeSummary(db, captureId, summary) {
+  await db.prepare(
+    'UPDATE captures SET change_summary = ? WHERE id = ?',
+  ).bind(JSON.stringify(summary), captureId).run();
 }

--- a/src/db.js
+++ b/src/db.js
@@ -1458,6 +1458,7 @@ function rowToSchedule(row) {
     lastRunAt: row.last_run_at ?? null,
     lastCaptureId: row.last_capture_id ?? null,
     lastCaptureStatus: row.last_capture_status ?? null,
+    changeSummary: row.change_summary ? JSON.parse(row.change_summary) : null,
     createdAt: row.created_at,
     updatedAt: row.updated_at ?? null,
   };
@@ -1515,7 +1516,11 @@ export async function getSchedule(db, id, tenantId) {
  */
 export async function listSchedules(db, tenantId) {
   const rows = await db.prepare(
-    'SELECT * FROM schedules WHERE tenant_id = ? ORDER BY created_at DESC',
+    `SELECT s.*, c.change_summary
+     FROM schedules s
+     LEFT JOIN captures c ON s.last_capture_id = c.id
+     WHERE s.tenant_id = ?
+     ORDER BY s.created_at DESC`,
   ).bind(tenantId).all();
   return (rows.results ?? []).map(rowToSchedule);
 }

--- a/src/diff.js
+++ b/src/diff.js
@@ -1,0 +1,244 @@
+// tva
+import { diffMain, diffCleanupSemantic, DIFF_DELETE, DIFF_INSERT } from 'diff-match-patch-es';
+
+// SECURITY: content fields contain raw captured HTML. Render with textContent only.
+
+const SIZE_LIMIT = 2 * 1024 * 1024; // 2 MB
+const CONTEXT_LINES = 3;
+const CONTEXT_GAP = 6;
+const MAX_HUNKS = 200;
+
+
+/**
+ * Convert a flat char-level diff array into line-based hunks with context.
+ *
+ * @param {Array<[number, string]>} diffs
+ * @returns {{ hunks: Array, stats: { additions: number, deletions: number }, truncated: boolean }}
+ */
+function buildHunks(diffs) {
+  // Expand diffs into per-line records
+  const lines = [];
+  let baseLine = 1;
+  let targetLine = 1;
+
+  for (const [type, text] of diffs) {
+    const parts = text.split('\n');
+    for (let i = 0; i < parts.length; i++) {
+      // Every split except the last represents a complete line; the last
+      // may be a partial line that will be continued by the next diff chunk.
+      // We emit a record for each newline-terminated segment.
+      const isLast = i === parts.length - 1;
+      const content = isLast ? parts[i] : parts[i] + '\n';
+      if (!isLast || content !== '') {
+        if (type === DIFF_DELETE) {
+          lines.push({ type: 'deletion', content, baseLine: baseLine++, targetLine: null });
+        } else if (type === DIFF_INSERT) {
+          lines.push({ type: 'addition', content, baseLine: null, targetLine: targetLine++ });
+        } else {
+          lines.push({ type: 'context', content, baseLine: baseLine++, targetLine: targetLine++ });
+        }
+      }
+    }
+  }
+
+  // Identify indices of changed lines
+  const changedIndices = new Set();
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].type !== 'context') changedIndices.add(i);
+  }
+
+  if (changedIndices.size === 0) {
+    return { hunks: [], stats: { additions: 0, deletions: 0 }, truncated: false };
+  }
+
+  // Build inclusion windows: changed index ± CONTEXT_LINES
+  const included = new Set();
+  for (const idx of changedIndices) {
+    for (let d = -CONTEXT_LINES; d <= CONTEXT_LINES; d++) {
+      const j = idx + d;
+      if (j >= 0 && j < lines.length) included.add(j);
+    }
+  }
+
+  // Group included indices into hunks; a gap > CONTEXT_GAP starts a new hunk
+  const sorted = [...included].sort((a, b) => a - b);
+  const groups = [];
+  let current = [sorted[0]];
+  for (let i = 1; i < sorted.length; i++) {
+    if (sorted[i] - sorted[i - 1] > CONTEXT_GAP) {
+      groups.push(current);
+      current = [sorted[i]];
+    } else {
+      current.push(sorted[i]);
+    }
+  }
+  groups.push(current);
+
+  // Count changed lines
+  let additions = 0;
+  let deletions = 0;
+  for (const line of lines) {
+    if (line.type === 'addition') additions++;
+    else if (line.type === 'deletion') deletions++;
+  }
+
+  let truncated = false;
+  let hunkList = groups;
+  if (hunkList.length > MAX_HUNKS) {
+    hunkList = hunkList.slice(0, MAX_HUNKS);
+    truncated = true;
+  }
+
+  const hunks = hunkList.map((group) => {
+    const first = lines[group[0]];
+    return {
+      baseLine: first.baseLine ?? first.targetLine,
+      targetLine: first.targetLine ?? first.baseLine,
+      lines: group.map((idx) => ({
+        type: lines[idx].type,
+        content: lines[idx].content,
+      })),
+    };
+  });
+
+  return { hunks, stats: { additions, deletions }, truncated };
+}
+
+/**
+ * Diff two HTML strings at character level using diff-match-patch.
+ *
+ * @param {string} baseHtml
+ * @param {string} targetHtml
+ * @returns {{ changed: boolean, truncated: boolean, stats: { additions: number, deletions: number }, hunks: Array }}
+ */
+export function diffHtml(baseHtml, targetHtml) {
+  if (baseHtml === targetHtml) {
+    return { changed: false, truncated: false, stats: { additions: 0, deletions: 0 }, hunks: [] };
+  }
+
+  if (baseHtml.length > SIZE_LIMIT || targetHtml.length > SIZE_LIMIT) {
+    return {
+      changed: true,
+      truncated: true,
+      stats: { additions: 0, deletions: 0 },
+      hunks: [],
+    };
+  }
+
+  const diffs = diffMain(baseHtml, targetHtml, { diffTimeout: 5 });
+  diffCleanupSemantic(diffs);
+
+  const { hunks, stats, truncated } = buildHunks(diffs);
+
+  return {
+    changed: stats.additions > 0 || stats.deletions > 0,
+    truncated,
+    stats,
+    hunks,
+  };
+}
+
+/**
+ * Diff two header snapshots.
+ *
+ * @param {{ status?: number, statusText?: string, headers?: Record<string, string> }} baseHeaders
+ * @param {{ status?: number, statusText?: string, headers?: Record<string, string> }} targetHeaders
+ * @returns {{ changed: boolean, added: Array, removed: Array, modified: Array, unchanged: number, statusChanged: boolean }}
+ */
+export function diffHeaders(baseHeaders, targetHeaders) {
+  const empty = { changed: false, added: [], removed: [], modified: [], unchanged: 0, statusChanged: false };
+
+  if (
+    !baseHeaders || typeof baseHeaders !== 'object' || !baseHeaders.headers ||
+    !targetHeaders || typeof targetHeaders !== 'object' || !targetHeaders.headers
+  ) {
+    return empty;
+  }
+
+  const baseH = baseHeaders.headers;
+  const targetH = targetHeaders.headers;
+
+  const statusChanged = baseHeaders.status !== targetHeaders.status;
+
+  const added = [];
+  const removed = [];
+  const modified = [];
+  let unchanged = 0;
+
+  const allKeys = new Set([...Object.keys(baseH), ...Object.keys(targetH)]);
+
+  for (const name of allKeys) {
+    const inBase = Object.prototype.hasOwnProperty.call(baseH, name);
+    const inTarget = Object.prototype.hasOwnProperty.call(targetH, name);
+
+    if (inBase && !inTarget) {
+      removed.push({ name, baseValue: baseH[name] });
+    } else if (!inBase && inTarget) {
+      added.push({ name, targetValue: targetH[name] });
+    } else if (baseH[name] !== targetH[name]) {
+      modified.push({ name, baseValue: baseH[name], targetValue: targetH[name] });
+    } else {
+      unchanged++;
+    }
+  }
+
+  const changed = statusChanged || added.length > 0 || removed.length > 0 || modified.length > 0;
+
+  return { changed, added, removed, modified, unchanged, statusChanged };
+}
+
+/**
+ * Compare two artifact hashes (SHA-256 hex or R2 ETag).
+ *
+ * @param {string|null|undefined} baseHash
+ * @param {string|null|undefined} targetHash
+ * @returns {{ changed: boolean, method: 'hash' }}
+ */
+export function diffScreenshot(baseHash, targetHash) {
+  const baseMissing = baseHash == null;
+  const targetMissing = targetHash == null;
+
+  if (baseMissing && targetMissing) {
+    return { changed: false, method: 'hash' };
+  }
+  if (baseMissing || targetMissing) {
+    return { changed: true, method: 'hash' };
+  }
+  return { changed: baseHash !== targetHash, method: 'hash' };
+}
+
+/**
+ * Aggregate individual diff results into a lightweight change summary.
+ *
+ * @param {{ changed: boolean, stats?: { additions: number, deletions: number } }} htmlDiff
+ * @param {{ changed: boolean, added?: Array, removed?: Array, modified?: Array }} headerDiff
+ * @param {{ changed: boolean }} screenshotDiff
+ * @returns {{ changed: boolean, html: object, screenshot: object, headers: object }}
+ */
+export function computeChangeSummary(htmlDiff, headerDiff, screenshotDiff) {
+  const htmlChanged = !!htmlDiff?.changed;
+  const headerChanged = !!headerDiff?.changed;
+  const screenshotChanged = !!screenshotDiff?.changed;
+
+  const headerChanges =
+    (headerDiff?.added?.length ?? 0) +
+    (headerDiff?.removed?.length ?? 0) +
+    (headerDiff?.modified?.length ?? 0) +
+    (headerDiff?.statusChanged ? 1 : 0);
+
+  return {
+    changed: htmlChanged || headerChanged || screenshotChanged,
+    html: {
+      changed: htmlChanged,
+      additions: htmlDiff?.stats?.additions ?? 0,
+      deletions: htmlDiff?.stats?.deletions ?? 0,
+    },
+    screenshot: {
+      changed: screenshotChanged,
+    },
+    headers: {
+      changed: headerChanged,
+      changes: headerChanges,
+    },
+  };
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,8 @@
 import { problemResponse, jsonResponse, batchItemSuccess, batchItemError } from './responses.js';
 import { verifyApiKey, verifyAdminKey } from './auth.js';
 import { validateUrl } from './url-validation.js';
-import { createCapture, getCapture, failCapture, listCaptures, listArchivedSigningKeys, TENANT_ID_RE, SCHEDULE_ID_RE, getTenantConfig, setTenantConfig, incrementUsage, setCaptureThreatCheck } from './db.js';
+import { createCapture, getCapture, failCapture, listCaptures, listArchivedSigningKeys, TENANT_ID_RE, SCHEDULE_ID_RE, getTenantConfig, setTenantConfig, incrementUsage, setCaptureThreatCheck, getPreviousCaptureId, setChangeSummary } from './db.js';
+import { diffHtml, diffHeaders, diffScreenshot, computeChangeSummary } from './diff.js';
 import { checkUrl, checkUrls } from './threat-check.js';
 import { rateLimitCounter } from './kv.js';
 import { performCapture } from './capture.js';
@@ -70,6 +71,7 @@ const routes = [
   ['GET',    /^\/v1\/captures\/(cap_[a-f0-9]{32})$/, handleGetCapture],
   ['GET',    /^\/v1\/captures\/(cap_[a-f0-9]{32})\/artifacts\/(screenshot-before|screenshot|html|headers|wacz)$/, handleGetCaptureArtifact],
   ['GET',    /^\/v1\/captures\/(cap_[a-f0-9]{32})\/certificate$/, handleGetCertificate],
+  ['GET',    /^\/v1\/captures\/(cap_[a-f0-9]{32})\/diff\/(cap_[a-f0-9]{32})$/, handleDiffCaptures],
   ['GET',    /^\/v1\/verify\/(cap_[a-f0-9]{32})$/, handleVerifyCapture],
   ['GET',    /^\/\.well-known\/signing-key$/, handleGetSigningKey],
   ['GET',    /^\/\.well-known\/signing-keys$/, handleGetSigningKeys],
@@ -243,6 +245,54 @@ async function handleCaptureMessage(msg, env, ctx) {
         }
       } catch (err) {
         log(env, 4, 'webhook', { event: 'webhook.dispatch_error', captureId, tenantId, errorCategory: 'unexpected', error: err.message });
+      }
+    })());
+    // Compute change summary for scheduled captures (non-blocking)
+    ctx.waitUntil((async () => {
+      try {
+        if (!scheduleId) return; // Only for scheduled captures
+        const previousId = await getPreviousCaptureId(env.DB, scheduleId, captureId);
+        if (!previousId) return; // First capture in schedule
+
+        // Fetch artifacts for hash/diff comparison
+        const [baseHtmlObj, targetHtmlObj, baseHeadersObj, targetHeadersObj] = await Promise.all([
+          env.BUCKET.get(`captures/${previousId}/rendered.html`),
+          env.BUCKET.get(`captures/${captureId}/rendered.html`),
+          env.BUCKET.get(`captures/${previousId}/headers.json`),
+          env.BUCKET.get(`captures/${captureId}/headers.json`),
+        ]);
+
+        // Screenshot: hash comparison via R2 head
+        const [baseScreenHead, targetScreenHead] = await Promise.all([
+          env.BUCKET.head(`captures/${previousId}/screenshot.png`),
+          env.BUCKET.head(`captures/${captureId}/screenshot.png`),
+        ]);
+
+        const screenshotDiff = diffScreenshot(
+          baseScreenHead?.httpEtag,
+          targetScreenHead?.httpEtag,
+        );
+
+        // HTML: lightweight diff for summary stats
+        let htmlDiff = { changed: false, stats: { additions: 0, deletions: 0 } };
+        if (baseHtmlObj && targetHtmlObj) {
+          const baseHtml = await baseHtmlObj.text();
+          const targetHtml = await targetHtmlObj.text();
+          htmlDiff = diffHtml(baseHtml, targetHtml);
+        }
+
+        // Headers
+        let headerDiff = { changed: false, added: [], removed: [], modified: [], unchanged: 0 };
+        if (baseHeadersObj && targetHeadersObj) {
+          headerDiff = diffHeaders(await baseHeadersObj.json(), await targetHeadersObj.json());
+        }
+
+        const summary = computeChangeSummary(htmlDiff, headerDiff, screenshotDiff);
+        summary.previousCaptureId = previousId;
+        await setChangeSummary(env.DB, captureId, summary);
+      } catch (err) {
+        // Graceful degradation: change_summary stays NULL, badge just does not show
+        log(env, 4, 'diff', { event: 'diff.summary_error', captureId, scheduleId, error: err?.message });
       }
     })());
     // 3b: Approaching free tier limit notification
@@ -1805,6 +1855,247 @@ async function handleGetCertificate(request, env, ctx, match) {
       'X-Signature-Key-Id': signingKeys.keyId,
     },
   });
+}
+
+// Authenticated endpoint -- requires read scope.
+// Compares two captures owned by the authenticated tenant and returns a
+// structured diff across HTML, screenshot, and headers.
+// Returns 404 (not 403) for cross-tenant or missing captures (no enumeration).
+// Returns 451 if either capture is quarantined.
+async function handleDiffCaptures(request, env, ctx, match) {
+  const start = Date.now();
+  const clientIp = request.headers.get('CF-Connecting-IP') || 'unknown';
+  const cip = await computeCip(env, clientIp);
+
+  // Step 1: Auth -- required, read scope.
+  // The fetch() gate runs optional auth for all /v1/captures/* GET routes.
+  // If credentials were absent, env._captureAuth is unset → enforce 401 here.
+  // If credentials were present but invalid, fetch() already returned 401.
+  const captureAuth = env._captureAuth;
+  if (!captureAuth) {
+    ctx.waitUntil(log(env, 5, 'security', { event: 'security.auth_fail', reason: 'missing_credentials', responseStatus: 401, cip }) ?? Promise.resolve());
+    return problemResponse(401, 'Authentication required.');
+  }
+  const { tenantId, authMethod } = captureAuth;
+  const keyName = null;
+  const keyHashPrefix = null;
+  // Re-assemble auth-like shape for checkCaptureRateLimit compatibility
+  const auth = { ok: true, tenantId, authMethod, keyName, keyHashPrefix, scopes: ['read'] };
+
+  ctx.waitUntil(
+    incrementUsage(env.DB, tenantId, { apiCalls: 1 })
+      .catch((err) => {
+        console.warn('wrl:usage_increment_fail', { tenantId, errorMessage: String(err?.message ?? '').slice(0, 128) });
+      })
+  );
+
+  // Step 2: Per-tenant rate limit (dual-layer for KV auth, IP-only for legacy)
+  const rl = await checkCaptureRateLimit(env, auth, clientIp, 'capture');
+  if (rl.exceeded) {
+    const limiter = rl.type === 'ip_guard' ? 'capture_per_ip_guard' : rl.type === 'ip' ? 'capture_per_ip' : 'capture_per_tenant';
+    ctx.waitUntil(log(env, 4, 'security', { event: 'security.rate_limit', limiter, tenantId, keyName, keyHashPrefix, authMethod, responseStatus: 429, cip }) ?? Promise.resolve());
+    if (rl.writePromise) ctx.waitUntil(rl.writePromise);
+    const retryAfter = String(rl.resetIn || 60);
+    const headers = { 'Retry-After': retryAfter };
+    if (rl.limit !== undefined) {
+      headers['X-RateLimit-Limit'] = String(rl.limit);
+      headers['X-RateLimit-Remaining'] = '0';
+      headers['X-RateLimit-Reset'] = retryAfter;
+    }
+    if (rl.type === 'tenant') {
+      return problemResponse(429, 'Per-tenant rate limit exceeded.', headers, { limitType: 'tenant' });
+    }
+    return problemResponse(429, 'Rate limit exceeded. Try again later.', headers);
+  }
+  if (rl.writePromise) ctx.waitUntil(rl.writePromise);
+
+  if (env.GLOBAL_CAPTURE_LIMITER) {
+    const { success } = await env.GLOBAL_CAPTURE_LIMITER.limit({ key: 'global' });
+    if (!success) {
+      ctx.waitUntil(log(env, 4, 'security', { event: 'security.capacity_limit', tenantId, keyName, keyHashPrefix, authMethod, responseStatus: 503, cip }) ?? Promise.resolve());
+      return problemResponse(503, 'Service is at capacity. Retry in 10 seconds.', { 'Retry-After': '10' });
+    }
+  }
+
+  // Step 3: Extract and validate capture IDs from route match
+  const id1 = match[1]; // base
+  const id2 = match[2]; // target
+
+  if (id1 === id2) {
+    return problemResponse(400, 'Cannot diff a capture with itself.');
+  }
+
+  // Step 4: Parse ?include query param
+  const url = new URL(request.url);
+  const VALID_SECTIONS = new Set(['summary', 'html', 'screenshot', 'headers']);
+  const rawInclude = url.searchParams.get('include') || 'summary,html,screenshot,headers';
+  const include = new Set(rawInclude.split(',').map((s) => s.trim()).filter(Boolean));
+
+  for (const section of include) {
+    if (!VALID_SECTIONS.has(section)) {
+      return problemResponse(400, `Unknown section: '${section}'. Valid values: summary, html, screenshot, headers.`);
+    }
+  }
+  // summary is always included
+  include.add('summary');
+
+  // Step 5: Fetch both capture records
+  const [base, target] = await Promise.all([
+    getCapture(env.DB, id1),
+    getCapture(env.DB, id2),
+  ]);
+
+  // Tenant isolation + existence + status checks -- identical 404 for all failure cases (no enumeration)
+  const notFound = problemResponse(404, 'Capture not found', { 'Cache-Control': 'no-store' });
+
+  if (!base || base.tenantId !== tenantId) return notFound;
+  if (!target || target.tenantId !== tenantId) return notFound;
+
+  // Check for quarantine before status check (451 takes precedence over 404)
+  if (base.status === 'quarantined' || target.status === 'quarantined') {
+    return problemResponse(451, 'Capture artifacts restricted due to content security policy', {
+      'Cache-Control': 'no-store',
+    });
+  }
+
+  if (base.status !== 'complete') return notFound;
+  if (target.status !== 'complete') return notFound;
+
+  // Step 6: Fetch artifacts from R2 for requested sections
+  let baseHtml = null;
+  let targetHtml = null;
+  let htmlTruncated = false;
+  let baseHeadersRaw = null;
+  let targetHeadersRaw = null;
+  let baseScreenshotHash = null;
+  let targetScreenshotHash = null;
+
+  const SIZE_GUARD = 2 * 1024 * 1024; // 2 MB
+
+  if (include.has('html')) {
+    const baseHtmlKey = base.artifacts?.html;
+    const targetHtmlKey = target.artifacts?.html;
+
+    if (baseHtmlKey && targetHtmlKey) {
+      // Size guard: use head() to avoid fetching large bodies unnecessarily
+      const [baseMeta, targetMeta] = await Promise.all([
+        env.BUCKET.head(baseHtmlKey),
+        env.BUCKET.head(targetHtmlKey),
+      ]);
+
+      if ((baseMeta?.size ?? 0) > SIZE_GUARD || (targetMeta?.size ?? 0) > SIZE_GUARD) {
+        htmlTruncated = true;
+      } else {
+        const [baseObj, targetObj] = await Promise.all([
+          env.BUCKET.get(baseHtmlKey),
+          env.BUCKET.get(targetHtmlKey),
+        ]);
+        if (baseObj) baseHtml = await baseObj.text();
+        if (targetObj) targetHtml = await targetObj.text();
+      }
+    }
+  }
+
+  if (include.has('headers')) {
+    const baseHeadersKey = base.artifacts?.headers;
+    const targetHeadersKey = target.artifacts?.headers;
+
+    const [baseHeadersObj, targetHeadersObj] = await Promise.all([
+      baseHeadersKey ? env.BUCKET.get(baseHeadersKey) : Promise.resolve(null),
+      targetHeadersKey ? env.BUCKET.get(targetHeadersKey) : Promise.resolve(null),
+    ]);
+
+    if (baseHeadersObj) {
+      try { baseHeadersRaw = JSON.parse(await baseHeadersObj.text()); } catch (err) {
+        console.warn('wrl:diff_headers_parse_fail', { captureId: id1, errorMessage: String(err?.message ?? '').slice(0, 128) });
+      }
+    }
+    if (targetHeadersObj) {
+      try { targetHeadersRaw = JSON.parse(await targetHeadersObj.text()); } catch (err) {
+        console.warn('wrl:diff_headers_parse_fail', { captureId: id2, errorMessage: String(err?.message ?? '').slice(0, 128) });
+      }
+    }
+  }
+
+  if (include.has('screenshot')) {
+    const baseScreenshotKey = base.artifacts?.screenshot;
+    const targetScreenshotKey = target.artifacts?.screenshot;
+
+    // Hash-only comparison via head() -- never fetch full screenshot bodies
+    const [baseMeta, targetMeta] = await Promise.all([
+      baseScreenshotKey ? env.BUCKET.head(baseScreenshotKey) : Promise.resolve(null),
+      targetScreenshotKey ? env.BUCKET.head(targetScreenshotKey) : Promise.resolve(null),
+    ]);
+
+    // Use etag as the hash; R2 returns etag for all objects
+    baseScreenshotHash = baseMeta?.etag ?? null;
+    targetScreenshotHash = targetMeta?.etag ?? null;
+  }
+
+  // Step 7: Compute diffs
+  const htmlDiff = include.has('html')
+    ? (htmlTruncated
+        ? { changed: true, truncated: true, stats: { additions: 0, deletions: 0 }, hunks: [] }
+        : diffHtml(baseHtml ?? '', targetHtml ?? ''))
+    : null;
+
+  const headersDiff = include.has('headers')
+    ? diffHeaders(baseHeadersRaw, targetHeadersRaw)
+    : null;
+
+  const screenshotDiff = include.has('screenshot')
+    ? diffScreenshot(baseScreenshotHash, targetScreenshotHash)
+    : null;
+
+  // Step 8: Build summary using effective diffs for all sections (null = not included)
+  const summaryHtmlDiff = htmlDiff ?? { changed: false, stats: { additions: 0, deletions: 0 } };
+  const summaryHeadersDiff = headersDiff ?? { changed: false, added: [], removed: [], modified: [] };
+  const summaryScreenshotDiff = screenshotDiff ?? { changed: false };
+  const changeSummary = computeChangeSummary(summaryHtmlDiff, summaryHeadersDiff, summaryScreenshotDiff);
+
+  // Step 9: Assemble response
+  const responseBody = {
+    base: {
+      id: base.captureId,
+      url: base.url,
+      createdAt: base.createdAt,
+    },
+    target: {
+      id: target.captureId,
+      url: target.url,
+      createdAt: target.createdAt,
+    },
+    summary: {
+      changed: changeSummary.changed,
+      sections: {
+        html: changeSummary.html,
+        screenshot: changeSummary.screenshot,
+        headers: changeSummary.headers,
+      },
+    },
+  };
+
+  if (include.has('html') && htmlDiff !== null) {
+    responseBody.html = htmlDiff;
+  }
+  if (include.has('screenshot') && screenshotDiff !== null) {
+    responseBody.screenshot = screenshotDiff;
+  }
+  if (include.has('headers') && headersDiff !== null) {
+    responseBody.headers = headersDiff;
+  }
+
+  ctx.waitUntil(log(env, 3, 'diff', {
+    event: 'diff.computed',
+    tenantId,
+    captureId1: id1,
+    captureId2: id2,
+    durationMs: Date.now() - start,
+    sections: Array.from(include),
+    changed: changeSummary.changed,
+  }) ?? Promise.resolve());
+
+  return jsonResponse(responseBody, 200, { 'Cache-Control': 'no-store' });
 }
 
 // Public endpoint -- no authentication. Rate-limited per IP.

--- a/src/index.js
+++ b/src/index.js
@@ -269,8 +269,8 @@ async function handleCaptureMessage(msg, env, ctx) {
         ]);
 
         const screenshotDiff = diffScreenshot(
-          baseScreenHead?.httpEtag,
-          targetScreenHead?.httpEtag,
+          baseScreenHead?.etag,
+          targetScreenHead?.etag,
         );
 
         // HTML: lightweight diff for summary stats

--- a/src/ui/ui-css.js
+++ b/src/ui/ui-css.js
@@ -1612,4 +1612,399 @@ input, select, textarea {
   flex: 1 1 14rem;
   min-width: 0;
 }
+
+/* ---------------------------------------------------------------------------
+   Diff view
+--------------------------------------------------------------------------- */
+
+/* Summary banner */
+
+.diff-summary-banner {
+  width: 100%;
+  padding: var(--space-3) var(--space-4);
+  border-radius: var(--radius-md);
+  margin-bottom: var(--space-4);
+  background: var(--color-info-bg);
+  border-left: 4px solid var(--color-info);
+  color: var(--color-info-text);
+  font-size: var(--text-base);
+  font-weight: var(--weight-medium);
+}
+
+.diff-summary-banner--loading {
+  background: var(--color-surface-muted);
+  border-left-color: var(--color-border);
+  color: var(--color-text-muted);
+}
+
+/* Two-column capture details */
+
+.diff-details-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-6);
+}
+
+.diff-details-col-heading {
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  color: var(--color-text-muted);
+  margin-bottom: var(--space-3);
+}
+
+.diff-data-grid {
+  grid-template-columns: 5rem 1fr;
+}
+
+/* Screenshot comparison */
+
+.diff-screenshot-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-4);
+  margin-bottom: var(--space-3);
+}
+
+.diff-screenshot-caption {
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+  margin-bottom: var(--space-3);
+}
+
+/* Tab bar */
+
+.diff-tab-bar {
+  display: flex;
+  gap: var(--space-1);
+  border-bottom: 2px solid var(--color-border);
+  margin-bottom: var(--space-4);
+}
+
+.diff-tab {
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -2px;
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  color: var(--color-text-muted);
+  cursor: pointer;
+  border-radius: var(--radius-sm) var(--radius-sm) 0 0;
+  transition: color 0.1s, border-color 0.1s;
+}
+
+.diff-tab:hover {
+  color: var(--color-text);
+}
+
+.diff-tab[aria-selected="true"] {
+  color: var(--color-primary);
+  border-bottom-color: var(--color-primary);
+}
+
+.diff-tab:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.diff-panels {
+  min-height: 4rem;
+}
+
+.diff-panel:focus {
+  outline: none;
+}
+
+/* Overlay */
+
+.diff-overlay-container {
+  position: relative;
+  display: inline-block;
+  max-width: 100%;
+  overflow: hidden;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  cursor: col-resize;
+  user-select: none;
+}
+
+.diff-overlay-img {
+  display: block;
+  max-width: 100%;
+  height: auto;
+}
+
+.diff-overlay-img--top {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.diff-overlay-line {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: var(--color-primary);
+  pointer-events: none;
+  transform: translateX(-50%);
+}
+
+.diff-overlay-slider {
+  position: absolute;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: 24px;
+  height: 24px;
+  background: var(--color-primary);
+  border-radius: 50%;
+  border: 2px solid var(--color-primary-text);
+  cursor: col-resize;
+}
+
+.diff-overlay-slider:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+/* Pixel diff canvas */
+
+.diff-canvas-wrap {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  overflow: auto;
+  background: var(--color-surface-muted);
+  min-height: 4rem;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.diff-canvas {
+  display: block;
+  max-width: 100%;
+  height: auto;
+}
+
+/* HTML diff code block */
+
+.diff-code-block {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  background: var(--color-surface-muted);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  overflow-x: auto;
+  line-height: 1.5;
+}
+
+.diff-line {
+  display: flex;
+  align-items: stretch;
+  min-height: 1.5em;
+  white-space: pre;
+}
+
+.diff-line--add {
+  background: var(--color-success-bg);
+  border-left: 3px solid var(--color-success);
+}
+
+.diff-line--remove {
+  background: var(--color-error-bg);
+  border-left: 3px solid var(--color-error);
+}
+
+.diff-gutter {
+  display: flex;
+  gap: 0;
+  flex-shrink: 0;
+  border-right: 1px solid var(--color-border);
+  background: var(--color-surface-muted);
+  padding: 0 var(--space-2);
+  opacity: 0.7;
+}
+
+.diff-gutter-num {
+  display: inline-block;
+  width: 3.5em;
+  text-align: right;
+  color: var(--color-text-muted);
+  font-size: var(--text-xs);
+  line-height: 1.5em;
+  padding: 0 var(--space-1);
+  user-select: none;
+}
+
+.diff-prefix {
+  display: inline-block;
+  width: 1.5em;
+  text-align: center;
+  flex-shrink: 0;
+  user-select: none;
+  color: var(--color-text-muted);
+  padding: 0 var(--space-1);
+}
+
+.diff-line--add .diff-prefix {
+  color: var(--color-success-text);
+}
+
+.diff-line--remove .diff-prefix {
+  color: var(--color-error-text);
+}
+
+.diff-content {
+  flex: 1;
+  padding: 0 var(--space-2);
+  overflow: visible;
+}
+
+.diff-separator {
+  height: 1.5em;
+  background: var(--color-surface-muted);
+  border-top: 1px dashed var(--color-border);
+  border-bottom: 1px dashed var(--color-border);
+  display: flex;
+  align-items: center;
+  padding: 0 var(--space-3);
+  color: var(--color-text-muted);
+  font-size: var(--text-xs);
+}
+
+.diff-separator::before {
+  content: '\\00b7\\00b7\\00b7';
+  letter-spacing: 0.2em;
+}
+
+.diff-truncation-note {
+  margin-top: var(--space-2);
+  font-size: var(--text-sm);
+  color: var(--color-warning-text);
+  background: var(--color-warning-bg);
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-sm);
+  border-left: 3px solid var(--color-warning);
+}
+
+.diff-no-changes {
+  font-size: var(--text-base);
+  color: var(--color-text-muted);
+  padding: var(--space-2) 0;
+}
+
+/* Header diff table */
+
+.diff-header-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--text-sm);
+  margin-bottom: var(--space-2);
+}
+
+.diff-header-table th {
+  text-align: left;
+  font-weight: var(--weight-medium);
+  color: var(--color-text-muted);
+  padding: var(--space-1) var(--space-2);
+  border-bottom: 1px solid var(--color-border);
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.diff-header-table td {
+  padding: var(--space-1) var(--space-2);
+  border-bottom: 1px solid var(--color-border-subtle);
+  vertical-align: top;
+  word-break: break-all;
+}
+
+.diff-header-table tr:last-child td {
+  border-bottom: none;
+}
+
+.diff-row--add {
+  background: var(--color-success-bg);
+}
+
+.diff-row--add td:first-child {
+  border-left: 3px solid var(--color-success);
+}
+
+.diff-row--remove {
+  background: var(--color-error-bg);
+}
+
+.diff-row--remove td:first-child {
+  border-left: 3px solid var(--color-error);
+}
+
+.diff-row--change {
+  background: var(--color-warning-bg);
+}
+
+.diff-row--change td:first-child {
+  border-left: 3px solid var(--color-warning);
+}
+
+.diff-unchanged-headers summary {
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+  cursor: pointer;
+}
+
+/* Change badges on schedule/capture list */
+
+.badge--change {
+  background: var(--color-warning-bg);
+  color: var(--color-warning-text);
+  border-color: var(--color-warning);
+}
+
+.badge--change-link {
+  background: var(--color-warning-bg);
+  color: var(--color-warning-text);
+  border-color: var(--color-warning);
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.badge--change-link:hover {
+  background: var(--color-warning);
+  color: var(--color-surface);
+}
+
+.badge--change-link:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.badge--unchanged {
+  background: var(--color-surface-muted);
+  color: var(--color-text-muted);
+  border-color: var(--color-border);
+}
+
+/* Mobile: diff view */
+
+@media (max-width: 640px) {
+  .diff-details-grid {
+    grid-template-columns: 1fr;
+    gap: var(--space-4);
+  }
+
+  .diff-screenshot-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .diff-data-grid {
+    grid-template-columns: 1fr;
+  }
+}
 `;

--- a/src/ui/ui-detail.js
+++ b/src/ui/ui-detail.js
@@ -277,6 +277,28 @@ function renderDetailComplete(view, id, data) {
   artifactsSection.appendChild(artList);
   card.appendChild(artifactsSection);
 
+  // Compare with previous (only when changeSummary has previousCaptureId)
+  if (data.changeSummary && data.changeSummary.previousCaptureId) {
+    var compareSection = document.createElement('section');
+    compareSection.className = 'section detail-section';
+
+    var compareH2 = document.createElement('h2');
+    compareH2.textContent = 'Changes';
+    compareSection.appendChild(compareH2);
+
+    var compareLink = document.createElement('a');
+    compareLink.href = '#/diff/' + data.changeSummary.previousCaptureId + '/' + id;
+    compareLink.className = 'detail-url-link';
+
+    if (data.changeSummary.changed === true) {
+      compareLink.textContent = 'Compare with previous capture (changes detected)';
+    } else {
+      compareLink.textContent = 'Compare with previous capture (no changes)';
+    }
+    compareSection.appendChild(compareLink);
+    card.appendChild(compareSection);
+  }
+
   // Verification link (only when WACZ is present)
   if (data.wacz) {
     var verifySection = document.createElement('section');

--- a/src/ui/ui-diff.js
+++ b/src/ui/ui-diff.js
@@ -1,0 +1,908 @@
+// tva
+// Diff view for WRL Web UI.
+// Exports a JS string constant for inline use in the HTML shell.
+
+export const DIFF_VIEW_JS = `
+// ---------------------------------------------------------------------------
+// Diff view helpers
+// ---------------------------------------------------------------------------
+
+function diffFormatDatetime(isoStr) {
+  if (!isoStr) return '';
+  try {
+    var d = new Date(isoStr);
+    return d.toLocaleString(undefined, {
+      year: 'numeric', month: 'short', day: 'numeric',
+      hour: '2-digit', minute: '2-digit', second: '2-digit',
+    });
+  } catch (e) {
+    return isoStr;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Normalise API response into a flat shape for rendering
+//
+// API response shape (from GET /v1/captures/:id1/diff/:id2):
+//   data.base     = { id, url, createdAt }
+//   data.target   = { id, url, createdAt }
+//   data.summary  = { changed, sections: { html, screenshot, headers } }
+//   data.html     = { changed, truncated, stats: { additions, deletions }, hunks }
+//                   hunks[].lines[].type = 'addition' | 'deletion' | 'context'
+//   data.headers  = { changed, added[{ name, targetValue }],
+//                     removed[{ name, baseValue }],
+//                     modified[{ name, baseValue, targetValue }],
+//                     unchanged (count), statusChanged }
+//   data.screenshot = { changed }
+// ---------------------------------------------------------------------------
+
+function normaliseApiResponse(data) {
+  var html = data.html || null;
+  var headers = data.headers || null;
+  var screenshot = data.screenshot || null;
+  var summary = data.summary || null;
+
+  // HTML hunks: translate type names and compute per-line numbers
+  var hunks = [];
+  var htmlTruncated = false;
+  if (html && html.hunks) {
+    htmlTruncated = !!(html.truncated);
+    for (var h = 0; h < html.hunks.length; h++) {
+      var rawHunk = html.hunks[h];
+      var lines = [];
+      var baseLineNo = rawHunk.baseLine || 1;
+      var targetLineNo = rawHunk.targetLine || 1;
+      for (var l = 0; l < (rawHunk.lines || []).length; l++) {
+        var rawLine = rawHunk.lines[l];
+        var uiType = rawLine.type === 'addition' ? 'add'
+                   : rawLine.type === 'deletion'  ? 'remove'
+                   : 'context';
+        lines.push({
+          type: uiType,
+          content: rawLine.content || '',
+          baseLineNo: (uiType === 'add') ? null : baseLineNo,
+          targetLineNo: (uiType === 'remove') ? null : targetLineNo,
+        });
+        if (uiType !== 'add') baseLineNo++;
+        if (uiType !== 'remove') targetLineNo++;
+      }
+      hunks.push({ lines: lines });
+    }
+  }
+
+  // Header changes: normalise to a flat array with add/remove/change types
+  var headerChanges = [];
+  var unchangedHeaderCount = 0;
+  if (headers) {
+    var addedH = headers.added || [];
+    var removedH = headers.removed || [];
+    var modifiedH = headers.modified || [];
+    unchangedHeaderCount = headers.unchanged || 0;
+
+    for (var i = 0; i < addedH.length; i++) {
+      headerChanges.push({ type: 'add', name: addedH[i].name, base: '', target: addedH[i].targetValue || '' });
+    }
+    for (var j = 0; j < removedH.length; j++) {
+      headerChanges.push({ type: 'remove', name: removedH[j].name, base: removedH[j].baseValue || '', target: '' });
+    }
+    for (var k = 0; k < modifiedH.length; k++) {
+      headerChanges.push({ type: 'change', name: modifiedH[k].name, base: modifiedH[k].baseValue || '', target: modifiedH[k].targetValue || '' });
+    }
+  }
+
+  var screenshotChanged = !!(screenshot && screenshot.changed) ||
+    !!(summary && summary.sections && summary.sections.screenshot && summary.sections.screenshot.changed);
+
+  var htmlStats = (html && html.stats) ? html.stats : null;
+  var htmlChangedLines = htmlStats ? (htmlStats.additions + htmlStats.deletions) : 0;
+
+  return {
+    base: data.base || null,
+    target: data.target || null,
+    hunks: hunks,
+    htmlTruncated: htmlTruncated,
+    headerChanges: headerChanges,
+    unchangedHeaderCount: unchangedHeaderCount,
+    screenshotChanged: screenshotChanged,
+    htmlChangedLines: htmlChangedLines,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Canvas pixel diff
+// ---------------------------------------------------------------------------
+
+function computePixelDiff(img1, img2) {
+  var maxW = Math.max(img1.width, img2.width);
+  var maxH = Math.max(img1.height, img2.height);
+  if (maxW * maxH > 8000000) {
+    return { canvas: null, changedPercent: 'N/A', tooLarge: true };
+  }
+  var canvas1 = document.createElement('canvas');
+  canvas1.width = maxW; canvas1.height = maxH;
+  var ctx1 = canvas1.getContext('2d');
+  ctx1.drawImage(img1, 0, 0);
+  var data1 = ctx1.getImageData(0, 0, maxW, maxH).data;
+
+  var canvas2 = document.createElement('canvas');
+  canvas2.width = maxW; canvas2.height = maxH;
+  var ctx2 = canvas2.getContext('2d');
+  ctx2.drawImage(img2, 0, 0);
+  var data2 = ctx2.getImageData(0, 0, maxW, maxH).data;
+
+  var diffCanvas = document.createElement('canvas');
+  diffCanvas.width = maxW; diffCanvas.height = maxH;
+  var diffCtx = diffCanvas.getContext('2d');
+  var diffData = diffCtx.createImageData(maxW, maxH);
+
+  var changed = 0;
+  var total = maxW * maxH;
+  for (var i = 0; i < data1.length; i += 4) {
+    var dr = data1[i] - data2[i];
+    var dg = data1[i+1] - data2[i+1];
+    var db = data1[i+2] - data2[i+2];
+    var dist = Math.sqrt(dr*dr + dg*dg + db*db);
+    if (dist > 35) {
+      diffData.data[i] = 255; diffData.data[i+1] = 0;
+      diffData.data[i+2] = 255; diffData.data[i+3] = 180;
+      changed++;
+    } else {
+      var gray = Math.round(0.299*data2[i] + 0.587*data2[i+1] + 0.114*data2[i+2]);
+      diffData.data[i] = gray; diffData.data[i+1] = gray;
+      diffData.data[i+2] = gray; diffData.data[i+3] = 255;
+    }
+  }
+  diffCtx.putImageData(diffData, 0, 0);
+  return { canvas: diffCanvas, changedPercent: (changed / total * 100).toFixed(1) };
+}
+
+// ---------------------------------------------------------------------------
+// Screenshot section with tabs
+// ---------------------------------------------------------------------------
+
+function buildScreenshotSection(id1, id2, normalised) {
+  var section = document.createElement('section');
+  section.className = 'section detail-section';
+
+  var h2 = document.createElement('h2');
+  h2.textContent = 'Screenshot Comparison';
+  section.appendChild(h2);
+
+  var captionEl = document.createElement('p');
+  captionEl.className = 'diff-screenshot-caption';
+  captionEl.textContent = normalised.screenshotChanged ? 'Screenshot changed' : 'Screenshots identical';
+  section.appendChild(captionEl);
+
+  // Tab bar
+  var tabBar = document.createElement('div');
+  tabBar.className = 'diff-tab-bar';
+  tabBar.setAttribute('role', 'tablist');
+  tabBar.setAttribute('aria-label', 'Screenshot comparison mode');
+
+  var tabs = [
+    { id: 'side-by-side', label: 'Side by side' },
+    { id: 'overlay',      label: 'Overlay' },
+    { id: 'diff',         label: 'Diff' },
+  ];
+
+  var tabEls = [];
+  var panelEls = [];
+
+  for (var t = 0; t < tabs.length; t++) {
+    (function(tab, idx) {
+      var tabEl = document.createElement('button');
+      tabEl.type = 'button';
+      tabEl.className = 'diff-tab';
+      tabEl.id = 'tab-' + tab.id;
+      tabEl.setAttribute('role', 'tab');
+      tabEl.setAttribute('aria-selected', idx === 0 ? 'true' : 'false');
+      tabEl.setAttribute('aria-controls', 'panel-' + tab.id);
+      tabEl.setAttribute('tabindex', idx === 0 ? '0' : '-1');
+      tabEl.textContent = tab.label;
+      tabEls.push(tabEl);
+      tabBar.appendChild(tabEl);
+    })(tabs[t], t);
+  }
+
+  var panelContainer = document.createElement('div');
+  panelContainer.className = 'diff-panels';
+
+  // --- Panel: Side by side ---
+  var panelSide = document.createElement('div');
+  panelSide.className = 'diff-panel';
+  panelSide.id = 'panel-side-by-side';
+  panelSide.setAttribute('role', 'tabpanel');
+  panelSide.setAttribute('aria-labelledby', 'tab-side-by-side');
+  panelSide.setAttribute('tabindex', '-1');
+
+  var sideGrid = document.createElement('div');
+  sideGrid.className = 'diff-screenshot-grid';
+
+  var fig1 = document.createElement('figure');
+  fig1.className = 'detail-screenshot-figure';
+  var img1El = document.createElement('img');
+  img1El.src = '/v1/captures/' + id1 + '/artifacts/screenshot';
+  img1El.alt = 'Base capture screenshot';
+  img1El.className = 'detail-screenshot-img';
+  img1El.id = 'diff-img-base';
+  img1El.loading = 'lazy';
+  var cap1 = document.createElement('figcaption');
+  cap1.className = 'detail-screenshot-caption';
+  cap1.textContent = 'Base';
+  fig1.appendChild(img1El);
+  fig1.appendChild(cap1);
+  sideGrid.appendChild(fig1);
+
+  var fig2 = document.createElement('figure');
+  fig2.className = 'detail-screenshot-figure';
+  var img2El = document.createElement('img');
+  img2El.src = '/v1/captures/' + id2 + '/artifacts/screenshot';
+  img2El.alt = 'Target capture screenshot';
+  img2El.className = 'detail-screenshot-img';
+  img2El.id = 'diff-img-target';
+  img2El.loading = 'lazy';
+  var cap2 = document.createElement('figcaption');
+  cap2.className = 'detail-screenshot-caption';
+  cap2.textContent = 'Target';
+  fig2.appendChild(img2El);
+  fig2.appendChild(cap2);
+  sideGrid.appendChild(fig2);
+
+  panelSide.appendChild(sideGrid);
+  panelEls.push(panelSide);
+
+  // --- Panel: Overlay ---
+  var panelOverlay = document.createElement('div');
+  panelOverlay.className = 'diff-panel';
+  panelOverlay.id = 'panel-overlay';
+  panelOverlay.setAttribute('role', 'tabpanel');
+  panelOverlay.setAttribute('aria-labelledby', 'tab-overlay');
+  panelOverlay.setAttribute('tabindex', '-1');
+  panelOverlay.setAttribute('hidden', '');
+
+  var overlayContainer = document.createElement('div');
+  overlayContainer.className = 'diff-overlay-container';
+  overlayContainer.id = 'diff-overlay-container';
+
+  var overlayBase = document.createElement('img');
+  overlayBase.src = '/v1/captures/' + id1 + '/artifacts/screenshot';
+  overlayBase.alt = 'Base capture screenshot';
+  overlayBase.className = 'diff-overlay-img diff-overlay-img--base';
+  overlayBase.setAttribute('aria-hidden', 'true');
+  overlayContainer.appendChild(overlayBase);
+
+  var overlayTarget = document.createElement('img');
+  overlayTarget.src = '/v1/captures/' + id2 + '/artifacts/screenshot';
+  overlayTarget.alt = 'Target capture screenshot';
+  overlayTarget.className = 'diff-overlay-img diff-overlay-img--top';
+  overlayTarget.setAttribute('aria-hidden', 'true');
+  overlayContainer.appendChild(overlayTarget);
+
+  var sliderLine = document.createElement('div');
+  sliderLine.className = 'diff-overlay-line';
+  sliderLine.setAttribute('aria-hidden', 'true');
+  overlayContainer.appendChild(sliderLine);
+
+  var sliderHandle = document.createElement('div');
+  sliderHandle.className = 'diff-overlay-slider';
+  sliderHandle.setAttribute('role', 'slider');
+  sliderHandle.setAttribute('tabindex', '0');
+  sliderHandle.setAttribute('aria-valuemin', '0');
+  sliderHandle.setAttribute('aria-valuemax', '100');
+  sliderHandle.setAttribute('aria-valuenow', '50');
+  sliderHandle.setAttribute('aria-label', 'Screenshot comparison slider');
+  overlayContainer.appendChild(sliderHandle);
+
+  panelOverlay.appendChild(overlayContainer);
+
+  var overlayHint = document.createElement('p');
+  overlayHint.className = 'diff-screenshot-caption';
+  overlayHint.textContent = 'Drag or use arrow keys to compare screenshots';
+  panelOverlay.appendChild(overlayHint);
+  panelEls.push(panelOverlay);
+
+  // --- Panel: Pixel diff ---
+  var panelDiff = document.createElement('div');
+  panelDiff.className = 'diff-panel';
+  panelDiff.id = 'panel-diff';
+  panelDiff.setAttribute('role', 'tabpanel');
+  panelDiff.setAttribute('aria-labelledby', 'tab-diff');
+  panelDiff.setAttribute('tabindex', '-1');
+  panelDiff.setAttribute('hidden', '');
+
+  var diffCanvasWrap = document.createElement('div');
+  diffCanvasWrap.className = 'diff-canvas-wrap';
+  diffCanvasWrap.id = 'diff-canvas-wrap';
+
+  var diffStatusMsg = document.createElement('p');
+  diffStatusMsg.className = 'diff-screenshot-caption';
+  diffStatusMsg.id = 'diff-canvas-status';
+  diffStatusMsg.style.padding = 'var(--space-4)';
+  diffStatusMsg.textContent = 'Activate this tab to compute pixel diff';
+  diffCanvasWrap.appendChild(diffStatusMsg);
+  panelDiff.appendChild(diffCanvasWrap);
+  panelEls.push(panelDiff);
+
+  for (var p = 0; p < panelEls.length; p++) {
+    panelContainer.appendChild(panelEls[p]);
+  }
+
+  // Tab state
+  var diffComputed = false;
+
+  function activateTab(idx) {
+    for (var k = 0; k < tabEls.length; k++) {
+      tabEls[k].setAttribute('aria-selected', k === idx ? 'true' : 'false');
+      tabEls[k].setAttribute('tabindex', k === idx ? '0' : '-1');
+      if (k === idx) {
+        panelEls[k].removeAttribute('hidden');
+      } else {
+        panelEls[k].setAttribute('hidden', '');
+      }
+    }
+    panelEls[idx].focus();
+
+    if (idx === 2 && !diffComputed) {
+      diffComputed = true;
+      computeDiffCanvas();
+    }
+    if (idx === 1) {
+      initOverlaySlider(50);
+    }
+  }
+
+  function computeDiffCanvas() {
+    var statusEl = document.getElementById('diff-canvas-status');
+    var wrapEl = document.getElementById('diff-canvas-wrap');
+    if (!wrapEl) return;
+
+    var baseImg = document.getElementById('diff-img-base');
+    var targetImg = document.getElementById('diff-img-target');
+
+    if (!baseImg || !targetImg) {
+      if (statusEl) statusEl.textContent = 'Screenshots not available for diff.';
+      return;
+    }
+
+    function runDiff() {
+      if (statusEl) statusEl.textContent = 'Computing pixel diff...';
+      try {
+        var result = computePixelDiff(baseImg, targetImg);
+        if (result.tooLarge) {
+          if (statusEl) statusEl.textContent = 'Screenshots are too large for in-browser pixel diff.';
+          return;
+        }
+        if (statusEl) statusEl.remove();
+
+        var canvas = result.canvas;
+        canvas.className = 'diff-canvas';
+        canvas.setAttribute('role', 'img');
+        canvas.setAttribute('aria-label', 'Pixel diff: changed pixels shown in magenta');
+        wrapEl.appendChild(canvas);
+
+        var pctMsg = document.createElement('p');
+        pctMsg.className = 'diff-screenshot-caption';
+        pctMsg.textContent = result.changedPercent + '% of pixels changed';
+        panelDiff.appendChild(pctMsg);
+      } catch (err) {
+        if (statusEl) statusEl.textContent = 'Could not compute pixel diff: ' + (err.message || 'Unknown error');
+      }
+    }
+
+    var needed = 2;
+    function onLoad() {
+      needed--;
+      if (needed <= 0) runDiff();
+    }
+    function onError() {
+      if (statusEl) statusEl.textContent = 'Could not load screenshots for pixel diff.';
+    }
+
+    if (baseImg.complete && baseImg.naturalWidth > 0) {
+      needed--;
+    } else {
+      baseImg.addEventListener('load', onLoad);
+      baseImg.addEventListener('error', onError);
+    }
+    if (targetImg.complete && targetImg.naturalWidth > 0) {
+      needed--;
+    } else {
+      targetImg.addEventListener('load', onLoad);
+      targetImg.addEventListener('error', onError);
+    }
+    if (needed <= 0) runDiff();
+  }
+
+  // Tab keyboard navigation
+  tabBar.addEventListener('keydown', function(e) {
+    var currentIdx = -1;
+    for (var k = 0; k < tabEls.length; k++) {
+      if (tabEls[k].getAttribute('aria-selected') === 'true') { currentIdx = k; break; }
+    }
+    if (currentIdx === -1) return;
+    var nextIdx = currentIdx;
+    if (e.key === 'ArrowRight') {
+      nextIdx = (currentIdx + 1) % tabEls.length;
+    } else if (e.key === 'ArrowLeft') {
+      nextIdx = (currentIdx - 1 + tabEls.length) % tabEls.length;
+    } else {
+      return;
+    }
+    e.preventDefault();
+    tabEls[nextIdx].focus();
+    activateTab(nextIdx);
+  });
+
+  for (var ti = 0; ti < tabEls.length; ti++) {
+    (function(idx) {
+      tabEls[idx].addEventListener('click', function() { activateTab(idx); });
+      tabEls[idx].addEventListener('keydown', function(e) {
+        if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); activateTab(idx); }
+      });
+    })(ti);
+  }
+
+  section.appendChild(tabBar);
+  section.appendChild(panelContainer);
+  return section;
+}
+
+// ---------------------------------------------------------------------------
+// Overlay slider
+// ---------------------------------------------------------------------------
+
+function initOverlaySlider(initialPct) {
+  var container = document.getElementById('diff-overlay-container');
+  if (!container) return;
+
+  var topImg = container.querySelector('.diff-overlay-img--top');
+  var line = container.querySelector('.diff-overlay-line');
+  var sliderHandle = container.querySelector('.diff-overlay-slider');
+  if (!topImg || !line || !sliderHandle) return;
+
+  var pct = initialPct;
+
+  function applyPct(val) {
+    pct = Math.max(0, Math.min(100, val));
+    topImg.style.clipPath = 'inset(0 ' + (100 - pct) + '% 0 0)';
+    sliderHandle.style.left = pct + '%';
+    line.style.left = pct + '%';
+    sliderHandle.setAttribute('aria-valuenow', String(Math.round(pct)));
+  }
+
+  applyPct(pct);
+
+  sliderHandle.addEventListener('keydown', function(e) {
+    if (e.key === 'ArrowRight')     { e.preventDefault(); applyPct(pct + 5); }
+    else if (e.key === 'ArrowLeft') { e.preventDefault(); applyPct(pct - 5); }
+    else if (e.key === 'Home')      { e.preventDefault(); applyPct(0); }
+    else if (e.key === 'End')       { e.preventDefault(); applyPct(100); }
+  });
+
+  var dragging = false;
+
+  function getPctFromEvent(e) {
+    var rect = container.getBoundingClientRect();
+    var clientX = e.touches ? e.touches[0].clientX : e.clientX;
+    return ((clientX - rect.left) / rect.width) * 100;
+  }
+
+  sliderHandle.addEventListener('mousedown', function(e) { e.preventDefault(); dragging = true; });
+  sliderHandle.addEventListener('touchstart', function() { dragging = true; }, { passive: true });
+  document.addEventListener('mousemove',  function(e) { if (dragging) applyPct(getPctFromEvent(e)); });
+  document.addEventListener('touchmove',  function(e) { if (dragging) applyPct(getPctFromEvent(e)); }, { passive: true });
+  document.addEventListener('mouseup',   function() { dragging = false; });
+  document.addEventListener('touchend',  function() { dragging = false; });
+}
+
+// ---------------------------------------------------------------------------
+// Capture details two-column section
+// ---------------------------------------------------------------------------
+
+function buildCaptureDetailsSection(base, target) {
+  var section = document.createElement('section');
+  section.className = 'section detail-section';
+
+  var h2 = document.createElement('h2');
+  h2.textContent = 'Capture Details';
+  section.appendChild(h2);
+
+  var grid = document.createElement('div');
+  grid.className = 'diff-details-grid';
+
+  function buildCol(label, data) {
+    var col = document.createElement('div');
+    col.className = 'diff-details-col';
+
+    var colH = document.createElement('h3');
+    colH.className = 'diff-details-col-heading';
+    colH.textContent = label;
+    col.appendChild(colH);
+
+    var dl = document.createElement('dl');
+    dl.className = 'data-grid diff-data-grid';
+
+    function addRow(labelText, valueText) {
+      var row = document.createElement('div');
+      row.className = 'data-row';
+      var dt = document.createElement('dt');
+      dt.className = 'data-label';
+      dt.textContent = labelText;
+      var dd = document.createElement('dd');
+      dd.className = 'data-value';
+      dd.textContent = valueText || '';
+      row.appendChild(dt);
+      row.appendChild(dd);
+      dl.appendChild(row);
+    }
+
+    if (data) {
+      addRow('ID', data.id || '');
+      addRow('URL', data.url || '');
+      addRow('Captured', diffFormatDatetime(data.completedAt || data.createdAt));
+    } else {
+      addRow('Status', 'Not available');
+    }
+
+    col.appendChild(dl);
+    return col;
+  }
+
+  grid.appendChild(buildCol('Base', base));
+  grid.appendChild(buildCol('Target', target));
+  section.appendChild(grid);
+  return section;
+}
+
+// ---------------------------------------------------------------------------
+// HTML diff section
+// ---------------------------------------------------------------------------
+
+function buildHtmlDiffSection(hunks, truncated) {
+  var section = document.createElement('section');
+  section.className = 'section detail-section';
+
+  var h2 = document.createElement('h2');
+  h2.textContent = 'HTML Changes';
+  section.appendChild(h2);
+
+  if (!hunks || hunks.length === 0) {
+    var noChange = document.createElement('p');
+    noChange.className = 'diff-no-changes';
+    noChange.textContent = 'No HTML changes detected.';
+    section.appendChild(noChange);
+    return section;
+  }
+
+  var codeWrap = document.createElement('div');
+  codeWrap.className = 'diff-code-block';
+
+  for (var h = 0; h < hunks.length; h++) {
+    var hunk = hunks[h];
+
+    if (h > 0) {
+      var sep = document.createElement('div');
+      sep.className = 'diff-separator';
+      sep.setAttribute('aria-hidden', 'true');
+      codeWrap.appendChild(sep);
+    }
+
+    var lines = hunk.lines || [];
+    for (var l = 0; l < lines.length; l++) {
+      var line = lines[l];
+      var lineDiv = document.createElement('div');
+      lineDiv.className = 'diff-line';
+
+      // type is 'add' | 'remove' | 'context' (normalised)
+      var lineType = line.type || 'context';
+      if (lineType === 'add')    { lineDiv.classList.add('diff-line--add'); }
+      if (lineType === 'remove') { lineDiv.classList.add('diff-line--remove'); }
+
+      // Gutter: two number columns (base line, target line)
+      var gutter = document.createElement('span');
+      gutter.className = 'diff-gutter';
+      gutter.setAttribute('aria-hidden', 'true');
+
+      var baseNum = document.createElement('span');
+      baseNum.className = 'diff-gutter-num';
+      baseNum.textContent = (line.baseLineNo != null) ? String(line.baseLineNo) : '';
+      gutter.appendChild(baseNum);
+
+      var targetNum = document.createElement('span');
+      targetNum.className = 'diff-gutter-num';
+      targetNum.textContent = (line.targetLineNo != null) ? String(line.targetLineNo) : '';
+      gutter.appendChild(targetNum);
+
+      lineDiv.appendChild(gutter);
+
+      // Prefix character
+      var prefix = document.createElement('span');
+      prefix.className = 'diff-prefix';
+      prefix.setAttribute('aria-hidden', 'true');
+      prefix.textContent = lineType === 'add' ? '+' : lineType === 'remove' ? '-' : ' ';
+      lineDiv.appendChild(prefix);
+
+      // Content: always textContent, NEVER innerHTML
+      var content = document.createElement('span');
+      content.className = 'diff-content';
+      content.textContent = line.content || '';
+      lineDiv.appendChild(content);
+
+      codeWrap.appendChild(lineDiv);
+    }
+  }
+
+  section.appendChild(codeWrap);
+
+  if (truncated) {
+    var truncNote = document.createElement('p');
+    truncNote.className = 'diff-truncation-note';
+    truncNote.setAttribute('role', 'note');
+    truncNote.textContent = 'Diff truncated. Only the first portion of changes is shown.';
+    section.appendChild(truncNote);
+  }
+
+  return section;
+}
+
+// ---------------------------------------------------------------------------
+// Header diff section
+// ---------------------------------------------------------------------------
+
+function buildHeaderDiffSection(headerChanges, unchangedHeaderCount) {
+  var section = document.createElement('section');
+  section.className = 'section detail-section';
+
+  var h2 = document.createElement('h2');
+  h2.textContent = 'Header Changes';
+  section.appendChild(h2);
+
+  if (!headerChanges || headerChanges.length === 0) {
+    var noChange = document.createElement('p');
+    noChange.className = 'diff-no-changes';
+    noChange.textContent = 'No header changes detected.';
+    section.appendChild(noChange);
+
+    if (unchangedHeaderCount > 0) {
+      var unchangedNote = document.createElement('p');
+      unchangedNote.className = 'diff-no-changes';
+      unchangedNote.style.marginTop = 'var(--space-1)';
+      unchangedNote.textContent = unchangedHeaderCount + ' header' +
+        (unchangedHeaderCount === 1 ? '' : 's') + ' unchanged.';
+      section.appendChild(unchangedNote);
+    }
+    return section;
+  }
+
+  var table = document.createElement('table');
+  table.className = 'diff-header-table';
+
+  var thead = document.createElement('thead');
+  var headRow = document.createElement('tr');
+  var colLabels = ['Header', 'Base', 'Target'];
+  for (var ci = 0; ci < colLabels.length; ci++) {
+    var th = document.createElement('th');
+    th.textContent = colLabels[ci];
+    th.scope = 'col';
+    headRow.appendChild(th);
+  }
+  thead.appendChild(headRow);
+  table.appendChild(thead);
+
+  var tbody = document.createElement('tbody');
+
+  for (var c = 0; c < headerChanges.length; c++) {
+    var hc = headerChanges[c];
+    var tr = document.createElement('tr');
+    tr.className = 'diff-row--' + (hc.type || 'unchanged');
+
+    var tdName = document.createElement('td');
+    if (hc.type === 'change') {
+      tdName.setAttribute('aria-label', hc.name + ': changed from ' + (hc.base || '') + ' to ' + (hc.target || ''));
+    } else if (hc.type === 'add') {
+      tdName.setAttribute('aria-label', hc.name + ': added with value ' + (hc.target || ''));
+    } else if (hc.type === 'remove') {
+      tdName.setAttribute('aria-label', hc.name + ': removed, was ' + (hc.base || ''));
+    }
+    tdName.textContent = hc.name || '';
+    tr.appendChild(tdName);
+
+    var tdBase = document.createElement('td');
+    tdBase.textContent = hc.base || '';
+    tr.appendChild(tdBase);
+
+    var tdTarget = document.createElement('td');
+    tdTarget.textContent = hc.target || '';
+    tr.appendChild(tdTarget);
+
+    tbody.appendChild(tr);
+  }
+
+  table.appendChild(tbody);
+  section.appendChild(table);
+
+  // Unchanged count disclosure (API returns count only, not individual values)
+  if (unchangedHeaderCount > 0) {
+    var details = document.createElement('details');
+    details.className = 'diff-unchanged-headers disclosure';
+    details.style.marginTop = 'var(--space-3)';
+
+    var summaryEl = document.createElement('summary');
+    summaryEl.textContent = unchangedHeaderCount + ' header' +
+      (unchangedHeaderCount === 1 ? '' : 's') + ' unchanged';
+    details.appendChild(summaryEl);
+
+    var note = document.createElement('p');
+    note.style.padding = 'var(--space-2) var(--space-3)';
+    note.style.fontSize = 'var(--text-sm)';
+    note.style.color = 'var(--color-text-muted)';
+    note.textContent = 'Individual values are not returned for unchanged headers.';
+    details.appendChild(note);
+
+    section.appendChild(details);
+  }
+
+  return section;
+}
+
+// ---------------------------------------------------------------------------
+// Summary banner
+// ---------------------------------------------------------------------------
+
+function buildSummaryBanner(normalised) {
+  var banner = document.createElement('div');
+  banner.className = 'diff-summary-banner';
+
+  var parts = [];
+
+  if (normalised) {
+    var htmlChangedLines = normalised.htmlChangedLines || 0;
+    if (htmlChangedLines > 0) {
+      parts.push(htmlChangedLines + ' HTML ' + (htmlChangedLines === 1 ? 'change' : 'changes'));
+    } else {
+      parts.push('No HTML changes');
+    }
+
+    parts.push(normalised.screenshotChanged ? 'Screenshot changed' : 'Screenshot identical');
+
+    var headerCount = normalised.headerChanges ? normalised.headerChanges.length : 0;
+    if (headerCount > 0) {
+      parts.push(headerCount + ' header ' + (headerCount === 1 ? 'change' : 'changes'));
+    }
+  } else {
+    parts.push('Loading diff...');
+  }
+
+  banner.textContent = parts.join(' | ');
+  return banner;
+}
+
+// ---------------------------------------------------------------------------
+// renderDiff -- builds DOM skeleton with loading state
+// ---------------------------------------------------------------------------
+
+function renderDiff(id1, id2) {
+  var view = document.getElementById('view');
+  if (!view) return;
+  // Safe: clearing the view container
+  view.textContent = '';
+  document.title = 'Diff \u2014 Web Resource Ledger';
+
+  // Back link to target capture
+  var back = document.createElement('a');
+  back.href = '#/captures/' + id2;
+  back.className = 'detail-back-link';
+  back.textContent = 'Back to capture';
+  view.appendChild(back);
+
+  // Placeholder banner
+  var bannerEl = document.createElement('div');
+  bannerEl.className = 'diff-summary-banner diff-summary-banner--loading';
+  bannerEl.id = 'diff-summary-banner';
+  bannerEl.setAttribute('aria-live', 'polite');
+  bannerEl.textContent = 'Loading diff\u2026';
+  view.appendChild(bannerEl);
+
+  // Card skeleton
+  var card = document.createElement('div');
+  card.className = 'card detail-card';
+  card.id = 'diff-card';
+
+  var loadingWrap = document.createElement('div');
+  loadingWrap.className = 'detail-loading';
+  loadingWrap.setAttribute('role', 'status');
+  loadingWrap.setAttribute('aria-label', 'Loading diff');
+
+  var spinner = document.createElement('div');
+  spinner.className = 'detail-spinner';
+  spinner.setAttribute('aria-hidden', 'true');
+  loadingWrap.appendChild(spinner);
+
+  var loadingText = document.createElement('p');
+  loadingText.className = 'detail-loading-text';
+  loadingText.textContent = 'Loading diff\u2026';
+  loadingWrap.appendChild(loadingText);
+
+  card.appendChild(loadingWrap);
+  view.appendChild(card);
+}
+
+// ---------------------------------------------------------------------------
+// mountDiff -- fetches diff data from API and renders results
+// ---------------------------------------------------------------------------
+
+function mountDiff(id1, id2) {
+  apiFetch('/v1/captures/' + id1 + '/diff/' + id2).then(function(res) {
+    if (!res) return; // 401 handled by apiFetch
+
+    var view = document.getElementById('view');
+    var card = document.getElementById('diff-card');
+    if (!view || !card) return;
+
+    if (!res.ok) {
+      card.textContent = '';
+      var errDiv = document.createElement('div');
+      errDiv.className = 'alert alert--error';
+      errDiv.setAttribute('role', 'alert');
+      errDiv.style.margin = 'var(--space-6)';
+      errDiv.textContent = res.status === 404
+        ? 'One or both captures not found.'
+        : 'Could not load diff (HTTP ' + res.status + ').';
+      card.appendChild(errDiv);
+
+      var bannerEl = document.getElementById('diff-summary-banner');
+      if (bannerEl) bannerEl.textContent = 'Error loading diff';
+      return;
+    }
+
+    res.json().then(function(data) {
+      var v = document.getElementById('view');
+      var c = document.getElementById('diff-card');
+      if (!v || !c) return;
+
+      var normalised = normaliseApiResponse(data);
+
+      // Update summary banner
+      var bannerEl = document.getElementById('diff-summary-banner');
+      if (bannerEl) {
+        bannerEl.parentNode.replaceChild(buildSummaryBanner(normalised), bannerEl);
+      }
+
+      // Clear loading state
+      c.textContent = '';
+
+      c.appendChild(buildCaptureDetailsSection(normalised.base, normalised.target));
+      c.appendChild(buildScreenshotSection(id1, id2, normalised));
+      c.appendChild(buildHtmlDiffSection(normalised.hunks, normalised.htmlTruncated));
+      c.appendChild(buildHeaderDiffSection(normalised.headerChanges, normalised.unchangedHeaderCount));
+
+      document.title = 'Diff \u2014 Web Resource Ledger';
+
+      var backLink = v.querySelector('.detail-back-link');
+      if (backLink) backLink.focus();
+    }).catch(function() {
+      var c = document.getElementById('diff-card');
+      if (!c) return;
+      c.textContent = '';
+      var errDiv = document.createElement('div');
+      errDiv.className = 'alert alert--error';
+      errDiv.setAttribute('role', 'alert');
+      errDiv.style.margin = 'var(--space-6)';
+      errDiv.textContent = 'Could not parse diff data.';
+      c.appendChild(errDiv);
+    });
+  }).catch(function(err) {
+    var c = document.getElementById('diff-card');
+    if (!c) return;
+    c.textContent = '';
+    var errDiv = document.createElement('div');
+    errDiv.className = 'alert alert--error';
+    errDiv.setAttribute('role', 'alert');
+    errDiv.style.margin = 'var(--space-6)';
+    errDiv.textContent = (err && err.message === 'fetch_timeout')
+      ? 'Connection timed out. Check your network and try again.'
+      : 'Connection failed. Check your network and try again.';
+    c.appendChild(errDiv);
+  });
+}
+`;

--- a/src/ui/ui-diff.js
+++ b/src/ui/ui-diff.js
@@ -329,6 +329,7 @@ function buildScreenshotSection(id1, id2, normalised) {
 
   // Tab state
   var diffComputed = false;
+  var overlayInitialized = false;
 
   function activateTab(idx) {
     for (var k = 0; k < tabEls.length; k++) {
@@ -346,7 +347,8 @@ function buildScreenshotSection(id1, id2, normalised) {
       diffComputed = true;
       computeDiffCanvas();
     }
-    if (idx === 1) {
+    if (idx === 1 && !overlayInitialized) {
+      overlayInitialized = true;
       initOverlaySlider(50);
     }
   }

--- a/src/ui/ui-schedules.js
+++ b/src/ui/ui-schedules.js
@@ -362,6 +362,24 @@ function buildScheduleRow(schedule, listEl) {
   // Status badge
   actionsCell.appendChild(scheduleStatusBadge(schedule));
 
+  // Change badge: shown when schedule carries changeSummary from last capture
+  if (schedule.changeSummary && schedule.lastCaptureId) {
+    var cs = schedule.changeSummary;
+    if (cs.changed === true && cs.previousCaptureId) {
+      var changeBadge = document.createElement('a');
+      changeBadge.className = 'badge badge--change-link';
+      changeBadge.href = '#/diff/' + cs.previousCaptureId + '/' + schedule.lastCaptureId;
+      changeBadge.textContent = 'Changed';
+      changeBadge.setAttribute('aria-label', 'View changes from previous capture');
+      actionsCell.appendChild(changeBadge);
+    } else if (cs.changed === false) {
+      var unchangedBadge = document.createElement('span');
+      unchangedBadge.className = 'badge badge--unchanged';
+      unchangedBadge.textContent = 'Unchanged';
+      actionsCell.appendChild(unchangedBadge);
+    }
+  }
+
   // Delete button
   var deleteBtn = document.createElement('button');
   deleteBtn.type = 'button';

--- a/src/ui/ui-shell.js
+++ b/src/ui/ui-shell.js
@@ -11,6 +11,7 @@ import { BILLING_JS } from './ui-billing.js';
 import { NOTIFICATIONS_JS } from './ui-notifications.js';
 import { SUBMIT_VIEW_JS } from './ui-submit.js';
 import { DETAIL_VIEW_JS } from './ui-detail.js';
+import { DIFF_VIEW_JS } from './ui-diff.js';
 import { POLL_JS } from './ui-poll.js';
 
 export function htmlDashboard() {
@@ -71,6 +72,9 @@ ${SUBMIT_VIEW_JS}
 
 // === VIEW: DETAIL ===
 ${DETAIL_VIEW_JS}
+
+// === VIEW: DIFF ===
+${DIFF_VIEW_JS}
 
 // ---------------------------------------------------------------------------
 // Hash router
@@ -151,6 +155,15 @@ function route() {
     } else {
       location.replace('#/captures');
     }
+    return;
+  }
+
+  // /diff/:id1/:id2
+  var diffMatch = path.match(/^\\/diff\\/(cap_[a-f0-9]{32})\\/(cap_[a-f0-9]{32})$/);
+  if (diffMatch) {
+    updateNavCurrent('/captures');
+    renderDiff(diffMatch[1], diffMatch[2]);
+    mountDiff(diffMatch[1], diffMatch[2]);
     return;
   }
 

--- a/src/ui/ui-submit.js
+++ b/src/ui/ui-submit.js
@@ -146,6 +146,27 @@ function buildCaptureItem(capture) {
   }
   badge.dataset.badge = '1';
   badgeCell.appendChild(badge);
+
+  // Change badge: shown when changeSummary is present and status is complete
+  if (capture.status === 'complete' && capture.changeSummary) {
+    var cs = capture.changeSummary;
+    if (cs.changed === true && cs.previousCaptureId) {
+      var changeBadge = document.createElement('a');
+      changeBadge.className = 'badge badge--change-link';
+      changeBadge.href = '#/diff/' + cs.previousCaptureId + '/' + capture.id;
+      changeBadge.textContent = 'Changed';
+      changeBadge.setAttribute('aria-label', 'View changes from previous capture');
+      // Prevent capture item link navigation when clicking the badge
+      changeBadge.addEventListener('click', function(e) { e.stopPropagation(); });
+      badgeCell.appendChild(changeBadge);
+    } else if (cs.changed === false) {
+      var unchangedBadge = document.createElement('span');
+      unchangedBadge.className = 'badge badge--unchanged';
+      unchangedBadge.textContent = 'Unchanged';
+      badgeCell.appendChild(unchangedBadge);
+    }
+  }
+
   item.appendChild(badgeCell);
 
   return item;

--- a/src/webhook-dispatch.js
+++ b/src/webhook-dispatch.js
@@ -112,6 +112,22 @@ export function buildWebhookPayload(eventType, captureRecord, env) {
 
   if (eventType === 'capture.complete') {
     data.completedAt = captureRecord.completedAt;
+    // Include change detection if available
+    if (captureRecord.changeSummary) {
+      const verifyBase = env?.VERIFICATION_BASE_URL
+        ? env.VERIFICATION_BASE_URL.replace(/\/$/, '')
+        : 'https://api.webresourceledger.com';
+      data.changeDetection = {
+        changed: captureRecord.changeSummary.changed,
+        previousCaptureId: captureRecord.changeSummary.previousCaptureId,
+        diffUrl: `${verifyBase}/v1/captures/${captureRecord.changeSummary.previousCaptureId}/diff/${captureRecord.captureId}`,
+        summary: {
+          htmlChanged: captureRecord.changeSummary.html?.changed ?? false,
+          screenshotChanged: captureRecord.changeSummary.screenshot?.changed ?? false,
+          headersChanged: captureRecord.changeSummary.headers?.changed ?? false,
+        },
+      };
+    }
   } else if (eventType === 'capture.failed') {
     data.failedAt = captureRecord.failedAt;
     // error is already sanitized by categorizeError() in the capture pipeline

--- a/src/webhook-dispatch.js
+++ b/src/webhook-dispatch.js
@@ -114,13 +114,10 @@ export function buildWebhookPayload(eventType, captureRecord, env) {
     data.completedAt = captureRecord.completedAt;
     // Include change detection if available
     if (captureRecord.changeSummary) {
-      const verifyBase = env?.VERIFICATION_BASE_URL
-        ? env.VERIFICATION_BASE_URL.replace(/\/$/, '')
-        : 'https://api.webresourceledger.com';
       data.changeDetection = {
         changed: captureRecord.changeSummary.changed,
         previousCaptureId: captureRecord.changeSummary.previousCaptureId,
-        diffUrl: `${verifyBase}/v1/captures/${captureRecord.changeSummary.previousCaptureId}/diff/${captureRecord.captureId}`,
+        diffUrl: `${base}/v1/captures/${captureRecord.changeSummary.previousCaptureId}/diff/${captureRecord.captureId}`,
         summary: {
           htmlChanged: captureRecord.changeSummary.html?.changed ?? false,
           screenshotChanged: captureRecord.changeSummary.screenshot?.changed ?? false,


### PR DESCRIPTION
## Summary

- **Diff API endpoint**: `GET /v1/captures/{baseId}/diff/{targetId}` returns structured differences across HTML content, screenshots, and HTTP headers with selective section loading via `?include` parameter
- **Change detection pipeline**: Automatic comparison with previous capture on completion, stored as `change_summary` JSON in D1 via `ctx.waitUntil()`
- **Visual diff UI**: Three screenshot comparison modes (side-by-side, overlay slider, canvas pixel diff), HTML hunk display with line context, header comparison table
- **Change badges**: Schedule list and capture detail views show Changed/Unchanged badges linking to diff view
- **Webhook enrichment**: `capture.complete` payload includes `changeDetection` with change flag and diff URL
- **OpenAPI spec**: Full schema for diff endpoint with examples

## Key design decisions

- **Screenshot diff**: Server-side hash comparison (R2 etag) + client-side canvas pixel diff. Server-side pixel comparison rejected due to Workers memory limits (~128MB). API returns boolean `changed` instead of numeric similarity score.
- **HTML diff library**: `diff-match-patch-es@1.0.1` — ESM rewrite of Google's algorithm, zero dependencies, 15KB.
- **Size guards**: 2MB HTML limit with `truncated: true` flag, 200 hunk cap, 5s diff timeout. Ensures CPU-bounded operation within Workers limits.
- **Schedule enrichment**: LEFT JOIN on captures table for change_summary, avoiding N+1 queries.

## Stats

- 20 files changed, +2476/-5 lines
- 1 new dependency (zero transitive)
- 1 D1 migration (0015_change_summary.sql)
- All 1449 existing tests pass

## Verification

- Code review: 3 ADVISE (code-review-minion, lucy, margo), 0 BLOCK. 3 findings auto-fixed (etag consistency, listener accumulation, duplicate URL construction).
- Tests: 56 files, 1449 passed, 0 failures
- OpenAPI: validates with only pre-existing warnings

## Deferred items

- Diff-specific unit/integration tests (`test/diff.test.js`)
- Pipeline diff stats optimization (skip hunk building when only stats needed)
- Screenshot similarity score in API (numeric % instead of boolean)

## Test plan

- [ ] Deploy to staging and verify diff endpoint with two captures of the same URL
- [ ] Verify change badges appear on schedule list after scheduled capture completes
- [ ] Test visual diff UI: side-by-side, overlay slider, pixel diff modes
- [ ] Verify webhook payload includes changeDetection field
- [ ] Test auth: diff endpoint returns 401 without auth, 404 for cross-tenant
- [ ] Test truncation: capture a large page (>2MB HTML) and verify truncated flag

Resolves #115