### PR TITLE
Add tests for email verification flow (#199)

### DIFF
--- a/docs/evolution/0084-email-verify-tests/decisions.md
+++ b/docs/evolution/0084-email-verify-tests/decisions.md
@@ -1,0 +1,37 @@
+# Decisions — Phase 0084: Email Verify Tests
+
+## File structure: single file vs split
+
+**Chosen**: Single `test/email-verify.test.js` with 5 describe blocks
+**Over**: Splitting unit tests and integration tests into separate files
+**Why**: Matches the established pattern in `test/notifications.test.js` which mixes token unit tests with HTTP integration tests in one file. The verification flow is a single feature — splitting would scatter related tests.
+
+## Resend tests location: new file vs existing
+
+**Chosen**: Include resend-verification tests in `test/email-verify.test.js`
+**Over**: Adding to existing `test/notifications.test.js`
+**Why**: Both test-minion and security-minion agreed. The resend handler is functionally part of the verification flow, not the notification preferences CRUD. `notifications.test.js` is already 579 lines. Grouping by feature is more discoverable.
+
+## Token expiry testing approach
+
+**Chosen**: Craft tokens with manually backdated `ts` field, sign with real HMAC key
+**Over**: Mocking `Date.now()` with `vi.useFakeTimers()`
+**Why**: `Date.now()` mocking is unreliable across the workerd runtime boundary when using `SELF.fetch()`. The backdated-token approach is already proven in `test/notifications.test.js` lines 397-418.
+
+## TOCTOU in swapVerifiedEmail: document vs fix
+
+**Chosen**: Document the gap in a test comment, write stale-token test, defer SQL fix
+**Over**: Including the `AND pending_email = ?` fix in this PR (security-minion recommendation)
+**Why**: Issue #199 scope is explicitly tests only. The fix is a 2-line SQL change but mixing code fixes into a test PR muddies commit history. The existing cross-check catches the common case; the TOCTOU requires concurrent requests to exploit, extremely unlikely in single-tenant D1. Worth fixing separately.
+
+## Static analysis "no email logging" test
+
+**Chosen**: Skip
+**Over**: Regex-based source scan test (security-minion recommendation)
+**Why**: Regex scanning of source code for log patterns is fragile and produces false positives/negatives as code evolves. The privacy invariant is better enforced by code review convention.
+
+## IP counter range
+
+**Chosen**: Start at 500 with `10.0.5.x` subnet
+**Over**: Reusing existing ranges
+**Why**: Prevents rate limiter cross-contamination between test files. Each test file uses a distinct range (notifications.test.js uses 400/`10.0.4.x`).

--- a/docs/evolution/0084-email-verify-tests/outcome.md
+++ b/docs/evolution/0084-email-verify-tests/outcome.md
@@ -1,0 +1,43 @@
+# Outcome — Phase 0084: Email Verify Tests
+
+## What was produced
+
+`test/email-verify.test.js` — 31 tests across 5 describe blocks covering the full email verification flow:
+
+| Block | Tests | Coverage |
+|-------|-------|----------|
+| Token generation and verification | 14 | Round-trip, expiry boundary, tampered payload/HMAC, 3 domain separation pairs, version mismatch, missing fields, malformed inputs |
+| GET /v1/notifications/verify-email | 5 | Valid token, invalid token, expired token, missing token, no-DB-mutation |
+| POST /v1/notifications/verify-email | 7 | Happy path (DB swap verified), invalid, expired, stale token, double verification, token in form body, empty token |
+| POST /v1/account/notifications/resend-verification | 4 | Happy path, no pending email, rate limit (429), missing CSRF |
+| Notification continuity | 1 | Old email stays active during pending, switches after verification |
+
+## What changed
+
+- **New file**: `test/email-verify.test.js` (351 lines, 31 tests)
+- **TOCTOU issue created**: #222 — tracks the `swapVerifiedEmail()` WHERE clause fix identified by security-minion
+- **No production code modified**
+
+## Test results
+
+- `npx vitest run test/email-verify.test.js`: 31/31 pass
+- Full suite: 61 files, 1561 tests pass, 2 skipped, 0 failures
+
+## Surprises
+
+- The resend rate limit test required backdating `verification_sent_at` between two PUT calls to avoid the 60-second rate limiter blocking the second PUT that changes the pending email. Not obvious from the issue description.
+
+## Surface consistency
+
+| Surface | Action |
+|---------|--------|
+| OpenAPI spec | No update needed — no new/changed endpoints |
+| Docs site | No update needed — no new features or behavior changes |
+| Landing page | No update needed — no pricing/capability changes |
+| MCP server | No update needed — no new API endpoints |
+| Legal pages | No update needed — no new data collection or services |
+
+## Backlog changes
+
+- Issue #199 resolved (this PR)
+- Issue #222 created (TOCTOU fix for swapVerifiedEmail, deferred from this phase)

--- a/docs/evolution/0084-email-verify-tests/process.md
+++ b/docs/evolution/0084-email-verify-tests/process.md
@@ -1,0 +1,81 @@
+# Process — Phase 0084: Email Verify Tests
+
+## TL;DR
+
+A focused test-writing phase that added 31 tests for the email verification flow (issue #199). Two specialists planned (test-minion, security-minion), five mandatory reviewers approved the plan, one execution agent wrote the tests. The security-minion found a TOCTOU gap in `swapVerifiedEmail()` — deferred to a separate issue (#222) since this phase was scoped to tests only. Total: ~25 minutes wall clock.
+
+## Phase 1: Meta-Plan
+
+Nefario identified two specialists for planning:
+
+- **test-minion**: Test strategy, file organization, mocking approach for 24h expiry
+- **security-minion**: Token security properties, attack vectors, coverage gaps
+
+Notable exclusions: no UX, docs, observability, or infrastructure specialists needed for a pure test-writing task. Lucy approved the team without adjustment.
+
+## Phase 2: Specialist Planning
+
+Both specialists ran in parallel and returned within ~2 minutes.
+
+**test-minion** recommended:
+- Single `test/email-verify.test.js` (matching the `notifications.test.js` pattern)
+- Backdated `ts` field + real HMAC signing for expiry tests (proven pattern, no `vi.useFakeTimers()`)
+- Resend tests in the new file (group by feature, not URL prefix)
+- ~25 tests across 5 describe blocks
+
+**security-minion** recommended:
+- Bidirectional domain separation tests (all 3 cross-domain pairs — verify/unsubscribe, verify/session, unsubscribe/verify)
+- TOCTOU race condition in `swapVerifiedEmail()` — `WHERE clause` lacks `AND pending_email = ?`
+- Skip timing attack tests (platform guarantee)
+- Malformed token edge cases (dot-only, multi-dot, missing fields)
+
+**Where they disagreed**: security-minion wanted a production code fix (SQL WHERE clause) alongside the tests. test-minion scoped to tests only. Resolved in synthesis.
+
+## Phase 3: Synthesis
+
+Nefario produced a single-task plan with no approval gates. Key conflict resolution:
+
+**TOCTOU fix**: Deferred. The SQL fix is valid but out of scope for #199. The stale-token test documents the common case, and the TOCTOU requires concurrent requests to exploit — extremely unlikely in single-tenant D1. A GitHub issue (#222) was created to track the fix.
+
+**Static analysis "no email logging" test**: Skipped. Regex scanning source code is fragile. Better enforced by code review convention.
+
+## Phase 3.5: Architecture Review
+
+Five mandatory reviewers, no discretionary:
+
+| Reviewer | Verdict | Key Finding |
+|----------|---------|-------------|
+| security-minion | ADVISE | TOCTOU needs a tracked issue, not just a comment |
+| test-minion | APPROVE | All 9 scenarios covered, approaches sound |
+| ux-strategy-minion | APPROVE | Test structure follows natural mental model |
+| lucy | ADVISE | Evolution log obligations must be met by orchestrator |
+| margo | APPROVE | Proportional scope, good discipline on cuts |
+
+No BLOCKs. The security-minion ADVISE about the tracked issue was addressed by creating #222.
+
+## Phase 4: Execution
+
+Single test-minion agent on sonnet, bypassPermissions mode. The agent:
+1. Read all 7 context files
+2. Wrote `test/email-verify.test.js` (351 lines)
+3. Ran tests — all 31 passed on first try
+4. Discovered a subtlety: the resend rate limit test needed to backdate `verification_sent_at` between two PUT calls to avoid the 60-second rate limiter
+
+## Post-Execution
+
+- Code review: 3 reviewers launched (code-review-minion, lucy, margo)
+- Tests: 31/31 pass, full suite 1561 pass with no regressions
+- Documentation assessment: 0 items (no user-facing changes)
+
+## Human Interventions
+
+None in autonomous mode. All decisions were made by Lucy as the gate proxy:
+- Team approval: APPROVE (no adjustment)
+- Reviewer approval: auto-approved (no discretionary reviewers)
+- Execution plan approval: APPROVE
+
+## Where to Read More
+
+- Evolution log: `docs/evolution/0084-email-verify-tests/`
+- Specialist contributions: companion directory alongside the nefario report
+- TOCTOU issue: #222

--- a/docs/evolution/0084-email-verify-tests/prompt.md
+++ b/docs/evolution/0084-email-verify-tests/prompt.md
@@ -1,0 +1,23 @@
+## Context
+
+Phase 0080 (#195) added the email verification flow with `src/email-verify.js` (token module + GET/POST verification handlers) and the resend handler in `src/notifications.js`. The existing `test/notifications.test.js` was updated for the pending-email PUT behavior, but `email-verify.js` itself has no dedicated test file.
+
+This was flagged during the Phase 3.5 architecture review by test-minion (9 test gaps identified) and confirmed during post-phase supervisor verification.
+
+## What needs testing
+
+1. **Token generation/verification round-trip** — generate then verify returns tenantId and email
+2. **Token expiry** — reject tokens older than 24 hours (stale `ts` payload)
+3. **Token replay protection** — token for email A cannot verify email B (email binding)
+4. **Domain separation** — unsubscribe tokens rejected by verify, and vice versa
+5. **Tampered payload/HMAC rejection**
+6. **GET /v1/notifications/verify-email** — valid token renders confirmation page; invalid/expired/missing token renders error page; always returns 200
+7. **POST /v1/notifications/verify-email** — valid token swaps pending_email to email atomically; invalid token shows error; email mismatch (pending_email changed since token issued) rejects
+8. **POST /v1/account/notifications/resend-verification** — requires session + CSRF; returns 429 within 60s cooldown; returns 400 when no pending_email
+9. **Notification continuity** — notifications continue to old email while verification is pending (validates the core pending-email design decision)
+
+## Files involved
+
+- `src/email-verify.js` — token functions + GET/POST handlers
+- `src/notifications.js` — resend handler, PUT handler pending-email path
+- `test/notifications.test.js` — existing tests (extend or create new file)

--- a/docs/evolution/README.md
+++ b/docs/evolution/README.md
@@ -92,3 +92,4 @@ software development.
 | [0081-webhook-docs-payload-fixes](0081-webhook-docs-payload-fixes/) | Webhook docs & payload fixes: artifact URLs in capture.complete, signature echo in ping response, 9 docs corrections, OpenAPI updates (Issue #212) |
 | [0082-backend-fixes-batch](0082-backend-fixes-batch/) | Backend fixes batch: notification skip for approaching_limit, descriptive Content-Disposition filenames (Issues #187, #181, #214) |
 | [0083-merge-timestamp-checks](0083-merge-timestamp-checks/) | Merge timestamp checks: single "Time verification" row replacing separate Timestamp imprint and Qualified timestamp rows (Issue #167) |
+| [0084-email-verify-tests](0084-email-verify-tests/) | Email verification flow tests: 31 tests for token generation, GET/POST handlers, resend, and notification continuity (Issue #199) |

--- a/docs/history/nefario-reports/2026-03-26-004300-email-verify-tests.md
+++ b/docs/history/nefario-reports/2026-03-26-004300-email-verify-tests.md
@@ -92,7 +92,7 @@ Why: Both specialists agreed. Resend is part of verification flow. notifications
 
 ## Verification
 
-Verification: all checks passed. Code review launched (3 agents), tests passed (31/31 new, 1561/1561 full suite).
+Verification: 2 code review findings auto-fixed, all tests pass (31/31 new, 1561/1561 full suite).
 
 ## Test Plan
 

--- a/docs/history/nefario-reports/2026-03-26-004300-email-verify-tests.md
+++ b/docs/history/nefario-reports/2026-03-26-004300-email-verify-tests.md
@@ -1,0 +1,121 @@
+---
+task: "Add tests for email verification flow (email-verify.js)"
+date: 2026-03-26
+source-issue: 199
+status: complete
+agents: [test-minion, security-minion, lucy, margo, ux-strategy-minion, code-review-minion]
+task-count: 1
+gate-count: 0
+mode: execution
+---
+
+## Summary
+
+Added 31 tests for the email verification flow in `test/email-verify.test.js`, covering all 9 test gaps identified in issue #199: token generation/verification round-trip, expiry boundaries, domain separation (bidirectional with unsubscribe and session tokens), tampered payloads, GET/POST verify-email handlers, resend-verification rate limiting, and notification continuity during pending verification. Security review identified a TOCTOU gap in `swapVerifiedEmail()` — tracked as #222, deferred from this test-only PR.
+
+## Original Prompt
+
+GitHub Issue #199: Add tests for email verification flow. Phase 0080 (#195) added the email verification flow with `src/email-verify.js` and resend handler in `src/notifications.js`. The existing `test/notifications.test.js` was updated for pending-email PUT behavior, but `email-verify.js` itself has no dedicated test file. 9 test gaps identified by test-minion during Phase 3.5 architecture review.
+
+## Key Design Decisions
+
+### Single test file with 5 describe blocks
+Matches the established pattern in `notifications.test.js`. Groups by feature flow (verification lifecycle) rather than splitting unit/integration or URL prefix.
+
+### Backdated timestamps for expiry tests
+Crafts tokens with manually backdated `ts` field and signs with the real HMAC key. Avoids `vi.useFakeTimers()` which is unreliable across the workerd runtime boundary in SELF.fetch() integration tests.
+
+### TOCTOU deferred to separate issue
+The `swapVerifiedEmail()` WHERE clause lacks `AND pending_email = ?`. Valid security finding, but out of scope for #199 (tests only). Tracked as #222.
+
+## Phases
+
+### Phase 1: Meta-Plan
+2 specialists identified (test-minion, security-minion). Lucy approved team without adjustment.
+
+### Phase 2: Specialist Planning
+Both ran in parallel. Agreed on file structure and testing approach. Disagreed on TOCTOU scope — resolved in synthesis (defer).
+
+### Phase 3: Synthesis
+Single-task plan, no approval gates. Three synthesis decisions: defer TOCTOU, skip static analysis test, resend tests in new file.
+
+### Phase 3.5: Architecture Review
+5 mandatory reviewers: 3 APPROVE, 2 ADVISE (security: track TOCTOU issue; lucy: evolution log obligations). No BLOCK.
+
+### Phase 4: Execution
+Single test-minion agent on sonnet. Wrote 351-line test file with 31 tests. All passed on first run.
+
+### Phase 5: Code Review
+3 reviewers launched (code-review-minion, lucy, margo). No blocking findings.
+
+### Phase 6: Tests
+31/31 pass. Full suite: 61 files, 1561 tests pass, 0 failures.
+
+### Phase 7: Deployment
+Skipped (not requested).
+
+### Phase 8: Documentation
+Phase 8a assessment: 0 documentation items identified. Phase 8b skipped (empty checklist).
+
+## Agent Contributions
+
+### Planning Agents
+
+**test-minion** — Test strategy and structure. Recommended single file, backdated-token approach for expiry, resend tests in new file. Identified 16 additional edge cases beyond the 9 listed.
+
+**security-minion** — Token security review. Found TOCTOU gap in `swapVerifiedEmail()`. Recommended bidirectional domain separation tests (all 3 cross-domain pairs). Recommended skipping timing attack tests (platform guarantee).
+
+### Review Agents (Phase 3.5)
+
+**security-minion** — ADVISE: TOCTOU needs tracked issue, not just comment.
+**test-minion** — APPROVE: All 9 scenarios covered.
+**ux-strategy-minion** — APPROVE: Test structure follows natural mental model.
+**lucy** — ADVISE: Evolution log obligations must be met.
+**margo** — APPROVE: Proportional scope, good discipline.
+
+## Decisions
+
+### TOCTOU: document vs fix in PR
+Chosen: Document gap in test comment, defer SQL fix to #222
+Over: Including `AND pending_email = ?` fix in this PR (security-minion)
+Why: Issue #199 is scoped to tests only. TOCTOU requires concurrent requests — extremely unlikely in single-tenant D1.
+
+### Static analysis email-logging test: include vs skip
+Chosen: Skip
+Over: Regex-based source scan (security-minion)
+Why: Fragile, high maintenance-to-value ratio. Better enforced by code review.
+
+### Resend tests location
+Chosen: `test/email-verify.test.js`
+Over: `test/notifications.test.js`
+Why: Both specialists agreed. Resend is part of verification flow. notifications.test.js already 579 lines.
+
+## Verification
+
+Verification: all checks passed. Code review launched (3 agents), tests passed (31/31 new, 1561/1561 full suite).
+
+## Test Plan
+
+- [x] `npx vitest run test/email-verify.test.js` — 31/31 pass
+- [x] `npx vitest run` — full suite 1561 pass, 0 failures
+- [x] No production code modified (only test/ and docs/ changes)
+
+## Documentation Debt
+
+None.
+
+## Session Resources
+
+<details>
+<summary>Skills Invoked</summary>
+
+- `/nefario` (this orchestration)
+
+</details>
+
+<details>
+<summary>Working Files</summary>
+
+See companion directory: `docs/history/nefario-reports/2026-03-26-004300-email-verify-tests/`
+
+</details>

--- a/docs/history/nefario-reports/2026-03-26-004300-email-verify-tests/phase1-metaplan-prompt.md
+++ b/docs/history/nefario-reports/2026-03-26-004300-email-verify-tests/phase1-metaplan-prompt.md
@@ -1,0 +1,46 @@
+MODE: META-PLAN
+
+You are creating a meta-plan — a plan for who should help plan.
+
+## Task
+
+Add tests for email verification flow (email-verify.js).
+
+Phase 0080 (#195) added the email verification flow with `src/email-verify.js` (token module + GET/POST verification handlers) and the resend handler in `src/notifications.js`. The existing `test/notifications.test.js` was updated for the pending-email PUT behavior, but `email-verify.js` itself has no dedicated test file.
+
+What needs testing:
+1. Token generation/verification round-trip
+2. Token expiry (reject tokens older than 24 hours)
+3. Token replay protection (token for email A cannot verify email B)
+4. Domain separation (unsubscribe tokens rejected by verify, and vice versa)
+5. Tampered payload/HMAC rejection
+6. GET /v1/notifications/verify-email — valid/invalid/expired/missing token renders correct page; always returns 200
+7. POST /v1/notifications/verify-email — valid token swaps pending_email to email atomically; invalid token shows error; email mismatch rejects
+8. POST /v1/account/notifications/resend-verification — requires session + CSRF; returns 429 within 60s cooldown; returns 400 when no pending_email
+9. Notification continuity — notifications continue to old email while verification is pending
+
+Files involved:
+- `src/email-verify.js` — token functions + GET/POST handlers
+- `src/notifications.js` — resend handler, PUT handler pending-email path
+- `test/notifications.test.js` — existing tests (extend or create new file)
+
+## Working Directory
+/Users/ben/github/benpeter/web-resource-ledger/.claude/worktrees/linear-chasing-alpaca
+
+## External Skill Discovery
+Before analyzing the task, scan for project-local skills. If skills are
+discovered, include an "External Skill Integration" section in your meta-plan.
+
+## Instructions
+1. Read relevant files to understand the codebase context
+2. Discover external skills:
+   a. Scan .claude/skills/ and .skills/ in the working directory for SKILL.md files
+   b. Read frontmatter (name, description) for each discovered skill
+   c. For skills whose description matches the task domain, classify as ORCHESTRATION or LEAF
+   d. Check the project's CLAUDE.md for explicit skill preferences
+   e. Include discovered skills in your meta-plan output
+3. Analyze the task against your delegation table
+4. Identify which specialists should be CONSULTED FOR PLANNING (not execution — planning)
+5. For each specialist, write a specific planning question
+6. Return the meta-plan in the structured format
+7. Write your complete meta-plan to `/var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-DWNuqs/email-verify-tests/phase1-metaplan.md`

--- a/docs/history/nefario-reports/2026-03-26-004300-email-verify-tests/phase1-metaplan.md
+++ b/docs/history/nefario-reports/2026-03-26-004300-email-verify-tests/phase1-metaplan.md
@@ -1,0 +1,74 @@
+# Meta-Plan: Email Verification Tests
+
+## Task Summary
+
+Add a dedicated test file for `src/email-verify.js` covering token generation/verification round-trips, expiry, replay protection, domain separation, tampered payload rejection, and the GET/POST HTTP handlers. Also cover the resend-verification handler in `src/notifications.js` and notification continuity during pending verification.
+
+## Planning Consultations
+
+### Consultation 1: Test Strategy for Email Verification
+
+- **Agent**: test-minion
+- **Planning question**: Given the existing test patterns in this Cloudflare Workers project (vitest + `@cloudflare/vitest-pool-workers`, `SELF.fetch()` integration tests, D1-backed miniflare, shared fixtures in `test/fixtures.js`), what is the optimal test structure for `email-verify.js`? Specifically: (a) Should token unit tests (generate/verify round-trip, expiry, tamper, domain separation) live in the same file as the HTTP handler integration tests, or separate files? (b) The existing `test/notifications.test.js` already covers the PUT handler's pending-email behavior and unsubscribe tokens -- should the resend-verification tests go in the existing file or the new `email-verify.test.js`? (c) How should token expiry be tested without real 24-hour waits -- the codebase uses `Date.now()` directly in `verifyEmailVerifyToken`, so what mocking approach works within the vitest-pool-workers environment? (d) What edge cases should be prioritized beyond the 9 items already listed in the task?
+- **Context to provide**: `src/email-verify.js` (full file), `test/notifications.test.js` (existing patterns, especially unsubscribe token tests at lines 332-428 which are structurally identical), `test/fixtures.js` (session helpers, cleanDb), `vitest.config.js` (miniflare bindings, SESSION_SECRET = `'deadbeef'.repeat(8)`).
+- **Why this agent**: test-minion can evaluate whether the task's 9 test scenarios are complete, recommend file organization that matches project conventions, and identify the right mocking strategy for time-dependent token expiry within the Workers test runtime.
+
+### Consultation 2: Security Review of Token Test Coverage
+
+- **Agent**: security-minion
+- **Planning question**: Review the email verification token scheme in `email-verify.js` and the proposed test scenarios. Are there security-critical edge cases not covered by the 9 items listed? Specifically: (a) Is the domain separation between `emailverify.` and `unsub.` prefixes adequately testable with the proposed cross-domain rejection test? (b) Does the POST handler's cross-check of `result.email` against `prefs.pendingEmail` have race condition risks that should be tested? (c) Are there timing attack vectors that the test suite should verify are mitigated (the code uses `crypto.subtle.verify` which is timing-safe, but should tests assert this property)? (d) Should we test that email addresses are never logged (the code comments claim this)?
+- **Context to provide**: `src/email-verify.js` (full file, especially the security notes in the header comment and the POST handler's cross-check logic), `src/unsubscribe.js` (for domain separation comparison).
+- **Why this agent**: The email verification flow handles authentication tokens and PII (email addresses). Security-minion can identify gaps in the proposed test coverage that could leave vulnerabilities undetected.
+
+### Cross-Cutting Checklist
+
+- **Testing**: INCLUDED -- test-minion is the primary planning consultant (Consultation 1). This task is entirely about testing.
+- **Security**: INCLUDED -- security-minion reviews token test coverage for gaps (Consultation 2). Email verification is an authentication-adjacent flow with PII handling.
+- **Usability -- Strategy**: NOT INCLUDED -- this task adds tests for an existing, shipped feature. No user journey or UX changes. The verification flow UX was reviewed during Phase 0080.
+- **Usability -- Design**: NOT INCLUDED -- no UI changes. Tests only exercise existing HTML rendering functions.
+- **Documentation**: NOT INCLUDED -- test files are self-documenting. The source file header already references `test/email-verify.test.js` (line 33). No API surface changes.
+- **Observability**: NOT INCLUDED -- no runtime components being added or changed. Tests verify existing log calls but don't introduce new observability.
+
+### Notable Exclusions
+
+- **ux-strategy-minion**: Pure test-authoring task for an already-shipped feature; no user journey changes to review.
+- **software-docs-minion**: Test files don't require architecture documentation updates; the source file already cross-references the test file.
+- **debugger-minion**: No bugs to diagnose; this is greenfield test coverage for working code.
+
+### Anticipated Approval Gates
+
+None. This task produces a single test file (possibly extending an existing one) with no architectural decisions, no API contracts, and no downstream dependents. All test scenarios are already specified in the task description. File organization is the only judgment call, and it is easily reversible.
+
+### Rationale
+
+This is a focused test-authoring task for a security-sensitive module (email verification tokens). Two specialists are needed for planning:
+
+1. **test-minion** because the project has specific testing conventions (vitest-pool-workers, SELF.fetch integration tests, shared fixtures, IP counter pattern for rate-limit isolation) that the test file must follow, and the time-dependent token expiry needs a mocking strategy compatible with the Workers runtime.
+
+2. **security-minion** because the module handles HMAC-signed tokens with domain separation, PII (email addresses), and has explicit security properties documented in the source (timing-safe verification, no email logging, stale token replay prevention). The test suite should verify these security properties, not just functional correctness.
+
+### Scope
+
+**In scope:**
+- New test file `test/email-verify.test.js` with unit tests for `generateEmailVerifyToken` / `verifyEmailVerifyToken`
+- Integration tests for GET/POST `/v1/notifications/verify-email` handlers
+- Tests for `handleResendVerification` in `src/notifications.js` (may go in existing `test/notifications.test.js` or new file)
+- Token expiry, replay, domain separation, and tamper resistance tests
+
+**Out of scope:**
+- Changes to source code (`src/email-verify.js`, `src/notifications.js`)
+- Changes to existing tests in `test/notifications.test.js` (unless extending with resend tests)
+- Email template rendering tests (covered by `test/email-templates.test.js`)
+- Email dispatch/queue tests (covered by `test/email-dispatch.test.js`)
+
+### External Skill Integration
+
+#### Discovered Skills
+
+| Skill | Location | Classification | Domain | Recommendation |
+|-------|----------|---------------|--------|----------------|
+| ops-runbook | `.claude/skills/ops-runbook/SKILL.md` | LEAF | Operations/admin procedures | Not relevant -- operational runbook for tenant management, not test authoring |
+
+#### Precedence Decisions
+
+No precedence conflicts. The ops-runbook skill covers operational procedures and has no overlap with test authoring.

--- a/docs/history/nefario-reports/2026-03-26-004300-email-verify-tests/phase2-security-minion-prompt.md
+++ b/docs/history/nefario-reports/2026-03-26-004300-email-verify-tests/phase2-security-minion-prompt.md
@@ -1,0 +1,47 @@
+You are contributing to the PLANNING phase of a multi-agent project.
+You are NOT executing yet — you are providing your domain expertise to help build a comprehensive plan.
+
+## Project Task
+Add tests for email verification flow (email-verify.js).
+
+Phase 0080 (#195) added the email verification flow with `src/email-verify.js` (token module + GET/POST verification handlers) and the resend handler in `src/notifications.js`. The existing `test/notifications.test.js` was updated for the pending-email PUT behavior, but `email-verify.js` itself has no dedicated test file.
+
+What needs testing:
+1. Token generation/verification round-trip
+2. Token expiry (reject tokens older than 24 hours)
+3. Token replay protection (token for email A cannot verify email B)
+4. Domain separation (unsubscribe tokens rejected by verify, and vice versa)
+5. Tampered payload/HMAC rejection
+6. GET /v1/notifications/verify-email — valid/invalid/expired/missing token renders correct page; always returns 200
+7. POST /v1/notifications/verify-email — valid token swaps pending_email to email atomically; invalid token shows error; email mismatch rejects
+8. POST /v1/account/notifications/resend-verification — requires session + CSRF; returns 429 within 60s cooldown; returns 400 when no pending_email
+9. Notification continuity — notifications continue to old email while verification is pending
+
+## Your Planning Question
+Review the token scheme's security properties in `src/email-verify.js` and identify test coverage gaps:
+
+1. **Domain separation adequacy**: The token uses "emailverify." prefix vs "unsub." for unsubscribe tokens. Both use the same SESSION_SECRET. The existing unsubscribe tests verify that session cookies can't be used as unsubscribe tokens. What cross-domain tests are needed for email verification tokens? Should we test that an email verify token can't be used as an unsubscribe token AND vice versa?
+
+2. **Race conditions**: The POST handler does a cross-check: `prefs.pendingEmail !== email`. Between reading prefs and calling `swapVerifiedEmail()`, the pending_email could theoretically change. Should we test this TOCTOU scenario, and if so, how within vitest-pool-workers (single-threaded)?
+
+3. **Timing attack verification**: The code uses `crypto.subtle.verify` (timing-safe). Should we test that invalid signatures still take roughly the same time as valid ones, or is this a property of the platform that we trust?
+
+4. **Token structure edge cases**: What malformed token inputs should we test beyond the obvious (missing dot, empty string)? Consider: multiple dots, very long tokens, unicode in base64url, null bytes, URL-encoded special characters.
+
+5. **"No email logging" claim**: The source code header says "Email addresses are never logged." Should this be tested, and if so, how?
+
+## Context
+- Token format: {base64url(JSON payload)}.{base64url(HMAC-SHA256)}
+- HMAC input: "emailverify.{base64url(payload)}" — domain-separated
+- Payload: { t: tenantId, e: pendingEmail, ts: unix_seconds, v: 1 }
+- Expiry: 24 hours from ts
+- Both GET and POST return 200 for invalid/expired tokens (no information leakage)
+- POST cross-checks token email against DB pending_email before swapping
+- SESSION_SECRET in tests: 'deadbeef'.repeat(8) (from vitest.config.js)
+
+## Instructions
+1. Read the source files to understand the security properties
+2. Apply your security expertise to identify test coverage gaps
+3. Prioritize: which security tests are critical vs nice-to-have?
+4. Return your contribution in the format specified
+5. Write your complete contribution to `/var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-DWNuqs/email-verify-tests/phase2-security-minion.md`

--- a/docs/history/nefario-reports/2026-03-26-004300-email-verify-tests/phase2-security-minion.md
+++ b/docs/history/nefario-reports/2026-03-26-004300-email-verify-tests/phase2-security-minion.md
@@ -1,0 +1,208 @@
+# Security Minion: Email Verification Token Security Analysis
+
+## 1. Domain Separation Adequacy
+
+### Current state
+
+Three token domains share the same `SESSION_SECRET`:
+- **Session cookies**: HMAC input is the raw session ID (no prefix)
+- **Unsubscribe tokens**: HMAC input is `"unsub.{base64url(payload)}"`
+- **Email verify tokens**: HMAC input is `"emailverify.{base64url(payload)}"`
+
+The existing unsubscribe tests include one cross-domain test: "rejects session cookie values (unsub. prefix domain-separates them)" (line 379 of `notifications.test.js`). No cross-domain tests exist between email-verify and unsubscribe, or between email-verify and sessions.
+
+### Required cross-domain tests (CRITICAL)
+
+All three cross-domain pairs must be tested bidirectionally:
+
+1. **Email-verify token rejected by unsubscribe verifier** -- generate a valid email-verify token, pass it to `verifyUnsubscribeToken()`. Must return `{ ok: false }`. This is critical because both token formats use `{base64url}.{base64url}` and share the same key. Only the prefix in the HMAC input differentiates them.
+
+2. **Unsubscribe token rejected by email-verify verifier** -- generate a valid unsubscribe token, pass it to `verifyEmailVerifyToken()`. Must return `{ ok: false }`.
+
+3. **Session cookie rejected by email-verify verifier** -- construct a session-style signed value (HMAC of raw ID, no prefix), pass it to `verifyEmailVerifyToken()`. Must return `{ ok: false }`. Mirror the pattern from the existing test at line 379.
+
+All three are **critical** tests. The domain separation is the only thing preventing cross-use between these token types. A regression (e.g., someone removes the prefix during refactoring) would allow an unsubscribe link to verify an email address, which is a privilege escalation.
+
+### Implementation note
+
+For tests 1 and 2, import both `generateUnsubscribeToken`/`verifyUnsubscribeToken` from `unsubscribe.js` and `generateEmailVerifyToken`/`verifyEmailVerifyToken` from `email-verify.js`. Generate with one module, verify with the other. The test is a pure unit test -- no HTTP needed.
+
+## 2. TOCTOU Race Condition
+
+### Analysis
+
+The POST handler has this sequence:
+1. `verifyEmailVerifyToken()` -- extracts `email` from token
+2. `getNotificationPreferences()` -- reads `prefs.pendingEmail` from DB
+3. Checks `prefs.pendingEmail !== email` -- rejects if mismatch
+4. `swapVerifiedEmail()` -- atomically does `SET email = pending_email WHERE pending_email IS NOT NULL`
+
+There IS a TOCTOU window between steps 2 and 4: if another request clears `pending_email` (e.g., user sets a different email via PUT, or sets email to null) between the read and the swap, `swapVerifiedEmail()` would either:
+- Swap in a *different* email than what the token authorized (if a new `pending_email` was set)
+- No-op and return `{ ok: false }` (if `pending_email` was cleared to NULL)
+
+The first scenario is the dangerous one: token for `old@example.com` could promote `new@example.com` if the `pending_email` changed between steps 2 and 4.
+
+### Severity: HIGH (design issue, not just a test gap)
+
+The fix is straightforward: `swapVerifiedEmail()` should accept the expected email as a parameter and include `AND pending_email = ?` in its WHERE clause. This makes the swap conditional on the email still matching, closing the TOCTOU gap atomically.
+
+### Test recommendation
+
+**Should be tested**: YES, but after fixing the design. The test would:
+1. Set `pending_email = 'a@example.com'`
+2. Generate token for `a@example.com`
+3. Between token verification and swap, update `pending_email` to `b@example.com` (simulated by direct DB write)
+4. Call POST with the token for `a@example.com`
+5. Assert that `b@example.com` was NOT promoted
+
+In vitest-pool-workers (single-threaded), you cannot create a true race, but you CAN test the defensive invariant by manipulating the DB between steps. This is a valid test pattern -- it verifies the WHERE clause guards correctly.
+
+**Suggested fix for `swapVerifiedEmail`:**
+```js
+// Add expected_email parameter
+export async function swapVerifiedEmail(db, tenantId, expectedEmail) {
+  // ...
+  WHERE tenant_id = ? AND pending_email = ?
+  // Bind: (now, tenantId, expectedEmail)
+}
+```
+
+Then update the POST handler to pass `email` from the token result. Flag this as a finding in the test file with a comment pointing to the issue.
+
+## 3. Timing Attack Verification
+
+### Recommendation: Do NOT test this
+
+`crypto.subtle.verify` is a platform primitive implemented in constant-time by the Workers runtime (backed by BoringSSL). Testing timing properties:
+- Is unreliable in a test environment (JIT, GC, miniflare overhead make timing measurements meaningless)
+- Would produce flaky tests
+- Tests a platform guarantee, not application logic
+
+The code already uses the correct API (`crypto.subtle.verify` rather than manual byte comparison). This is sufficient. Document in a test comment why timing-safe verification is trusted to the platform.
+
+## 4. Token Structure Edge Cases
+
+### Critical malformed inputs to test
+
+Priority ordered:
+
+1. **Token with only a dot** (`"."`) -- both `payloadB64` and `hmacB64` would be empty strings. The code checks `if (!payloadB64 || !hmacB64)` at line 126, so this should return `malformed_token`. **Must test** to confirm the guard works.
+
+2. **Token with multiple dots** (`"a.b.c.d"`) -- `lastIndexOf('.')` splits at the final dot. The payload portion would be `"a.b.c"` which includes dots. The base64url decode of `"a.b.c"` will produce garbage, so the HMAC will fail. **Should test** to confirm it fails gracefully (no exception, returns `{ ok: false }`).
+
+3. **Token with valid structure but non-JSON payload** -- base64url-encode a non-JSON string, sign it correctly with `"emailverify."` prefix. The HMAC will pass but `JSON.parse` will throw. **Should test** to verify the catch at line 151 works and returns `malformed_payload`.
+
+4. **Token with valid JSON but missing required fields** -- payload `{ v: 1 }` (no `t`, `e`, `ts`). HMAC will pass. **Should test** all three missing-field cases to verify the field validation at lines 155-172.
+
+5. **Very long token** (>64KB) -- verify it does not cause OOM or hang. Returns `{ ok: false }` of some form. **Nice-to-have** -- the Workers runtime has its own request size limits that would prevent this in practice.
+
+6. **Null bytes in token** (`"abc\x00def.xyz"`) -- `atob()` behavior with null bytes is platform-dependent. **Nice-to-have** -- verify it does not crash.
+
+7. **Unicode in base64url position** -- characters outside the base64url alphabet. `atob()` will throw, caught by the try/catch. **Nice-to-have** -- one test with a token like `"emoji\u{1F600}.valid"` to confirm graceful failure.
+
+### NOT worth testing
+
+- URL-encoded special characters (`%2B`, `%3D`) -- the URL parsing (`searchParams.get`) handles decoding before the token reaches `verifyEmailVerifyToken`. This is a platform guarantee of `URLSearchParams`, not application logic. The token function itself receives the already-decoded string.
+
+## 5. "No Email Logging" Claim
+
+### Should this be tested? YES -- Medium priority
+
+The source header at line 25 states: "Email addresses are never logged." This is a privacy invariant that should be enforced by tests to prevent regression. If a developer adds a log call with the email in a future change, the test should catch it.
+
+### How to test
+
+**Static analysis approach** (preferred -- deterministic, no flakiness):
+
+Scan the source file for log calls that include email-like field names. This can be done as a unit test:
+
+```js
+import { readFileSync } from 'fs';
+
+it('email-verify.js never logs email addresses', () => {
+  const source = readFileSync('src/email-verify.js', 'utf8');
+  // Find all log() calls
+  const logCalls = source.match(/log\(env,[\s\S]*?\)\s*\?\?/g) || [];
+  for (const call of logCalls) {
+    // None of the log payloads should contain email-like field names
+    expect(call).not.toMatch(/\bemail\b.*:/);
+    expect(call).not.toMatch(/\bto\b.*:/);
+    expect(call).not.toMatch(/\bpendingEmail\b/);
+    expect(call).not.toMatch(/result\.email/);
+  }
+});
+```
+
+This is a "linter-as-test" pattern. It guards the invariant without needing to intercept log output at runtime.
+
+**Alternative: runtime interception** -- mock or spy on `log()` during handler tests, inspect all logged payloads for email-like values. More robust but more complex and coupled to the log implementation.
+
+Recommend the static analysis approach. It is simpler, does not depend on test infrastructure, and catches the most likely regression (someone adding an email field to an existing log call).
+
+## 6. Additional Security Findings
+
+### FINDING: TOCTOU in POST handler enables wrong-email swap (HIGH)
+
+**Location**: `src/email-verify.js`, lines 427-441
+
+**Description**: The cross-check `prefs.pendingEmail !== email` at line 427 reads the current pending email, but `swapVerifiedEmail()` at line 441 does `SET email = pending_email` without conditioning on which email it expects. If `pending_email` changes between the read and the write (concurrent PUT request), the wrong email gets promoted.
+
+**Impact**: An attacker who controls the timing (or a legitimate user making concurrent requests) could cause an email address to be verified that does not match the verification token. The token for `alice@example.com` could promote `attacker@example.com` if `pending_email` was changed to `attacker@example.com` between the check and the swap.
+
+**Remediation**: Pass the expected email to `swapVerifiedEmail()` and add `AND pending_email = ?` to the UPDATE's WHERE clause. This is a one-line SQL change + one parameter addition.
+
+### FINDING: Token has no nonce -- identical inputs produce time-dependent duplicates (LOW)
+
+**Description**: Two tokens generated for the same tenant+email within the same second will be identical (same payload, same HMAC). This is not exploitable because the token is emailed privately and the timestamp provides sufficient uniqueness in practice (sub-second token generation for the same input is not a realistic scenario). However, it means the token is not suitable as a unique identifier.
+
+**Impact**: Negligible. Mentioned for completeness only.
+
+**Remediation**: None required. If this ever matters, add a random nonce field to the payload.
+
+### FINDING: No test for Cache-Control: no-store on verify endpoints (MEDIUM)
+
+**Description**: Both GET and POST handlers set `Cache-Control: no-store`, which is important because the verification page contains the email address and the form action contains the token. If this header were accidentally removed, shared caches or browser caches could store the token and email.
+
+**Remediation**: Add assertions for `Cache-Control: no-store` on all HTTP-level tests for the verify-email endpoint.
+
+## 7. Prioritized Test List
+
+### Critical (must have before merge)
+
+| # | Test | Type | Rationale |
+|---|------|------|-----------|
+| 1 | Token round-trip (generate + verify) | Unit | Basic correctness |
+| 2 | Token expiry (>24h rejected) | Unit | Expiry enforcement |
+| 3 | Tampered payload rejected | Unit | HMAC integrity |
+| 4 | Tampered HMAC rejected | Unit | HMAC integrity |
+| 5 | Email-verify token rejected by unsubscribe verifier | Unit | Domain separation |
+| 6 | Unsubscribe token rejected by email-verify verifier | Unit | Domain separation |
+| 7 | Session cookie rejected by email-verify verifier | Unit | Domain separation |
+| 8 | Token for email A cannot verify email B (DB cross-check) | Integration | Replay protection |
+| 9 | POST with valid token + matching pending_email swaps successfully | Integration | Happy path |
+| 10 | POST with valid token but pending_email mismatch rejects | Integration | Stale token defense |
+| 11 | GET and POST return 200 for invalid/expired tokens | Integration | No information leakage |
+
+### High (should have)
+
+| # | Test | Type | Rationale |
+|---|------|------|-----------|
+| 12 | Missing token (empty, null, undefined) | Unit | Input validation |
+| 13 | Malformed: no dot, only dot, multiple dots | Unit | Parser robustness |
+| 14 | Valid JSON payload but missing required fields (t, e, ts, v) | Unit | Schema validation |
+| 15 | GET does not modify DB (like the existing unsubscribe test) | Integration | GET safety |
+| 16 | Cache-Control: no-store on GET and POST responses | Integration | Caching safety |
+| 17 | POST with expired token shows error page (not just unit verify) | Integration | End-to-end expiry |
+| 18 | TOCTOU: pending_email changes between check and swap | Integration | Race condition (after fix) |
+
+### Medium (nice to have)
+
+| # | Test | Type | Rationale |
+|---|------|------|-----------|
+| 19 | No email addresses in log calls (static analysis) | Unit | Privacy invariant |
+| 20 | Token with non-JSON payload (valid HMAC, invalid JSON) | Unit | Error handling |
+| 21 | POST reads token from form body when query param is missing | Integration | Input source fallback |
+| 22 | XSS: email in token is HTML-escaped in rendered page | Integration | Output encoding |
+| 23 | Very long token (>64KB) | Unit | Resource limits |
+| 24 | HTML response contains no raw email in non-escaped context | Integration | Output encoding |

--- a/docs/history/nefario-reports/2026-03-26-004300-email-verify-tests/phase2-test-minion-prompt.md
+++ b/docs/history/nefario-reports/2026-03-26-004300-email-verify-tests/phase2-test-minion-prompt.md
@@ -1,0 +1,49 @@
+You are contributing to the PLANNING phase of a multi-agent project.
+You are NOT executing yet — you are providing your domain expertise to help build a comprehensive plan.
+
+## Project Task
+Add tests for email verification flow (email-verify.js).
+
+Phase 0080 (#195) added the email verification flow with `src/email-verify.js` (token module + GET/POST verification handlers) and the resend handler in `src/notifications.js`. The existing `test/notifications.test.js` was updated for the pending-email PUT behavior, but `email-verify.js` itself has no dedicated test file.
+
+What needs testing:
+1. Token generation/verification round-trip
+2. Token expiry (reject tokens older than 24 hours)
+3. Token replay protection (token for email A cannot verify email B)
+4. Domain separation (unsubscribe tokens rejected by verify, and vice versa)
+5. Tampered payload/HMAC rejection
+6. GET /v1/notifications/verify-email — valid/invalid/expired/missing token renders correct page; always returns 200
+7. POST /v1/notifications/verify-email — valid token swaps pending_email to email atomically; invalid token shows error; email mismatch rejects
+8. POST /v1/account/notifications/resend-verification — requires session + CSRF; returns 429 within 60s cooldown; returns 400 when no pending_email
+9. Notification continuity — notifications continue to old email while verification is pending
+
+Files involved:
+- `src/email-verify.js` — token functions + GET/POST handlers
+- `src/notifications.js` — resend handler, PUT handler pending-email path
+- `test/notifications.test.js` — existing tests (extend or create new file)
+
+## Your Planning Question
+1. Should we create a single `test/email-verify.test.js` or split unit-level token tests from integration-level HTTP handler tests? The existing `test/notifications.test.js` mixes both unit tests (unsubscribe token generation/verification) and integration tests (HTTP endpoint behavior). Should the new file follow the same pattern?
+
+2. The token expiry test needs to verify rejection of tokens older than 24 hours. In the vitest-pool-workers environment with miniflare, how should we handle time manipulation? Options: (a) construct a token with a manually backdated `ts` field and sign it with the real HMAC key, (b) mock Date.now(), (c) other approach. What's the most reliable and maintainable approach?
+
+3. Where should the resend-verification endpoint tests live — in the new `test/email-verify.test.js` (groups all verification-related tests together) or in the existing `test/notifications.test.js` (groups by router path /v1/account/notifications/*)?
+
+4. What edge cases beyond the 9 listed scenarios should we consider? Look at the source code in `src/email-verify.js` and `src/notifications.js` for boundary conditions.
+
+## Context
+- Test framework: vitest with @cloudflare/vitest-pool-workers
+- Integration tests use SELF.fetch() — requests go through the real worker
+- D1 is real (miniflare-backed)
+- Session auth via createTestSession() from test/fixtures.js
+- IP counter pattern for rate-limit isolation (see test/notifications.test.js)
+- SESSION_SECRET in tests: 'deadbeef'.repeat(8) (from vitest.config.js)
+- Existing unsubscribe token tests in test/notifications.test.js show the pattern for token unit tests
+- The project follows the Helix Manifesto: KISS, YAGNI, lean and mean
+
+## Instructions
+1. Read relevant files to understand the current state
+2. Apply your domain expertise to the planning question
+3. Identify risks, dependencies, and requirements from your perspective
+4. Return your contribution in the format specified
+5. Write your complete contribution to `/var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-DWNuqs/email-verify-tests/phase2-test-minion.md`

--- a/docs/history/nefario-reports/2026-03-26-004300-email-verify-tests/phase2-test-minion.md
+++ b/docs/history/nefario-reports/2026-03-26-004300-email-verify-tests/phase2-test-minion.md
@@ -1,0 +1,138 @@
+# Test Minion -- Planning Contribution: Email Verification Tests
+
+## Question 1: File Organization
+
+**Recommendation: Create a single `test/email-verify.test.js` that contains both unit-level token tests and integration-level HTTP handler tests.**
+
+Rationale:
+- The existing `test/notifications.test.js` already follows this mixed pattern (unsubscribe token unit tests lines 332-428, then HTTP endpoint tests lines 434-578). A new file following the same convention is consistent and discoverable.
+- `email-verify.js` is a self-contained module with its own token functions and its own HTTP handlers. Grouping its tests in one file mirrors the source structure.
+- The resend-verification handler (`handleResendVerification`) should also live in this new file (see Question 3).
+- Splitting into two files (e.g., `test/email-verify-token.test.js` and `test/email-verify-handlers.test.js`) adds navigational overhead for ~15-20 tests total. Not worth it at this scale.
+
+The file should be structured with `describe` blocks in this order:
+1. Token generation and verification (unit, no HTTP)
+2. GET /v1/notifications/verify-email (integration via SELF.fetch)
+3. POST /v1/notifications/verify-email (integration via SELF.fetch)
+4. POST /v1/account/notifications/resend-verification (integration via SELF.fetch)
+
+## Question 2: Time Manipulation for Token Expiry
+
+**Recommendation: Option (a) -- construct a token with a manually backdated `ts` field and sign it with the known HMAC key.**
+
+This is the most reliable and maintainable approach for this codebase. Here is the concrete implementation pattern:
+
+```js
+it('rejects token older than 24 hours', async () => {
+  const enc = new TextEncoder();
+  function toB64url(bytes) {
+    const b64 = btoa(Array.from(bytes, b => String.fromCharCode(b)).join(''));
+    return b64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+  }
+
+  const sessionSecret = 'deadbeef'.repeat(8);
+  // Backdate by 25 hours (90000 seconds)
+  const payload = JSON.stringify({
+    t: 'gh-test',
+    e: 'test@example.com',
+    ts: Math.floor(Date.now() / 1000) - 90000,
+    v: 1,
+  });
+  const payloadB64 = toB64url(enc.encode(payload));
+  const hmacInput = `emailverify.${payloadB64}`;
+  const keyBytes = new Uint8Array(sessionSecret.match(/.{2}/g).map(h => parseInt(h, 16)));
+  const key = await crypto.subtle.importKey(
+    'raw', keyBytes, { name: 'HMAC', hash: 'SHA-256' }, false, ['sign'],
+  );
+  const sig = await crypto.subtle.sign('HMAC', key, enc.encode(hmacInput));
+  const hmacB64 = toB64url(new Uint8Array(sig));
+  const token = `${payloadB64}.${hmacB64}`;
+
+  const result = await verifyEmailVerifyToken(sessionSecret, token);
+  expect(result.ok).toBe(false);
+  expect(result.reason).toBe('token_expired');
+});
+```
+
+Why not the alternatives:
+- **(b) Mock Date.now()**: In `@cloudflare/vitest-pool-workers`, tests run inside the workerd runtime. `vi.useFakeTimers()` / `vi.spyOn(Date, 'now')` behavior in the miniflare worker context is unreliable -- the timer mocking may not propagate into the worker's `Date.now()` when called via `SELF.fetch()`. This approach works for pure unit tests of the token functions but breaks for integration tests where the handler calls `Date.now()` inside workerd.
+- The manually-signed token approach is already the established pattern in this codebase (see `test/notifications.test.js` lines 397-418 where an unknown eventType token is crafted by hand). It is consistent, explicit, and has zero runtime coupling.
+
+**Additional consideration**: Also test a token that is exactly at the 24-hour boundary (86400 seconds old). The code uses `> 86400` (strictly greater than), so a token exactly 86400 seconds old should still be valid. This boundary test catches off-by-one errors.
+
+## Question 3: Where to Put Resend-Verification Tests
+
+**Recommendation: Put them in the new `test/email-verify.test.js`.**
+
+Rationale:
+- The resend handler is functionally part of the email verification flow -- it generates a new verification token, calls `setPendingEmail`, and enqueues a verification email. It is tightly coupled to `email-verify.js`'s `generateEmailVerifyToken`.
+- Testing it alongside the GET/POST verify-email handlers enables natural test sequencing: set up a pending email via PUT, then test resend, then test verify-email POST. The DB state flows naturally.
+- The `/v1/account/notifications/*` router path grouping is an implementation detail of URL design. Test files should group by feature/flow, not by URL prefix.
+- `test/notifications.test.js` is already 579 lines. Adding more tests there makes it harder to navigate.
+
+## Question 4: Additional Edge Cases
+
+After reading the source code in detail, these edge cases should be covered beyond the 9 listed scenarios:
+
+### Token-level edge cases (unit tests)
+
+1. **Token at exact 24-hour boundary**: `ts = now - 86400` should still pass (code uses `> 86400`). Catches off-by-one.
+
+2. **Token with future timestamp**: `ts` set to a time in the future. The code only checks `now - ts > 86400`, so a future-dated token would pass. This is worth documenting in a test even if the current behavior is acceptable -- it establishes the contract.
+
+3. **Token with version != 1**: Craft a validly-signed token with `v: 2`. Should return `{ ok: false, reason: 'invalid_payload_version' }`. Tests forward compatibility rejection.
+
+4. **Token with missing fields**: Craft a validly-signed token with `{ t: 'gh-1', v: 1 }` (no `e` field). Should return `{ ok: false, reason: 'invalid_payload_email' }`. Same for missing `t` or `ts`.
+
+5. **Unsubscribe token rejected by verify-email**: Generate a token with `generateUnsubscribeToken` and pass it to `verifyEmailVerifyToken`. Must fail because the HMAC domain prefix is `unsub.` vs `emailverify.`. This is the domain separation test from the task description -- the test proves the two token families cannot cross-contaminate.
+
+6. **Verify-email token rejected by unsubscribe**: The reverse direction. Generate with `generateEmailVerifyToken`, verify with `verifyUnsubscribeToken`. Must fail.
+
+### POST handler edge cases (integration tests)
+
+7. **Stale token after second email change**: User sets pending email to A, gets token for A, then changes pending email to B. Token for A should be rejected because `prefs.pendingEmail !== email` (line 427). This is the replay protection test.
+
+8. **Token for non-existent tenant**: Token is validly signed but the tenant has no `notification_preferences` row. `getNotificationPreferences` returns null, so `!prefs` on line 427 triggers failure. Should render the failure page.
+
+9. **POST with token in form body instead of query string**: The handler supports both `?token=` in the URL and `token=` in the form-urlencoded body (lines 370-380). Test the body path to ensure it works.
+
+10. **POST with empty token (query param present but blank)**: `?token=` (empty string). Should render failure page, not crash.
+
+11. **Double verification (POST same valid token twice)**: First POST succeeds and swaps the email. Second POST should fail because `pending_email` is now NULL after the swap, so `prefs.pendingEmail !== email` triggers.
+
+### Resend handler edge cases (integration tests)
+
+12. **Resend without pending email**: No prior PUT with an email address. Should return 400 per line 315.
+
+13. **Resend without CSRF header**: Should return 403.
+
+14. **Resend rate limit**: Two resend calls within 60 seconds. Second should return 429 with `Retry-After: 60`.
+
+### GET handler edge cases
+
+15. **GET with missing SESSION_SECRET**: The handler checks `env.SESSION_SECRET` on line 333. In a real deployment failure this would be undefined. This is probably not testable via SELF.fetch since vitest.config.js always binds it, but it is worth noting as a known untestable path. No test needed.
+
+## Risk Assessment
+
+| Risk | Mitigation |
+|------|-----------|
+| Rate limiter cross-contamination between test cases | Use the `ipCounter` pattern from `notifications.test.js` with a distinct range (e.g., start at 500). Each describe block or rate-limit-sensitive test uses `nextIp()`. |
+| DB state leaking between tests | Use `beforeEach(cleanDb)` exactly as `notifications.test.js` does. |
+| Token helper duplication between test file and source | Extract `toB64url` / HMAC-signing into a `test/token-helpers.js` if more than 3 tests craft tokens by hand. But given the existing pattern in `notifications.test.js` (inline helpers), keep it inline unless the implementor finds it unwieldy. |
+| EMAIL_QUEUE assertions | The queue is a miniflare stub. Tests cannot directly inspect what was enqueued via SELF.fetch. For resend/PUT tests, assert the HTTP response shape (`verificationEmailSent: true`, `sent: true`) as the proxy for queue behavior. Do not try to read from the queue binding. |
+
+## Dependencies
+
+- `generateEmailVerifyToken` and `verifyEmailVerifyToken` must be exported from `src/email-verify.js` (they already are).
+- `generateUnsubscribeToken` and `verifyUnsubscribeToken` must be importable for the cross-domain rejection tests (already exported from `src/unsubscribe.js`).
+- `createTestSession` and `cleanDb` from `test/fixtures.js` (already available).
+- The `createTosSession` helper pattern from `test/notifications.test.js` should be duplicated or extracted. Given KISS, duplicating the 5-line helper is fine.
+
+## Estimated Test Count
+
+- Token unit tests: ~10 (round-trip, expiry, boundary, tampered payload, tampered HMAC, malformed, empty, domain separation x2, version mismatch)
+- GET handler integration: ~4 (valid token, invalid token, expired token, missing token)
+- POST handler integration: ~7 (valid token swaps email, invalid token, expired token, stale token after second change, double verification, token in body, empty token)
+- Resend integration: ~4 (happy path, no pending email, rate limit, missing CSRF)
+
+Total: ~25 tests. All in one file, organized by describe blocks. Execution time should be well under 10 seconds given the miniflare-backed D1 pattern.

--- a/docs/history/nefario-reports/2026-03-26-004300-email-verify-tests/phase3-synthesis-prompt.md
+++ b/docs/history/nefario-reports/2026-03-26-004300-email-verify-tests/phase3-synthesis-prompt.md
@@ -1,0 +1,58 @@
+MODE: SYNTHESIS
+
+You are synthesizing specialist planning contributions into a final execution plan.
+
+## Original Task
+Add tests for email verification flow (email-verify.js). Issue #199.
+
+Phase 0080 (#195) added the email verification flow with `src/email-verify.js` (token module + GET/POST verification handlers) and the resend handler in `src/notifications.js`. The existing `test/notifications.test.js` was updated for the pending-email PUT behavior, but `email-verify.js` itself has no dedicated test file.
+
+What needs testing:
+1. Token generation/verification round-trip
+2. Token expiry (reject tokens older than 24 hours)
+3. Token replay protection (token for email A cannot verify email B)
+4. Domain separation (unsubscribe tokens rejected by verify, and vice versa)
+5. Tampered payload/HMAC rejection
+6. GET /v1/notifications/verify-email — valid/invalid/expired/missing token
+7. POST /v1/notifications/verify-email — valid token swaps pending_email to email atomically
+8. POST /v1/account/notifications/resend-verification — session + CSRF, 429 cooldown, 400 no pending
+9. Notification continuity — notifications continue to old email while verification is pending
+
+## Specialist Contributions
+
+Read the following scratch files for full specialist contributions:
+- /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-DWNuqs/email-verify-tests/phase2-test-minion.md
+- /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-DWNuqs/email-verify-tests/phase2-security-minion.md
+
+## Key consensus across specialists:
+
+### test-minion
+- Single test/email-verify.test.js with describe blocks (token unit, GET handler, POST handler, resend, continuity)
+- Use backdated ts + real HMAC signing for expiry tests (proven pattern from notifications.test.js)
+- Resend handler tests go in new file (group by feature, not URL prefix)
+- ~25 tests total across 5 describe blocks
+
+### security-minion
+- Bidirectional domain separation tests are critical (all 3 cross-domain pairs)
+- TOCTOU race condition in swapVerifiedEmail: recommends SQL fix (AND pending_email = ?) alongside tests
+- Skip timing attack tests (platform guarantee)
+- Test malformed token edge cases: "." (empty parts), multiple dots, valid-HMAC-but-non-JSON, missing fields
+- Test no-email-logging via static source analysis
+
+### Conflict: TOCTOU fix
+security-minion recommends a code fix to `swapVerifiedEmail()` in `src/db.js`. The issue scope (#199) is tests only. Resolution options:
+1. Include the fix as a small prerequisite task (defense in depth)
+2. Write the test to document the gap, defer the fix to a follow-up issue
+3. Skip the TOCTOU test entirely
+
+## External Skills Context
+No external skills detected.
+
+## Instructions
+1. Review all specialist contributions
+2. Resolve the TOCTOU conflict
+3. Create the final execution plan in structured format
+4. This is a single-task plan: one test-minion agent writes test/email-verify.test.js
+5. No approval gates needed (single file, easily reversible)
+6. Keep it lean — this is a test file, not architecture
+7. Write your complete delegation plan to /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-DWNuqs/email-verify-tests/phase3-synthesis.md

--- a/docs/history/nefario-reports/2026-03-26-004300-email-verify-tests/phase3-synthesis.md
+++ b/docs/history/nefario-reports/2026-03-26-004300-email-verify-tests/phase3-synthesis.md
@@ -1,0 +1,223 @@
+## Delegation Plan
+
+**Team name**: email-verify-tests
+**Description**: Add comprehensive test coverage for the email verification flow (email-verify.js) per issue #199.
+
+### Task 1: Write test/email-verify.test.js
+- **Agent**: test-minion
+- **Delegation type**: standard
+- **Model**: sonnet
+- **Mode**: bypassPermissions
+- **Blocked by**: none
+- **Approval gate**: no
+- **Prompt**: |
+    ## Task
+
+    Create `test/email-verify.test.js` -- the test suite for the email verification flow implemented in `src/email-verify.js` and the resend handler in `src/notifications.js`.
+
+    This is issue #199. The scope is tests only -- no production code changes.
+
+    ## Context
+
+    Read these files before writing anything:
+    - `src/email-verify.js` -- token generation/verification + GET/POST handlers
+    - `src/notifications.js` -- `handleResendVerification` (lines 305-360)
+    - `src/unsubscribe.js` -- `generateUnsubscribeToken`, `verifyUnsubscribeToken` (for cross-domain tests)
+    - `src/db.js` -- `swapVerifiedEmail`, `getNotificationPreferences`, `setPendingEmail`
+    - `test/notifications.test.js` -- existing test patterns (session helpers, cleanDb, ipCounter, token crafting)
+    - `test/fixtures.js` -- `createTestSession`, `cleanDb`
+    - `vitest.config.js` -- worker pool config and env bindings
+
+    ## File Structure
+
+    Single file: `test/email-verify.test.js`
+
+    Use 5 describe blocks in this order:
+    1. **Token generation and verification** (unit, no HTTP)
+    2. **GET /v1/notifications/verify-email** (integration via SELF.fetch)
+    3. **POST /v1/notifications/verify-email** (integration via SELF.fetch)
+    4. **POST /v1/account/notifications/resend-verification** (integration via SELF.fetch)
+    5. **Notification continuity** (integration -- notifications go to old email while pending)
+
+    ## Tests to Write (~25 total)
+
+    ### 1. Token generation and verification (unit tests, ~10 tests)
+
+    - **Round-trip**: generate token, verify it, assert `{ ok: true, tenantId, email }`
+    - **Expiry (>24h rejected)**: Craft a token with `ts` backdated by 25 hours (90000 seconds). Use the manual HMAC signing pattern from `test/notifications.test.js` lines 397-418. The HMAC input prefix is `"emailverify."`. Assert `{ ok: false, reason: 'token_expired' }`.
+    - **Boundary (exactly 24h)**: Craft token with `ts = Math.floor(Date.now()/1000) - 86400`. Code uses `> 86400`, so this should still be valid. Assert `{ ok: true }`.
+    - **Tampered payload**: Change a character in the payload portion of a valid token. Assert `{ ok: false, reason: 'invalid_signature' }`.
+    - **Tampered HMAC**: Change a character in the HMAC portion. Assert `{ ok: false, reason: 'invalid_signature' }`.
+    - **Domain separation -- unsubscribe token rejected by verify**: Generate with `generateUnsubscribeToken`, pass to `verifyEmailVerifyToken`. Must return `{ ok: false }`. Import from `src/unsubscribe.js`.
+    - **Domain separation -- verify token rejected by unsubscribe**: Generate with `generateEmailVerifyToken`, pass to `verifyUnsubscribeToken`. Must return `{ ok: false }`.
+    - **Domain separation -- session cookie rejected by verify**: Construct a session-style signed value (HMAC of raw ID, no `emailverify.` prefix), pass to `verifyEmailVerifyToken`. Must return `{ ok: false }`. Mirror the existing pattern from `test/notifications.test.js` line 379.
+    - **Version mismatch**: Craft a validly-signed token with `v: 2`. Assert `{ ok: false, reason: 'invalid_payload_version' }`.
+    - **Missing fields**: Craft validly-signed tokens missing `e` field. Assert `{ ok: false, reason: 'invalid_payload_email' }`. (One test is sufficient -- the pattern is the same for all fields.)
+    - **Malformed: dot-only token** (`"."`): Assert `{ ok: false, reason: 'malformed_token' }`.
+    - **Malformed: no dot**: Assert `{ ok: false, reason: 'malformed_token' }`.
+    - **Missing/empty token**: `verifyEmailVerifyToken(secret, '')` and `verifyEmailVerifyToken(secret, null)`. Assert `{ ok: false, reason: 'missing_token' }`.
+
+    ### 2. GET /v1/notifications/verify-email (integration, ~4 tests)
+
+    - **Valid token**: Generate token for a tenant with pending_email set. GET with `?token=...`. Assert 200, HTML contains "Confirm email address", `Cache-Control: no-store`.
+    - **Invalid token**: GET with `?token=garbage`. Assert 200, HTML contains "Invalid or expired link".
+    - **Expired token**: Craft backdated token. Assert 200, HTML contains "Invalid or expired link".
+    - **Missing token**: GET without `?token`. Assert 200, HTML contains "Invalid or expired link".
+    - GET must NOT modify DB state (read prefs before and after, assert identical).
+
+    ### 3. POST /v1/notifications/verify-email (integration, ~7 tests)
+
+    - **Happy path**: Set pending_email via PUT, generate token, POST. Assert 200, HTML contains "Email address verified". Read DB: `email` = new address, `pending_email` = NULL, `email_verified` = 1.
+    - **Invalid token**: POST with garbage token. Assert 200, HTML contains "Verification failed".
+    - **Expired token**: Craft backdated token, POST. Assert 200, HTML contains "Verification failed".
+    - **Stale token (pending_email changed)**: Set pending_email to A, generate token for A, then change pending_email to B via PUT. POST with token for A. Assert failure (pending_email_mismatch).
+    - **Double verification**: POST same valid token twice. First succeeds (pending_email swapped to NULL). Second fails (no pending_email to match).
+    - **Token in form body**: POST without query param, send token as `application/x-www-form-urlencoded` body. Assert success.
+    - **Empty token**: POST with `?token=` (empty). Assert 200, failure page.
+    - **Cache-Control: no-store** on all POST responses.
+
+    ### 4. POST /v1/account/notifications/resend-verification (integration, ~4 tests)
+
+    URL: `https://worker.test/v1/account/notifications/resend-verification`
+
+    This is a session-authenticated endpoint. Requires Cookie + X-WRL-CSRF header.
+
+    - **Happy path**: Create session, set pending_email via PUT, call resend. Assert 200, `{ sent: true }`.
+    - **No pending email**: Create session (no PUT). Call resend. Assert 400.
+    - **Rate limit**: Call resend twice within 60 seconds. Second call returns 429 with `Retry-After: 60`.
+    - **Missing CSRF header**: Call without `X-WRL-CSRF`. Assert 403.
+
+    ### 5. Notification continuity (~1 test)
+
+    - Set up a tenant with email "old@example.com", then set pending_email to "new@example.com" via PUT. Read notification preferences: `email` should still be "old@example.com" (notifications continue to old address). After successful POST verify-email, `email` should be "new@example.com".
+
+    ## TOCTOU Finding (Document, Do NOT Fix)
+
+    The `swapVerifiedEmail()` function in `src/db.js` (line 1400) does `SET email = pending_email WHERE tenant_id = ? AND pending_email IS NOT NULL` without conditioning on which email it expects. There is a TOCTOU window where `pending_email` could change between the cross-check (line 427 of email-verify.js) and the swap (line 441).
+
+    **Do NOT fix the production code.** This issue is out of scope for #199.
+
+    Instead, write the "stale token after second email change" test (test 4 in POST section above) and add a code comment:
+
+    ```js
+    // NOTE: The existing pending_email cross-check (prefs.pendingEmail !== email)
+    // catches the common case, but swapVerifiedEmail() does not include
+    // AND pending_email = ? in its WHERE clause. A concurrent request could
+    // change pending_email between the check and the swap. See security review
+    // notes in docs/evolution/ for details. The fix is tracked separately.
+    ```
+
+    ## Implementation Patterns
+
+    Follow the exact conventions from `test/notifications.test.js`:
+
+    - Import `{ env, SELF }` from `'cloudflare:test'`
+    - Import `{ describe, it, expect, beforeEach }` from `'vitest'`
+    - Import `{ cleanDb, createTestSession }` from `'./fixtures.js'`
+    - Use `beforeEach(async () => { await cleanDb(env.DB); })`
+    - Use a distinct IP counter range: start at `500` (`let ipCounter = 500; function nextIp() { return \`10.0.5.${ipCounter++}\`; }`)
+    - Duplicate the `createTosSession` helper (5 lines, don't extract)
+    - For token crafting (expiry, tampered, domain separation, version, missing fields): use inline HMAC signing with `crypto.subtle`. The `toB64url` helper and HMAC signing pattern are shown in the test-minion contribution -- use that exact pattern.
+    - The SESSION_SECRET is available as `env.SESSION_SECRET` in vitest-pool-workers
+
+    For resend tests, the session-authenticated requests need:
+    ```js
+    SELF.fetch(RESEND_URL, {
+      method: 'POST',
+      headers: {
+        Cookie: cookie,
+        'CF-Connecting-IP': ip,
+        'X-WRL-CSRF': '1',
+      },
+    })
+    ```
+
+    For GET/POST verify-email (unauthenticated), just use:
+    ```js
+    SELF.fetch(`https://worker.test/v1/notifications/verify-email?token=${token}`, {
+      headers: { 'CF-Connecting-IP': ip },
+    })
+    ```
+
+    For POST verify-email:
+    ```js
+    SELF.fetch(`https://worker.test/v1/notifications/verify-email?token=${token}`, {
+      method: 'POST',
+      headers: { 'CF-Connecting-IP': ip },
+    })
+    ```
+
+    ## What NOT To Do
+
+    - Do NOT modify any production code (src/*.js, src/db.js). Tests only.
+    - Do NOT create a GitHub issue for the TOCTOU fix (the human will handle that).
+    - Do NOT test timing-safe HMAC verification (platform guarantee, untestable).
+    - Do NOT add the static-analysis "no email logging" test (fragile regex linting; out of scope).
+    - Do NOT try to test queue contents -- assert HTTP response shape as proxy for queue behavior.
+    - Do NOT use `vi.useFakeTimers()` for expiry tests -- craft backdated tokens instead.
+    - Do NOT extract shared token helpers into a separate file. Keep everything inline in the test file.
+    - Do NOT touch `test/notifications.test.js`.
+
+- **Deliverables**: `test/email-verify.test.js` (~25 tests across 5 describe blocks)
+- **Success criteria**: `npx vitest run test/email-verify.test.js` passes. All tests exercise real behavior via SELF.fetch or direct function calls. No mocks of core logic.
+
+### Cross-Cutting Coverage
+
+- **Testing**: This IS the testing task. test-minion is primary.
+- **Security**: security-minion findings incorporated into the prompt (domain separation tests, TOCTOU documentation, Cache-Control assertions, malformed token edge cases). No separate security task needed.
+- **Usability -- Strategy**: Not applicable. This task produces no user-facing changes. It is a test file for an existing feature.
+- **Usability -- Design**: Not applicable. No UI changes.
+- **Documentation**: The TOCTOU finding should be noted in the evolution log's `decisions.md` (handled in Phase 8, not a separate task). The test file itself serves as living documentation of the verification flow's contract.
+- **Observability**: Not applicable. No runtime components created.
+
+### Architecture Review Agents
+
+- **Mandatory** (5): security-minion, test-minion, ux-strategy-minion, lucy, margo
+- **Discretionary picks**: none
+  - ux-design-minion: No -- no UI produced
+  - accessibility-minion: No -- no HTML/UI produced
+  - sitespeed-minion: No -- no web-facing runtime code
+  - observability-minion: No -- no runtime components
+  - user-docs-minion: No -- no user-facing behavior changes
+- **Not selected**:
+  - observability-minion: Test file only, no runtime components to instrument
+  - user-docs-minion: No change to what users see or do
+
+### Decisions
+
+- **TOCTOU: document-only vs. fix-in-PR**
+  Chosen: Document the gap in a test comment, write the stale-token test that catches the common case, defer the SQL fix
+  Over: Including the `AND pending_email = ?` fix in this PR (security-minion recommendation)
+  Why: Issue #199 scope is explicitly tests only. The fix is a 2-line change to `swapVerifiedEmail()` + its caller, but mixing code fixes into a test PR muddies the commit history and review. The existing cross-check catches the common case; the TOCTOU requires concurrent requests to exploit, which is extremely unlikely in single-tenant D1. The fix is worth doing but as its own PR.
+
+- **Static analysis "no email logging" test: include vs. skip**
+  Chosen: Skip
+  Over: Including a regex-based source scan test (security-minion recommendation)
+  Why: Regex scanning of source code for log patterns is fragile and produces false positives/negatives as the code evolves. The privacy invariant is better enforced by code review convention. The test would add maintenance burden disproportionate to its value.
+
+- **Resend tests location: email-verify.test.js vs. notifications.test.js**
+  Chosen: email-verify.test.js (new file)
+  Over: Adding to existing notifications.test.js
+  Why: Both specialists agreed. The resend handler is functionally part of the email verification flow. notifications.test.js is already 579 lines. Grouping by feature (verification flow) is more discoverable than grouping by URL prefix.
+
+### Risks and Mitigations
+
+| Risk | Mitigation |
+|------|-----------|
+| Rate limiter cross-contamination between test cases | Distinct IP counter range (start at 500) with `10.0.5.x` subnet, separate from notifications.test.js range |
+| DB state leaking between tests | `beforeEach(cleanDb)` -- same proven pattern |
+| Token helper code duplication | Inline in test file, consistent with existing codebase pattern. Not worth extracting at ~25 tests |
+| Queue assertions impossible via SELF.fetch | Assert HTTP response shape as proxy (`verificationEmailSent: true`, `sent: true`) |
+
+### Execution Order
+
+```
+Batch 1: Task 1 (test-minion writes test/email-verify.test.js)
+-- no gates, single task --
+```
+
+### Verification Steps
+
+1. `npx vitest run test/email-verify.test.js` -- all ~25 tests pass
+2. `npx vitest run` -- full suite passes (no regressions in existing tests)
+3. No production code files modified (git diff should show only test/ changes)

--- a/docs/history/nefario-reports/2026-03-26-004300-email-verify-tests/phase3.5-lucy-prompt.md
+++ b/docs/history/nefario-reports/2026-03-26-004300-email-verify-tests/phase3.5-lucy-prompt.md
@@ -1,0 +1,16 @@
+You are reviewing a delegation plan before execution begins.
+Your role: convention adherence, CLAUDE.md compliance, intent drift.
+
+## Delegation Plan
+Read the full plan from: /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-DWNuqs/email-verify-tests/phase3-synthesis.md
+
+## Your Review Focus
+Does the plan follow the project's CLAUDE.md conventions? Does it match the intent of issue #199? Is the scope appropriate (no scope creep, no missing requirements)?
+
+## Original User Request
+Read the original user request from: /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-DWNuqs/email-verify-tests/prompt.md
+
+## Instructions
+Return exactly one verdict: APPROVE, ADVISE, or BLOCK.
+Be concise. Only flag issues within your domain expertise.
+Write your verdict to: /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-DWNuqs/email-verify-tests/phase3.5-lucy.md

--- a/docs/history/nefario-reports/2026-03-26-004300-email-verify-tests/phase3.5-lucy.md
+++ b/docs/history/nefario-reports/2026-03-26-004300-email-verify-tests/phase3.5-lucy.md
@@ -1,0 +1,67 @@
+# Lucy Review: email-verify-tests
+
+## Verdict: ADVISE
+
+## Original Request (verbatim from prompt.md)
+
+Issue #199: Add test coverage for `src/email-verify.js` -- token round-trip, expiry, domain separation, GET/POST handlers, resend handler, notification continuity. Tests only, no production code changes.
+
+## Requirement Traceability
+
+| Requirement (from prompt.md) | Plan Element | Status |
+|------------------------------|-------------|--------|
+| Token round-trip | Task 1, describe block 1 | Covered |
+| Token expiry | Task 1, describe block 1 (expiry + boundary) | Covered |
+| Token replay / email binding | Task 1, describe block 3 (stale token test) | Covered |
+| Domain separation | Task 1, describe block 1 (3 tests) | Covered |
+| Tampered payload/HMAC | Task 1, describe block 1 | Covered |
+| GET handler | Task 1, describe block 2 | Covered |
+| POST handler | Task 1, describe block 3 | Covered |
+| Resend handler | Task 1, describe block 4 | Covered |
+| Notification continuity | Task 1, describe block 5 | Covered |
+| Tests only, no production code | Explicit in "What NOT To Do" | Covered |
+
+No orphaned requirements. No unaddressed requirements.
+
+## Scope Check
+
+- **Single task, single deliverable** -- proportional to the problem (one test file for one untested module). No scope creep detected.
+- **~25 tests across 5 describe blocks** -- matches the 9 test gaps identified in prompt.md, expanded into specific assertions. The count is reasonable, not inflated.
+- **TOCTOU comment in test file** -- this is the only item that touches on non-test concerns. The plan explicitly scopes it as a code comment in the test file + a note in `decisions.md`. No production code fix included. Acceptable.
+
+## CLAUDE.md Compliance
+
+### Evolution Log (REQUIRED by CLAUDE.md)
+
+The plan's "Cross-Cutting Coverage > Documentation" section says: "The TOCTOU finding should be noted in the evolution log's `decisions.md` (handled in Phase 8, not a separate task)."
+
+**Finding [COMPLIANCE]**: The plan does not include creating the evolution log directory (`docs/evolution/NNNN-email-verify-tests/`) with `prompt.md`, `decisions.md`, and `outcome.md`. CLAUDE.md rule 1 says "Before starting a phase: create the directory and write prompt.md." The plan defers evolution log work to "Phase 8" but does not make this explicit as a required step. The calling session must ensure the evolution log directory, `prompt.md`, `decisions.md`, `outcome.md`, backlog review, and README index update all happen as part of this orchestration -- not silently dropped because the plan's single task doesn't mention them.
+
+**Recommendation**: The nefario orchestration must handle evolution log creation in Phase 8 (or equivalent). This is not a blocking issue since the plan acknowledges it exists ("handled in Phase 8"), but the calling session must not skip it. Flag for nefario to confirm.
+
+### Process Documentation (REQUIRED by CLAUDE.md)
+
+CLAUDE.md requires `process.md` "after every nefario orchestration that produces a PR." The plan does not mention `process.md`.
+
+**Recommendation**: Same as above -- the calling session must write `process.md` after PR creation. Not a plan defect per se (process.md is written after execution, not planned as a task), but worth flagging.
+
+### Engineering Philosophy Compliance
+
+- **No mocks of core logic** -- stated in success criteria. Aligns with "Test the real boundaries."
+- **No framework additions** -- no new dependencies introduced.
+- **Fail loudly** -- not applicable (test file only).
+- **YAGNI** -- no speculative features in the plan.
+
+### Naming / Conventions
+
+- File placed at `test/email-verify.test.js` -- matches existing pattern (`test/notifications.test.js`).
+- Import patterns match existing conventions (vitest, cloudflare:test, fixtures.js).
+- IP counter range (500+, `10.0.5.x`) is distinct from existing tests -- good isolation.
+
+## Drift Assessment
+
+No goal drift detected. The plan is tightly scoped to the 9 test gaps from #199, uses established patterns from the existing test suite, and explicitly excludes production code changes. The TOCTOU documentation-only approach is a sound scope decision with clear rationale.
+
+## Summary
+
+One advisory finding: ensure the evolution log obligations (prompt.md, decisions.md, outcome.md, process.md, backlog review, README index update) are fulfilled by the orchestration's wrap-up phase, since the plan's single task (test-minion) will not produce them. The plan itself is well-scoped and aligned with intent.

--- a/docs/history/nefario-reports/2026-03-26-004300-email-verify-tests/phase3.5-margo-prompt.md
+++ b/docs/history/nefario-reports/2026-03-26-004300-email-verify-tests/phase3.5-margo-prompt.md
@@ -1,0 +1,16 @@
+You are reviewing a delegation plan before execution begins.
+Your role: over-engineering, YAGNI, dependency bloat.
+
+## Delegation Plan
+Read the full plan from: /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-DWNuqs/email-verify-tests/phase3-synthesis.md
+
+## Your Review Focus
+Is the test plan over-engineered? Too many tests? Unnecessary abstractions or helpers? Does it follow KISS and YAGNI principles from the Helix Manifesto?
+
+## Original User Request
+Read the original user request from: /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-DWNuqs/email-verify-tests/prompt.md
+
+## Instructions
+Return exactly one verdict: APPROVE, ADVISE, or BLOCK.
+Be concise. Only flag issues within your domain expertise.
+Write your verdict to: /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-DWNuqs/email-verify-tests/phase3.5-margo.md

--- a/docs/history/nefario-reports/2026-03-26-004300-email-verify-tests/phase3.5-margo.md
+++ b/docs/history/nefario-reports/2026-03-26-004300-email-verify-tests/phase3.5-margo.md
@@ -1,0 +1,15 @@
+## Verdict: APPROVE
+
+The plan is proportional to the problem. Specific observations:
+
+**Scope is tight.** Single task, single file, single agent. No abstraction layers, no shared helper modules, no test infrastructure to maintain. The explicit "Do NOT extract shared token helpers" instruction prevents premature abstraction -- good.
+
+**Test count (~25) is justified.** The production code has 4 exported functions covering a security-sensitive flow (token generation, verification, two HTTP handlers) plus a resend endpoint. Token verification alone has multiple distinct failure modes (expiry, tampering, domain separation, malformed input) that each represent real attack surface. For a crypto-token verification flow, ~25 tests is the essential complexity, not gold plating.
+
+**No unnecessary dependencies or tooling.** Tests use existing fixtures (`cleanDb`, `createTestSession`), existing test infrastructure (`vitest-pool-workers`, `SELF.fetch`), and inline HMAC crafting. No new test libraries, no mock frameworks, no helper extraction.
+
+**YAGNI compliance.** The plan explicitly defers the TOCTOU fix (document-only), skips the fragile static-analysis test, and avoids fake timers in favor of backdated tokens. Each "what NOT to do" item reflects a deliberate scope cut.
+
+**One minor note (non-blocking).** The "notification continuity" describe block (section 5) contains a single test that largely duplicates assertions already covered by the POST happy-path test (section 3, test 1) -- both verify that email swaps from old to new after POST. The continuity test adds one extra read-before-POST assertion. This is marginal but not worth blocking over; the test documents the design intent explicitly.
+
+No complexity flags. No YAGNI violations. No scope creep.

--- a/docs/history/nefario-reports/2026-03-26-004300-email-verify-tests/phase3.5-security-minion-prompt.md
+++ b/docs/history/nefario-reports/2026-03-26-004300-email-verify-tests/phase3.5-security-minion-prompt.md
@@ -1,0 +1,16 @@
+You are reviewing a delegation plan before execution begins.
+Your role: identify gaps, risks, or concerns from your domain.
+
+## Delegation Plan
+Read the full plan from: /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-DWNuqs/email-verify-tests/phase3-synthesis.md
+
+## Your Review Focus
+Security gaps in the test plan: Are all token security properties covered? Any missing attack vectors? Is the TOCTOU deferral acceptable from a security perspective?
+
+## Original User Request
+Read the original user request from: /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-DWNuqs/email-verify-tests/prompt.md
+
+## Instructions
+Return exactly one verdict: APPROVE, ADVISE, or BLOCK.
+Be concise. Only flag issues within your domain expertise.
+Write your verdict to: /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-DWNuqs/email-verify-tests/phase3.5-security-minion.md

--- a/docs/history/nefario-reports/2026-03-26-004300-email-verify-tests/phase3.5-security-minion.md
+++ b/docs/history/nefario-reports/2026-03-26-004300-email-verify-tests/phase3.5-security-minion.md
@@ -1,0 +1,61 @@
+## Security Minion Review -- email-verify-tests
+
+**Verdict: ADVISE**
+
+The plan is fundamentally sound. Token security properties are well-covered. One tracking gap and one minor test-design note follow.
+
+---
+
+### What is covered (well)
+
+- **Domain separation**: three cross-domain tests (unsubscribe token rejected by verify, verify token rejected by unsubscribe, session-style HMAC rejected by verify). This is the right set -- the domain prefix `emailverify.` is the only thing separating these from the same key.
+- **Expiry boundary**: exact 24h boundary test correctly notes the `> 86400` vs `>= 86400` distinction.
+- **Tampered payload and HMAC**: separate tests, correct.
+- **Stale token (pending_email changed)**: covered by "stale token after second email change" test.
+- **Double-verification replay**: covered. The second POST finds `pendingEmail = NULL`, fails the cross-check.
+- **Cache-Control: no-store**: asserted on both GET and POST responses. Required -- these pages must not be cached by proxies or scanners.
+- **CSRF enforcement on resend**: `Missing CSRF header -> 403` test is present.
+- **Rate limiting on resend**: two-call-within-60s test is present.
+- **GET does not mutate DB**: read-before/read-after assertion is present and important (scanner pre-fetch must not verify).
+- **Malformed token edge cases**: dot-only, no-dot, empty, null. Good set.
+- **Version mismatch**: v: 2 rejection is covered.
+- **Missing fields**: `e` field only (one representative test). Acceptable -- the parse path is identical for all fields.
+
+---
+
+### ADVISE items
+
+#### 1. TOCTOU deferral: acceptable, but the follow-up issue must be tracked
+
+The confirmed SQL: `WHERE tenant_id = ? AND pending_email IS NOT NULL` with no `AND pending_email = ?` clause. The plan defers the fix correctly -- the TOCTOU window requires a concurrent request between the cross-check (line 427) and the swap (line 441), and D1's request-scoped isolation makes this extremely unlikely in practice.
+
+The deferral is acceptable **on condition** that a GitHub issue is created before this PR merges. The plan says "Do NOT create a GitHub issue for the TOCTOU fix (the human will handle that)." That is the right call for test-minion, but someone must own creating the issue. If that issue is not tracked, this will be forgotten -- the code comment alone is not enough.
+
+**Recommendation**: nefario or the human must create the tracking issue as part of the evolution log phase, not after. The comment in the test file should reference the issue number once created.
+
+The fix itself is two lines:
+```sql
+AND pending_email = ?
+```
+added to the `swapVerifiedEmail` WHERE clause, with the expected email passed as a bind parameter from the caller. This should be the first thing in the follow-on PR.
+
+#### 2. Token-in-body test: assert form submission path only (minor)
+
+The "Token in form body" test sends `application/x-www-form-urlencoded`. The plan covers this correctly. One clarification for test-minion: the test should verify that the token is NOT in the query string, to confirm it is exercising the body-parsing path and not the query param fallback. Otherwise the test could silently pass via the wrong code path.
+
+#### 3. No-session-secret path not explicitly tested
+
+The GET and POST handlers both gate on `env.SESSION_SECRET`. If `SESSION_SECRET` is absent, GET renders the invalid-token page and POST renders the failure page. This is fail-closed behavior. It is not tested. This is low priority -- the test environment always has the secret -- but worth noting as a gap in the production hardening coverage. Out of scope for #199 is fine; noting it for completeness.
+
+---
+
+### What was considered and rejected
+
+- **Static-analysis "no email logging" test**: the decision to skip this is correct. The invariant is enforced at line 456 of email-verify.js where only `tenantId` (not email) appears in the success log. A regex scan of source would be fragile. Code review is the right enforcement mechanism.
+- **Timing-safe HMAC verification test**: correctly excluded. `crypto.subtle.verify` is a platform guarantee, not testable from test code.
+
+---
+
+### Summary
+
+The test plan covers all meaningful token security properties. The TOCTOU deferral is the only item that needs a concrete owner before this PR ships -- everything else is fine to proceed as written.

--- a/docs/history/nefario-reports/2026-03-26-004300-email-verify-tests/phase3.5-test-minion-prompt.md
+++ b/docs/history/nefario-reports/2026-03-26-004300-email-verify-tests/phase3.5-test-minion-prompt.md
@@ -1,0 +1,16 @@
+You are reviewing a delegation plan before execution begins.
+Your role: identify gaps, risks, or concerns from your domain.
+
+## Delegation Plan
+Read the full plan from: /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-DWNuqs/email-verify-tests/phase3-synthesis.md
+
+## Your Review Focus
+Test coverage completeness, test structure, testing patterns and conventions. Does the plan cover all 9 test scenarios from the issue? Are the testing approaches sound?
+
+## Original User Request
+Read the original user request from: /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-DWNuqs/email-verify-tests/prompt.md
+
+## Instructions
+Return exactly one verdict: APPROVE, ADVISE, or BLOCK.
+Be concise. Only flag issues within your domain expertise.
+Write your verdict to: /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-DWNuqs/email-verify-tests/phase3.5-test-minion.md

--- a/docs/history/nefario-reports/2026-03-26-004300-email-verify-tests/phase3.5-test-minion.md
+++ b/docs/history/nefario-reports/2026-03-26-004300-email-verify-tests/phase3.5-test-minion.md
@@ -1,0 +1,48 @@
+# test-minion Review
+
+**Verdict: APPROVE**
+
+## Coverage Assessment
+
+All 9 scenarios from the issue are addressed:
+
+1. Token generation/verification round-trip -- covered (describe block 1, round-trip test)
+2. Token expiry -- covered (>24h test + boundary at exactly 24h)
+3. Token replay protection / email binding -- covered (stale token test in POST block)
+4. Domain separation -- covered (3 tests: unsubscribe->verify, verify->unsubscribe, session->verify)
+5. Tampered payload/HMAC rejection -- covered (2 dedicated unit tests)
+6. GET handler -- covered (valid, invalid, expired, missing token; no-DB-mutation assertion)
+7. POST handler -- covered (happy path, invalid, expired, stale, double-verify, form body, empty token)
+8. Resend endpoint -- covered (happy path, no-pending-email 400, rate-limit 429, missing CSRF 403)
+9. Notification continuity -- covered (describe block 5)
+
+Total: ~26 tests, modestly above the 25 estimate. Acceptable.
+
+## Test Design
+
+The plan is grounded in the real source code. Specific checks:
+
+- Boundary condition (exactly 24h): plan's assertion (`{ ok: true }`) is correct. `email-verify.js` line 176 uses `> 86400`, not `>=`, so `ts = now - 86400` is not expired.
+- "Dot-only token": payload and HMAC are both empty strings; the `!payloadB64 || !hmacB64` guard at line 126 fires before HMAC verification. Returns `malformed_token`. Correct.
+- Version mismatch (`v: 2`): the `parsed.v !== 1` check at line 155 fires after HMAC validation. Requires a validly-signed token. The plan correctly instructs inline HMAC crafting for this case.
+- Missing `e` field: hits `invalid_payload_email` at line 167, not `invalid_payload_version` (because `v: 1` is present). Correct.
+- Double-verification: second POST finds `pending_email = NULL`, so `prefs.pendingEmail !== email` fires at line 427. Returns failure page. Correct.
+
+## Patterns and Conventions
+
+The plan correctly adopts all conventions from `test/notifications.test.js`:
+- `SELF.fetch` for integration, direct function calls for unit
+- `beforeEach(cleanDb)` for isolation
+- Distinct IP range (`10.0.5.x`, starting at 500) -- no collision with the existing `10.0.4.x` range
+- Inline HMAC crafting (no extraction) -- consistent with existing codebase pattern
+- Duplicate `createTosSession` helper -- acceptable at this scale
+
+## Minor Observations (non-blocking)
+
+1. **Form body test -- example code gap**: The prompt shows the `POST verify-email` fetch pattern using `?token=` in the URL, but the form-body test specifically tests the case where the token is absent from the query string and sent in the body instead. The implementing agent will need to construct the fetch call with `body: new URLSearchParams({token})` and `Content-Type: application/x-www-form-urlencoded` without the query param. The description is clear enough that a competent agent will get this right, but the example code omits it. Not a blocker.
+
+2. **GET no-DB-mutation assertion**: The plan says "read prefs before and after, assert identical" but the test setup requires a tenant with `pending_email` set (otherwise there is no prefs row to compare). The implementing agent should set up a complete tenant before the before/after comparison. This is derivable from the context but worth noting.
+
+3. **TOCTOU documentation placement**: The comment is to be placed in the test file. This is appropriate -- a test comment that documents a known gap is a reasonable record until the fix PR is opened.
+
+These are implementation details the agent can handle without guidance. No changes to the plan are required.

--- a/docs/history/nefario-reports/2026-03-26-004300-email-verify-tests/phase3.5-ux-strategy-minion-prompt.md
+++ b/docs/history/nefario-reports/2026-03-26-004300-email-verify-tests/phase3.5-ux-strategy-minion-prompt.md
@@ -1,0 +1,16 @@
+You are reviewing a delegation plan before execution begins.
+Your role: evaluate journey coherence, cognitive load, and simplification opportunities.
+
+## Delegation Plan
+Read the full plan from: /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-DWNuqs/email-verify-tests/phase3-synthesis.md
+
+## Your Review Focus
+This is a test-writing task — no user-facing changes. Evaluate whether the test structure is coherent and whether the test file organization makes sense for developer experience.
+
+## Original User Request
+Read the original user request from: /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-DWNuqs/email-verify-tests/prompt.md
+
+## Instructions
+Return exactly one verdict: APPROVE, ADVISE, or BLOCK.
+Be concise. Only flag issues within your domain expertise.
+Write your verdict to: /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-DWNuqs/email-verify-tests/phase3.5-ux-strategy-minion.md

--- a/docs/history/nefario-reports/2026-03-26-004300-email-verify-tests/phase3.5-ux-strategy-minion.md
+++ b/docs/history/nefario-reports/2026-03-26-004300-email-verify-tests/phase3.5-ux-strategy-minion.md
@@ -1,0 +1,25 @@
+## UX Strategy Review — email-verify-tests
+
+**Verdict: APPROVE**
+
+This task produces no user-facing changes. My review scope here is developer experience — the cognitive coherence of the test structure for the engineers who will read, run, and maintain it.
+
+### Test Organization: Coherent
+
+The 5 describe blocks follow the natural mental model of the feature: token mechanics first (pure unit), then each HTTP endpoint in the order a developer would reason about the flow (GET confirmation page → POST verification → POST resend), and finally the behavioral contract (notification continuity). This is the right ordering. A developer debugging a failure will immediately know which describe block to look in.
+
+### Progressive Disclosure Applied Correctly
+
+The plan puts unit tests first (no HTTP, no DB, fast feedback) and integration tests after. This means a failing token logic test fails fast and loudly before you even hit the HTTP layer — that's good test architecture. The boundary test (exactly 24h) is explicitly called out to document the `> 86400` vs `>= 86400` edge, which is high-value for future maintainers.
+
+### One Developer Experience Note
+
+The instruction to duplicate `createTosSession` inline rather than extracting it is a deliberate choice the plan defends (consistency with existing codebase pattern, ~25 tests not worth extracting). That reasoning is sound — premature extraction creates coupling overhead in test code. At 25 tests, the duplication cost is lower than the abstraction cost.
+
+### TOCTOU Comment Placement
+
+The TOCTOU comment will live inside a test file, not production code — that is appropriate. It will be visible exactly when a developer is reading verification flow tests, which is when they need it most. No concern here.
+
+### No Issues
+
+Nothing in this plan creates developer confusion, false safety, or unnecessary cognitive overhead. The scope is tight, the structure mirrors the feature's natural boundaries, and the explicit "What NOT To Do" list prevents scope creep during implementation.

--- a/docs/history/nefario-reports/2026-03-26-004300-email-verify-tests/phase4-test-minion-prompt.md
+++ b/docs/history/nefario-reports/2026-03-26-004300-email-verify-tests/phase4-test-minion-prompt.md
@@ -1,0 +1,156 @@
+## Task
+
+Create `test/email-verify.test.js` -- the test suite for the email verification flow implemented in `src/email-verify.js` and the resend handler in `src/notifications.js`.
+
+This is issue #199. The scope is tests only -- no production code changes.
+
+## Context
+
+Read these files before writing anything:
+- `src/email-verify.js` -- token generation/verification + GET/POST handlers
+- `src/notifications.js` -- `handleResendVerification` (lines 305-360)
+- `src/unsubscribe.js` -- `generateUnsubscribeToken`, `verifyUnsubscribeToken` (for cross-domain tests)
+- `src/db.js` -- `swapVerifiedEmail`, `getNotificationPreferences`, `setPendingEmail`
+- `test/notifications.test.js` -- existing test patterns (session helpers, cleanDb, ipCounter, token crafting)
+- `test/fixtures.js` -- `createTestSession`, `cleanDb`
+- `vitest.config.js` -- worker pool config and env bindings
+
+## File Structure
+
+Single file: `test/email-verify.test.js`
+
+Use 5 describe blocks in this order:
+1. **Token generation and verification** (unit, no HTTP)
+2. **GET /v1/notifications/verify-email** (integration via SELF.fetch)
+3. **POST /v1/notifications/verify-email** (integration via SELF.fetch)
+4. **POST /v1/account/notifications/resend-verification** (integration via SELF.fetch)
+5. **Notification continuity** (integration -- notifications go to old email while pending)
+
+## Tests to Write (~25 total)
+
+### 1. Token generation and verification (unit tests, ~10 tests)
+
+- **Round-trip**: generate token, verify it, assert `{ ok: true, tenantId, email }`
+- **Expiry (>24h rejected)**: Craft a token with `ts` backdated by 25 hours (90000 seconds). Use the manual HMAC signing pattern from `test/notifications.test.js` lines 397-418. The HMAC input prefix is `"emailverify."`. Assert `{ ok: false, reason: 'token_expired' }`.
+- **Boundary (exactly 24h)**: Craft token with `ts = Math.floor(Date.now()/1000) - 86400`. Code uses `> 86400`, so this should still be valid. Assert `{ ok: true }`.
+- **Tampered payload**: Change a character in the payload portion of a valid token. Assert `{ ok: false, reason: 'invalid_signature' }`.
+- **Tampered HMAC**: Change a character in the HMAC portion. Assert `{ ok: false, reason: 'invalid_signature' }`.
+- **Domain separation -- unsubscribe token rejected by verify**: Generate with `generateUnsubscribeToken`, pass to `verifyEmailVerifyToken`. Must return `{ ok: false }`. Import from `src/unsubscribe.js`.
+- **Domain separation -- verify token rejected by unsubscribe**: Generate with `generateEmailVerifyToken`, pass to `verifyUnsubscribeToken`. Must return `{ ok: false }`.
+- **Domain separation -- session cookie rejected by verify**: Construct a session-style signed value (HMAC of raw ID, no `emailverify.` prefix), pass to `verifyEmailVerifyToken`. Must return `{ ok: false }`. Mirror the existing pattern from `test/notifications.test.js` line 379.
+- **Version mismatch**: Craft a validly-signed token with `v: 2`. Assert `{ ok: false, reason: 'invalid_payload_version' }`.
+- **Missing fields**: Craft validly-signed tokens missing `e` field. Assert `{ ok: false, reason: 'invalid_payload_email' }`.
+- **Malformed: dot-only token** (`"."`): Assert `{ ok: false, reason: 'malformed_token' }`.
+- **Malformed: no dot**: Assert `{ ok: false, reason: 'malformed_token' }`.
+- **Missing/empty token**: `verifyEmailVerifyToken(secret, '')` and `verifyEmailVerifyToken(secret, null)`. Assert `{ ok: false, reason: 'missing_token' }`.
+
+### 2. GET /v1/notifications/verify-email (integration, ~4 tests)
+
+- **Valid token**: Generate token for a tenant with pending_email set. GET with `?token=...`. Assert 200, HTML contains "Confirm email address", `Cache-Control: no-store`.
+- **Invalid token**: GET with `?token=garbage`. Assert 200, HTML contains "Invalid or expired link".
+- **Expired token**: Craft backdated token. Assert 200, HTML contains "Invalid or expired link".
+- **Missing token**: GET without `?token`. Assert 200, HTML contains "Invalid or expired link".
+- GET must NOT modify DB state (read prefs before and after, assert identical).
+
+### 3. POST /v1/notifications/verify-email (integration, ~7 tests)
+
+- **Happy path**: Set pending_email via PUT, generate token, POST. Assert 200, HTML contains "Email address verified". Read DB: `email` = new address, `pending_email` = NULL, `email_verified` = 1.
+- **Invalid token**: POST with garbage token. Assert 200, HTML contains "Verification failed".
+- **Expired token**: Craft backdated token, POST. Assert 200, HTML contains "Verification failed".
+- **Stale token (pending_email changed)**: Set pending_email to A, generate token for A, then change pending_email to B via PUT. POST with token for A. Assert failure (pending_email_mismatch).
+- **Double verification**: POST same valid token twice. First succeeds (pending_email swapped to NULL). Second fails (no pending_email to match).
+- **Token in form body**: POST without query param, send token as `application/x-www-form-urlencoded` body. Assert success.
+- **Empty token**: POST with `?token=` (empty). Assert 200, failure page.
+- **Cache-Control: no-store** on all POST responses.
+
+### 4. POST /v1/account/notifications/resend-verification (integration, ~4 tests)
+
+URL: `https://worker.test/v1/account/notifications/resend-verification`
+
+This is a session-authenticated endpoint. Requires Cookie + X-WRL-CSRF header.
+
+- **Happy path**: Create session, set pending_email via PUT, call resend. Assert 200, `{ sent: true }`.
+- **No pending email**: Create session (no PUT). Call resend. Assert 400.
+- **Rate limit**: Call resend twice within 60 seconds. Second call returns 429 with `Retry-After: 60`.
+- **Missing CSRF header**: Call without `X-WRL-CSRF`. Assert 403.
+
+### 5. Notification continuity (~1 test)
+
+- Set up a tenant with email "old@example.com", then set pending_email to "new@example.com" via PUT. Read notification preferences: `email` should still be "old@example.com" (notifications continue to old address). After successful POST verify-email, `email` should be "new@example.com".
+
+## TOCTOU Finding (Document, Do NOT Fix)
+
+The `swapVerifiedEmail()` function in `src/db.js` does `SET email = pending_email WHERE tenant_id = ? AND pending_email IS NOT NULL` without conditioning on which email it expects.
+
+**Do NOT fix the production code.** This issue is out of scope for #199.
+
+Instead, write the "stale token after second email change" test (test 4 in POST section above) and add a code comment:
+
+```js
+// NOTE: The existing pending_email cross-check (prefs.pendingEmail !== email)
+// catches the common case, but swapVerifiedEmail() does not include
+// AND pending_email = ? in its WHERE clause. A concurrent request could
+// change pending_email between the check and the swap. See security review
+// notes in docs/evolution/ for details. The fix is tracked separately.
+```
+
+## Implementation Patterns
+
+Follow the exact conventions from `test/notifications.test.js`:
+
+- Import `{ env, SELF }` from `'cloudflare:test'`
+- Import `{ describe, it, expect, beforeEach }` from `'vitest'`
+- Import `{ cleanDb, createTestSession }` from `'./fixtures.js'`
+- Use `beforeEach(async () => { await cleanDb(env.DB); })`
+- Use a distinct IP counter range: start at `500` (`let ipCounter = 500; function nextIp() { return \`10.0.5.${ipCounter++}\`; }`)
+- Duplicate the `createTosSession` helper (5 lines, don't extract)
+- For token crafting (expiry, tampered, domain separation, version, missing fields): use inline HMAC signing with `crypto.subtle`. The `toB64url` helper and HMAC signing pattern are shown in the existing tests -- use that exact pattern.
+- The SESSION_SECRET is available as `env.SESSION_SECRET` in vitest-pool-workers
+
+For resend tests, the session-authenticated requests need:
+```js
+SELF.fetch(RESEND_URL, {
+  method: 'POST',
+  headers: {
+    Cookie: cookie,
+    'CF-Connecting-IP': ip,
+    'X-WRL-CSRF': '1',
+  },
+})
+```
+
+For GET/POST verify-email (unauthenticated), just use:
+```js
+SELF.fetch(`https://worker.test/v1/notifications/verify-email?token=${token}`, {
+  headers: { 'CF-Connecting-IP': ip },
+})
+```
+
+For POST verify-email:
+```js
+SELF.fetch(`https://worker.test/v1/notifications/verify-email?token=${token}`, {
+  method: 'POST',
+  headers: { 'CF-Connecting-IP': ip },
+})
+```
+
+## What NOT To Do
+
+- Do NOT modify any production code (src/*.js, src/db.js). Tests only.
+- Do NOT create a GitHub issue for the TOCTOU fix (the human will handle that).
+- Do NOT test timing-safe HMAC verification (platform guarantee, untestable).
+- Do NOT add the static-analysis "no email logging" test (fragile regex linting; out of scope).
+- Do NOT try to test queue contents -- assert HTTP response shape as proxy for queue behavior.
+- Do NOT use `vi.useFakeTimers()` for expiry tests -- craft backdated tokens instead.
+- Do NOT extract shared token helpers into a separate file. Keep everything inline in the test file.
+- Do NOT touch `test/notifications.test.js`.
+
+## Deliverables
+`test/email-verify.test.js` (~25 tests across 5 describe blocks)
+
+## Success Criteria
+`npx vitest run test/email-verify.test.js` passes. All tests exercise real behavior via SELF.fetch or direct function calls. No mocks of core logic.
+
+When you finish your task, report:
+- File paths with change scope and line counts
+- 1-2 sentence summary of what was produced

--- a/docs/history/nefario-reports/2026-03-26-004300-email-verify-tests/prompt.md
+++ b/docs/history/nefario-reports/2026-03-26-004300-email-verify-tests/prompt.md
@@ -1,0 +1,23 @@
+## Context
+
+Phase 0080 (#195) added the email verification flow with `src/email-verify.js` (token module + GET/POST verification handlers) and the resend handler in `src/notifications.js`. The existing `test/notifications.test.js` was updated for the pending-email PUT behavior, but `email-verify.js` itself has no dedicated test file.
+
+This was flagged during the Phase 3.5 architecture review by test-minion (9 test gaps identified) and confirmed during post-phase supervisor verification.
+
+## What needs testing
+
+1. **Token generation/verification round-trip** — generate then verify returns tenantId and email
+2. **Token expiry** — reject tokens older than 24 hours (stale `ts` payload)
+3. **Token replay protection** — token for email A cannot verify email B (email binding)
+4. **Domain separation** — unsubscribe tokens rejected by verify, and vice versa
+5. **Tampered payload/HMAC rejection**
+6. **GET /v1/notifications/verify-email** — valid token renders confirmation page; invalid/expired/missing token renders error page; always returns 200
+7. **POST /v1/notifications/verify-email** — valid token swaps pending_email to email atomically; invalid token shows error; email mismatch (pending_email changed since token issued) rejects
+8. **POST /v1/account/notifications/resend-verification** — requires session + CSRF; returns 429 within 60s cooldown; returns 400 when no pending_email
+9. **Notification continuity** — notifications continue to old email while verification is pending (validates the core pending-email design decision)
+
+## Files involved
+
+- `src/email-verify.js` — token functions + GET/POST handlers
+- `src/notifications.js` — resend handler, PUT handler pending-email path
+- `test/notifications.test.js` — existing tests (extend or create new file)

--- a/test/email-verify.test.js
+++ b/test/email-verify.test.js
@@ -1,0 +1,660 @@
+// tva
+// Integration and unit tests for the email verification flow.
+// Covers: token generation/verification, GET/POST verify-email handlers,
+//         resend-verification endpoint, and notification continuity.
+
+import { env, SELF } from 'cloudflare:test';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { cleanDb, createTestSession } from './fixtures.js';
+import { generateEmailVerifyToken, verifyEmailVerifyToken } from '../src/email-verify.js';
+import { generateUnsubscribeToken, verifyUnsubscribeToken } from '../src/unsubscribe.js';
+
+const VERIFY_URL = 'https://worker.test/v1/notifications/verify-email';
+const RESEND_URL = 'https://worker.test/v1/account/notifications/resend-verification';
+const NOTIF_URL = 'https://worker.test/v1/account/notifications';
+
+// Distinct IP range to avoid rate-limit cross-contamination with other test files
+let ipCounter = 500;
+function nextIp() {
+  return `10.0.5.${ipCounter++}`;
+}
+
+// ---------------------------------------------------------------------------
+// Session helper (duplicated inline -- not extracted per task instructions)
+// ---------------------------------------------------------------------------
+
+async function createTosSession(overrides = {}) {
+  const session = await createTestSession(env.DB, env, overrides);
+  await env.DB.prepare(
+    "UPDATE github_users SET tos_accepted_at = '2026-01-01T00:00:00.000Z', tos_version = '1.0' WHERE github_id = ?",
+  ).bind(session.githubId).run();
+  return session;
+}
+
+// ---------------------------------------------------------------------------
+// Inline HMAC helpers for crafting manipulated tokens in unit tests
+// ---------------------------------------------------------------------------
+
+const enc = new TextEncoder();
+
+function toB64url(bytes) {
+  const b64 = btoa(Array.from(bytes, b => String.fromCharCode(b)).join(''));
+  return b64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+}
+
+async function craftEmailVerifyToken(sessionSecret, payload) {
+  const payloadStr = JSON.stringify(payload);
+  const payloadB64 = toB64url(enc.encode(payloadStr));
+  const hmacInput = `emailverify.${payloadB64}`;
+  const keyBytes = new Uint8Array(sessionSecret.match(/.{2}/g).map(h => parseInt(h, 16)));
+  const key = await crypto.subtle.importKey(
+    'raw', keyBytes, { name: 'HMAC', hash: 'SHA-256' }, false, ['sign'],
+  );
+  const sig = await crypto.subtle.sign('HMAC', key, enc.encode(hmacInput));
+  const hmacB64 = toB64url(new Uint8Array(sig));
+  return `${payloadB64}.${hmacB64}`;
+}
+
+beforeEach(async () => {
+  await cleanDb(env.DB);
+});
+
+// ---------------------------------------------------------------------------
+// 1. Token generation and verification (unit tests, no HTTP)
+// ---------------------------------------------------------------------------
+
+describe('email verify token -- generation and verification', () => {
+  const sessionSecret = 'deadbeef'.repeat(8);
+
+  it('round-trip: generate then verify returns ok=true with tenantId and email', async () => {
+    const token = await generateEmailVerifyToken(sessionSecret, 'gh-1001', 'user@example.com');
+    const result = await verifyEmailVerifyToken(sessionSecret, token);
+    expect(result.ok).toBe(true);
+    expect(result.tenantId).toBe('gh-1001');
+    expect(result.email).toBe('user@example.com');
+  });
+
+  it('rejects token with ts backdated by 25 hours (token_expired)', async () => {
+    const ts = Math.floor(Date.now() / 1000) - 90000; // 25 hours ago
+    const token = await craftEmailVerifyToken(sessionSecret, {
+      t: 'gh-1001', e: 'user@example.com', ts, v: 1,
+    });
+    const result = await verifyEmailVerifyToken(sessionSecret, token);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('token_expired');
+  });
+
+  it('accepts token at exactly 24h boundary (>86400 check, not >=)', async () => {
+    // Code uses > 86400, so ts = now - 86400 should still be valid
+    const ts = Math.floor(Date.now() / 1000) - 86400;
+    const token = await craftEmailVerifyToken(sessionSecret, {
+      t: 'gh-1001', e: 'user@example.com', ts, v: 1,
+    });
+    const result = await verifyEmailVerifyToken(sessionSecret, token);
+    expect(result.ok).toBe(true);
+  });
+
+  it('rejects tampered payload (invalid_signature)', async () => {
+    const token = await generateEmailVerifyToken(sessionSecret, 'gh-1001', 'user@example.com');
+    const dotIndex = token.lastIndexOf('.');
+    const payloadB64 = token.slice(0, dotIndex);
+    const hmacB64 = token.slice(dotIndex + 1);
+    // Corrupt one character in the payload
+    const tampered = payloadB64.slice(0, -1) + (payloadB64.slice(-1) === 'A' ? 'B' : 'A');
+    const tamperedToken = `${tampered}.${hmacB64}`;
+    const result = await verifyEmailVerifyToken(sessionSecret, tamperedToken);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('invalid_signature');
+  });
+
+  it('rejects tampered HMAC (invalid_signature)', async () => {
+    const token = await generateEmailVerifyToken(sessionSecret, 'gh-1001', 'user@example.com');
+    const dotIndex = token.lastIndexOf('.');
+    const payloadB64 = token.slice(0, dotIndex);
+    const tamperedToken = `${payloadB64}.AAAA_invalid_hmac_bytes`;
+    const result = await verifyEmailVerifyToken(sessionSecret, tamperedToken);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('invalid_signature');
+  });
+
+  it('domain separation: unsubscribe token rejected by verifyEmailVerifyToken', async () => {
+    const token = await generateUnsubscribeToken(sessionSecret, 'gh-1001', 'capture_failure');
+    const result = await verifyEmailVerifyToken(sessionSecret, token);
+    expect(result.ok).toBe(false);
+  });
+
+  it('domain separation: email verify token rejected by verifyUnsubscribeToken', async () => {
+    const token = await generateEmailVerifyToken(sessionSecret, 'gh-1001', 'user@example.com');
+    const result = await verifyUnsubscribeToken(sessionSecret, token);
+    expect(result.ok).toBe(false);
+  });
+
+  it('domain separation: session cookie value rejected by verifyEmailVerifyToken', async () => {
+    // Session cookies are signed without any prefix: HMAC(sessionId), not HMAC("emailverify." + ...)
+    const fakeSessionId = 'deadbeef'.repeat(4);
+    const keyBytes = new Uint8Array(sessionSecret.match(/.{2}/g).map(h => parseInt(h, 16)));
+    const key = await crypto.subtle.importKey(
+      'raw', keyBytes, { name: 'HMAC', hash: 'SHA-256' }, false, ['sign'],
+    );
+    const sig = await crypto.subtle.sign('HMAC', key, enc.encode(fakeSessionId));
+    const hmacHex = Array.from(new Uint8Array(sig)).map(b => b.toString(16).padStart(2, '0')).join('');
+    const sessionCookieValue = `${fakeSessionId}.${hmacHex}`;
+    const result = await verifyEmailVerifyToken(sessionSecret, sessionCookieValue);
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects token with v=2 (invalid_payload_version)', async () => {
+    const token = await craftEmailVerifyToken(sessionSecret, {
+      t: 'gh-1001', e: 'user@example.com', ts: Math.floor(Date.now() / 1000), v: 2,
+    });
+    const result = await verifyEmailVerifyToken(sessionSecret, token);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('invalid_payload_version');
+  });
+
+  it('rejects token missing e field (invalid_payload_email)', async () => {
+    const token = await craftEmailVerifyToken(sessionSecret, {
+      t: 'gh-1001', ts: Math.floor(Date.now() / 1000), v: 1,
+    });
+    const result = await verifyEmailVerifyToken(sessionSecret, token);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('invalid_payload_email');
+  });
+
+  it('rejects dot-only token (malformed_token)', async () => {
+    const result = await verifyEmailVerifyToken(sessionSecret, '.');
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('malformed_token');
+  });
+
+  it('rejects token with no dot separator (malformed_token)', async () => {
+    const result = await verifyEmailVerifyToken(sessionSecret, 'nodotintoken');
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('malformed_token');
+  });
+
+  it('rejects empty string (missing_token)', async () => {
+    const result = await verifyEmailVerifyToken(sessionSecret, '');
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('missing_token');
+  });
+
+  it('rejects null (missing_token)', async () => {
+    const result = await verifyEmailVerifyToken(sessionSecret, null);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('missing_token');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. GET /v1/notifications/verify-email
+// ---------------------------------------------------------------------------
+
+describe('GET /v1/notifications/verify-email', () => {
+  it('returns 200 HTML with confirm page for a valid token', async () => {
+    const { tenantId } = await createTosSession();
+    // Set pending email via the notifications PUT endpoint
+    const { cookie } = await createTosSession({ githubId: 20001 });
+    await env.DB.prepare(
+      "UPDATE github_users SET tos_accepted_at = '2026-01-01T00:00:00.000Z', tos_version = '1.0' WHERE github_id = ?",
+    ).bind(20001).run();
+    const putRes = await SELF.fetch(NOTIF_URL, {
+      method: 'PUT',
+      headers: {
+        Cookie: cookie,
+        'CF-Connecting-IP': nextIp(),
+        'Content-Type': 'application/json',
+        'X-WRL-CSRF': '1',
+      },
+      body: JSON.stringify({ email: 'verify-me@example.com' }),
+    });
+    expect(putRes.status).toBe(200);
+    const putBody = await putRes.json();
+    const tid = putBody.tenantId ?? `gh-20001`;
+
+    const token = await generateEmailVerifyToken(env.SESSION_SECRET, 'gh-20001', 'verify-me@example.com');
+    const res = await SELF.fetch(`${VERIFY_URL}?token=${encodeURIComponent(token)}`, {
+      headers: { 'CF-Connecting-IP': nextIp() },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toContain('text/html');
+    expect(res.headers.get('Cache-Control')).toBe('no-store');
+    const html = await res.text();
+    expect(html).toContain('Confirm email address');
+  });
+
+  it('returns 200 HTML with invalid-link page for garbage token', async () => {
+    const res = await SELF.fetch(`${VERIFY_URL}?token=garbage_token_xyz`, {
+      headers: { 'CF-Connecting-IP': nextIp() },
+    });
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain('Invalid or expired link');
+    expect(res.headers.get('Cache-Control')).toBe('no-store');
+  });
+
+  it('returns 200 HTML with invalid-link page for expired token', async () => {
+    const ts = Math.floor(Date.now() / 1000) - 90000;
+    const token = await craftEmailVerifyToken('deadbeef'.repeat(8), {
+      t: 'gh-20001', e: 'verify-me@example.com', ts, v: 1,
+    });
+    const res = await SELF.fetch(`${VERIFY_URL}?token=${encodeURIComponent(token)}`, {
+      headers: { 'CF-Connecting-IP': nextIp() },
+    });
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain('Invalid or expired link');
+  });
+
+  it('returns 200 HTML with invalid-link page when token is absent', async () => {
+    const res = await SELF.fetch(VERIFY_URL, {
+      headers: { 'CF-Connecting-IP': nextIp() },
+    });
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain('Invalid or expired link');
+  });
+
+  it('GET does not modify DB state', async () => {
+    // Seed a tenant with a pending email
+    const tenantId = 'gh-20010';
+    await env.DB.prepare('INSERT OR IGNORE INTO tenants (id) VALUES (?)').bind(tenantId).run();
+    await env.DB.prepare(
+      `INSERT OR IGNORE INTO notification_preferences (tenant_id, pending_email, verification_sent_at)
+       VALUES (?, 'get-test@example.com', '2026-01-01T00:00:00.000Z')`,
+    ).bind(tenantId).run();
+
+    const before = await env.DB.prepare(
+      'SELECT * FROM notification_preferences WHERE tenant_id = ?',
+    ).bind(tenantId).first();
+
+    const token = await generateEmailVerifyToken(env.SESSION_SECRET, tenantId, 'get-test@example.com');
+    await SELF.fetch(`${VERIFY_URL}?token=${encodeURIComponent(token)}`, {
+      headers: { 'CF-Connecting-IP': nextIp() },
+    });
+
+    const after = await env.DB.prepare(
+      'SELECT * FROM notification_preferences WHERE tenant_id = ?',
+    ).bind(tenantId).first();
+
+    expect(after).toEqual(before);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. POST /v1/notifications/verify-email
+// ---------------------------------------------------------------------------
+
+describe('POST /v1/notifications/verify-email', () => {
+  it('happy path: valid token verifies pending email and swaps it into email column', async () => {
+    const { cookie } = await createTosSession({ githubId: 30001 });
+    const tenantId = 'gh-30001';
+    // PUT to set pending_email
+    await SELF.fetch(NOTIF_URL, {
+      method: 'PUT',
+      headers: {
+        Cookie: cookie,
+        'CF-Connecting-IP': nextIp(),
+        'Content-Type': 'application/json',
+        'X-WRL-CSRF': '1',
+      },
+      body: JSON.stringify({ email: 'confirmed@example.com' }),
+    });
+
+    const token = await generateEmailVerifyToken(env.SESSION_SECRET, tenantId, 'confirmed@example.com');
+    const res = await SELF.fetch(`${VERIFY_URL}?token=${encodeURIComponent(token)}`, {
+      method: 'POST',
+      headers: { 'CF-Connecting-IP': nextIp() },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Cache-Control')).toBe('no-store');
+    const html = await res.text();
+    expect(html).toContain('Email address verified');
+
+    // Verify DB state
+    const row = await env.DB.prepare(
+      'SELECT email, pending_email, email_verified FROM notification_preferences WHERE tenant_id = ?',
+    ).bind(tenantId).first();
+    expect(row).not.toBeNull();
+    expect(row.email).toBe('confirmed@example.com');
+    expect(row.pending_email).toBeNull();
+    expect(row.email_verified).toBe(1);
+  });
+
+  it('returns 200 failure page for invalid token', async () => {
+    const res = await SELF.fetch(`${VERIFY_URL}?token=bad_token`, {
+      method: 'POST',
+      headers: { 'CF-Connecting-IP': nextIp() },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Cache-Control')).toBe('no-store');
+    const html = await res.text();
+    expect(html).toContain('Verification failed');
+  });
+
+  it('returns 200 failure page for expired token', async () => {
+    const ts = Math.floor(Date.now() / 1000) - 90000;
+    const token = await craftEmailVerifyToken('deadbeef'.repeat(8), {
+      t: 'gh-30002', e: 'any@example.com', ts, v: 1,
+    });
+    const res = await SELF.fetch(`${VERIFY_URL}?token=${encodeURIComponent(token)}`, {
+      method: 'POST',
+      headers: { 'CF-Connecting-IP': nextIp() },
+    });
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain('Verification failed');
+  });
+
+  it('stale token: fails when pending_email was changed after token was issued', async () => {
+    // NOTE: The existing pending_email cross-check (prefs.pendingEmail !== email)
+    // catches the common case, but swapVerifiedEmail() does not include
+    // AND pending_email = ? in its WHERE clause. A concurrent request could
+    // change pending_email between the check and the swap. See security review
+    // notes in docs/evolution/ for details. The fix is tracked separately.
+    const { cookie } = await createTosSession({ githubId: 30003 });
+    const tenantId = 'gh-30003';
+
+    // Set pending_email to address A
+    await SELF.fetch(NOTIF_URL, {
+      method: 'PUT',
+      headers: {
+        Cookie: cookie,
+        'CF-Connecting-IP': nextIp(),
+        'Content-Type': 'application/json',
+        'X-WRL-CSRF': '1',
+      },
+      body: JSON.stringify({ email: 'address-a@example.com' }),
+    });
+
+    // Generate token for address A
+    const tokenForA = await generateEmailVerifyToken(env.SESSION_SECRET, tenantId, 'address-a@example.com');
+
+    // Backdate verification_sent_at so the second PUT is not rate-limited
+    await env.DB.prepare(
+      "UPDATE notification_preferences SET verification_sent_at = '2020-01-01T00:00:00.000Z' WHERE tenant_id = ?",
+    ).bind(tenantId).run();
+
+    // Change pending_email to address B
+    await SELF.fetch(NOTIF_URL, {
+      method: 'PUT',
+      headers: {
+        Cookie: cookie,
+        'CF-Connecting-IP': nextIp(),
+        'Content-Type': 'application/json',
+        'X-WRL-CSRF': '1',
+      },
+      body: JSON.stringify({ email: 'address-b@example.com' }),
+    });
+
+    // POST with the stale token for A -- should fail (pending_email_mismatch)
+    const res = await SELF.fetch(`${VERIFY_URL}?token=${encodeURIComponent(tokenForA)}`, {
+      method: 'POST',
+      headers: { 'CF-Connecting-IP': nextIp() },
+    });
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain('Verification failed');
+
+    // pending_email should still be address B (not swapped)
+    const row = await env.DB.prepare(
+      'SELECT pending_email, email FROM notification_preferences WHERE tenant_id = ?',
+    ).bind(tenantId).first();
+    expect(row.pending_email).toBe('address-b@example.com');
+    expect(row.email).toBeNull();
+  });
+
+  it('double verification: second POST with same token fails (no pending_email left)', async () => {
+    const { cookie } = await createTosSession({ githubId: 30004 });
+    const tenantId = 'gh-30004';
+
+    await SELF.fetch(NOTIF_URL, {
+      method: 'PUT',
+      headers: {
+        Cookie: cookie,
+        'CF-Connecting-IP': nextIp(),
+        'Content-Type': 'application/json',
+        'X-WRL-CSRF': '1',
+      },
+      body: JSON.stringify({ email: 'double@example.com' }),
+    });
+
+    const token = await generateEmailVerifyToken(env.SESSION_SECRET, tenantId, 'double@example.com');
+    const url = `${VERIFY_URL}?token=${encodeURIComponent(token)}`;
+
+    const res1 = await SELF.fetch(url, {
+      method: 'POST',
+      headers: { 'CF-Connecting-IP': nextIp() },
+    });
+    expect(res1.status).toBe(200);
+    const html1 = await res1.text();
+    expect(html1).toContain('Email address verified');
+
+    const res2 = await SELF.fetch(url, {
+      method: 'POST',
+      headers: { 'CF-Connecting-IP': nextIp() },
+    });
+    expect(res2.status).toBe(200);
+    const html2 = await res2.text();
+    expect(html2).toContain('Verification failed');
+  });
+
+  it('accepts token in form body (application/x-www-form-urlencoded)', async () => {
+    const { cookie } = await createTosSession({ githubId: 30005 });
+    const tenantId = 'gh-30005';
+
+    await SELF.fetch(NOTIF_URL, {
+      method: 'PUT',
+      headers: {
+        Cookie: cookie,
+        'CF-Connecting-IP': nextIp(),
+        'Content-Type': 'application/json',
+        'X-WRL-CSRF': '1',
+      },
+      body: JSON.stringify({ email: 'form-body@example.com' }),
+    });
+
+    const token = await generateEmailVerifyToken(env.SESSION_SECRET, tenantId, 'form-body@example.com');
+
+    // POST with token in form body, no query param
+    const res = await SELF.fetch(VERIFY_URL, {
+      method: 'POST',
+      headers: {
+        'CF-Connecting-IP': nextIp(),
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: `token=${encodeURIComponent(token)}`,
+    });
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain('Email address verified');
+  });
+
+  it('returns 200 failure page for empty token query param', async () => {
+    const res = await SELF.fetch(`${VERIFY_URL}?token=`, {
+      method: 'POST',
+      headers: { 'CF-Connecting-IP': nextIp() },
+    });
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain('Verification failed');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. POST /v1/account/notifications/resend-verification
+// ---------------------------------------------------------------------------
+
+describe('POST /v1/account/notifications/resend-verification', () => {
+  it('happy path: returns 200 { sent: true } when pending_email is set', async () => {
+    const { cookie } = await createTosSession({ githubId: 40001 });
+    const ip = nextIp();
+
+    // Set pending_email
+    await SELF.fetch(NOTIF_URL, {
+      method: 'PUT',
+      headers: {
+        Cookie: cookie,
+        'CF-Connecting-IP': nextIp(),
+        'Content-Type': 'application/json',
+        'X-WRL-CSRF': '1',
+      },
+      body: JSON.stringify({ email: 'resend-test@example.com' }),
+    });
+
+    // Backdate verification_sent_at so rate limit is clear
+    await env.DB.prepare(
+      "UPDATE notification_preferences SET verification_sent_at = '2020-01-01T00:00:00.000Z' WHERE tenant_id = ?",
+    ).bind('gh-40001').run();
+
+    const res = await SELF.fetch(RESEND_URL, {
+      method: 'POST',
+      headers: {
+        Cookie: cookie,
+        'CF-Connecting-IP': ip,
+        'X-WRL-CSRF': '1',
+      },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.sent).toBe(true);
+  });
+
+  it('returns 400 when no pending email exists', async () => {
+    const { cookie } = await createTosSession({ githubId: 40002 });
+    const ip = nextIp();
+
+    // No PUT -- no pending email
+    const res = await SELF.fetch(RESEND_URL, {
+      method: 'POST',
+      headers: {
+        Cookie: cookie,
+        'CF-Connecting-IP': ip,
+        'X-WRL-CSRF': '1',
+      },
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 429 with Retry-After: 60 on second call within 60 seconds', async () => {
+    const { cookie } = await createTosSession({ githubId: 40003 });
+
+    // Set pending_email
+    await SELF.fetch(NOTIF_URL, {
+      method: 'PUT',
+      headers: {
+        Cookie: cookie,
+        'CF-Connecting-IP': nextIp(),
+        'Content-Type': 'application/json',
+        'X-WRL-CSRF': '1',
+      },
+      body: JSON.stringify({ email: 'rate-limit@example.com' }),
+    });
+
+    // First resend -- should succeed (verification_sent_at was just set by PUT)
+    // Backdate it first so the PUT's own timestamp doesn't interfere
+    await env.DB.prepare(
+      "UPDATE notification_preferences SET verification_sent_at = '2020-01-01T00:00:00.000Z' WHERE tenant_id = ?",
+    ).bind('gh-40003').run();
+
+    const res1 = await SELF.fetch(RESEND_URL, {
+      method: 'POST',
+      headers: {
+        Cookie: cookie,
+        'CF-Connecting-IP': nextIp(),
+        'X-WRL-CSRF': '1',
+      },
+    });
+    expect(res1.status).toBe(200);
+
+    // Second resend immediately -- should hit rate limit
+    const res2 = await SELF.fetch(RESEND_URL, {
+      method: 'POST',
+      headers: {
+        Cookie: cookie,
+        'CF-Connecting-IP': nextIp(),
+        'X-WRL-CSRF': '1',
+      },
+    });
+    expect(res2.status).toBe(429);
+    expect(res2.headers.get('Retry-After')).toBe('60');
+  });
+
+  it('returns 403 when X-WRL-CSRF header is missing', async () => {
+    const { cookie } = await createTosSession({ githubId: 40004 });
+    const ip = nextIp();
+
+    const res = await SELF.fetch(RESEND_URL, {
+      method: 'POST',
+      headers: {
+        Cookie: cookie,
+        'CF-Connecting-IP': ip,
+        // X-WRL-CSRF intentionally omitted
+      },
+    });
+    expect(res.status).toBe(403);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Notification continuity
+// ---------------------------------------------------------------------------
+
+describe('notification continuity', () => {
+  it('notifications go to old email while pending; switch to new email after verification', async () => {
+    const { cookie } = await createTosSession({ githubId: 50001 });
+    const tenantId = 'gh-50001';
+
+    // Seed with a verified old email directly in DB
+    await env.DB.prepare(
+      `INSERT OR REPLACE INTO notification_preferences
+         (tenant_id, email, email_verified, email_source)
+       VALUES (?, 'old@example.com', 1, 'manual')`,
+    ).bind(tenantId).run();
+
+    // PUT a new pending email
+    await SELF.fetch(NOTIF_URL, {
+      method: 'PUT',
+      headers: {
+        Cookie: cookie,
+        'CF-Connecting-IP': nextIp(),
+        'Content-Type': 'application/json',
+        'X-WRL-CSRF': '1',
+      },
+      body: JSON.stringify({ email: 'new@example.com' }),
+    });
+
+    // During pending period, email should still be old@example.com
+    const getRes = await SELF.fetch(NOTIF_URL, {
+      headers: {
+        Cookie: cookie,
+        'CF-Connecting-IP': nextIp(),
+      },
+    });
+    const prefs = await getRes.json();
+    expect(prefs.email).toBe('old@example.com');
+    expect(prefs.pendingEmail).toBe('new@example.com');
+
+    // Verify the new email via POST
+    const token = await generateEmailVerifyToken(env.SESSION_SECRET, tenantId, 'new@example.com');
+    const postRes = await SELF.fetch(`${VERIFY_URL}?token=${encodeURIComponent(token)}`, {
+      method: 'POST',
+      headers: { 'CF-Connecting-IP': nextIp() },
+    });
+    expect(postRes.status).toBe(200);
+    const postHtml = await postRes.text();
+    expect(postHtml).toContain('Email address verified');
+
+    // After verification, email should be new@example.com
+    const afterRes = await SELF.fetch(NOTIF_URL, {
+      headers: {
+        Cookie: cookie,
+        'CF-Connecting-IP': nextIp(),
+      },
+    });
+    const afterPrefs = await afterRes.json();
+    expect(afterPrefs.email).toBe('new@example.com');
+    expect(afterPrefs.pendingEmail).toBeNull();
+    expect(afterPrefs.emailVerified).toBe(true);
+  });
+});

--- a/test/email-verify.test.js
+++ b/test/email-verify.test.js
@@ -192,12 +192,8 @@ describe('email verify token -- generation and verification', () => {
 
 describe('GET /v1/notifications/verify-email', () => {
   it('returns 200 HTML with confirm page for a valid token', async () => {
-    const { tenantId } = await createTosSession();
     // Set pending email via the notifications PUT endpoint
     const { cookie } = await createTosSession({ githubId: 20001 });
-    await env.DB.prepare(
-      "UPDATE github_users SET tos_accepted_at = '2026-01-01T00:00:00.000Z', tos_version = '1.0' WHERE github_id = ?",
-    ).bind(20001).run();
     const putRes = await SELF.fetch(NOTIF_URL, {
       method: 'PUT',
       headers: {
@@ -209,8 +205,6 @@ describe('GET /v1/notifications/verify-email', () => {
       body: JSON.stringify({ email: 'verify-me@example.com' }),
     });
     expect(putRes.status).toBe(200);
-    const putBody = await putRes.json();
-    const tid = putBody.tenantId ?? `gh-20001`;
 
     const token = await generateEmailVerifyToken(env.SESSION_SECRET, 'gh-20001', 'verify-me@example.com');
     const res = await SELF.fetch(`${VERIFY_URL}?token=${encodeURIComponent(token)}`, {
@@ -235,7 +229,7 @@ describe('GET /v1/notifications/verify-email', () => {
 
   it('returns 200 HTML with invalid-link page for expired token', async () => {
     const ts = Math.floor(Date.now() / 1000) - 90000;
-    const token = await craftEmailVerifyToken('deadbeef'.repeat(8), {
+    const token = await craftEmailVerifyToken(env.SESSION_SECRET, {
       t: 'gh-20001', e: 'verify-me@example.com', ts, v: 1,
     });
     const res = await SELF.fetch(`${VERIFY_URL}?token=${encodeURIComponent(token)}`, {
@@ -334,7 +328,7 @@ describe('POST /v1/notifications/verify-email', () => {
 
   it('returns 200 failure page for expired token', async () => {
     const ts = Math.floor(Date.now() / 1000) - 90000;
-    const token = await craftEmailVerifyToken('deadbeef'.repeat(8), {
+    const token = await craftEmailVerifyToken(env.SESSION_SECRET, {
       t: 'gh-30002', e: 'any@example.com', ts, v: 1,
     });
     const res = await SELF.fetch(`${VERIFY_URL}?token=${encodeURIComponent(token)}`, {


### PR DESCRIPTION

## Post-Nefario Updates

### 2026-03-26 00:51 — Code review fixes

Fixed 2 ADVISE findings from code-review-minion:

1. Removed orphaned `createTosSession()` call and unused `tid` variable in GET valid-token test
2. Replaced hardcoded `'deadbeef'.repeat(8)` with `env.SESSION_SECRET` in expired-token tests (latent fragility)

**Commits**: 2 commits since initial report
**Files changed**:
| File | Action | Description |
|------|--------|-------------|
| `test/email-verify.test.js` | modified | Remove dead variable, use env.SESSION_SECRET |
| `docs/history/nefario-reports/2026-03-26-004300-email-verify-tests.md` | modified | Update verification summary |

