### PR TITLE
Add Mermaid architecture diagrams to docs site

### DIFF
--- a/docs/evolution/0086-mermaid-architecture-diagrams/decisions.md
+++ b/docs/evolution/0086-mermaid-architecture-diagrams/decisions.md
@@ -1,0 +1,41 @@
+# Decisions — Mermaid Architecture Diagrams
+
+## Diagram abstraction level
+- **Chosen**: Conceptual flows with descriptive labels (e.g., "Create Capture") and endpoint paths in parentheses
+- **Over**: Endpoint-level diagrams showing every route path
+- **Why**: API Reference already covers endpoints. Architecture diagrams explain HOW, not WHAT.
+
+## Share link flow
+- **Chosen**: Removed entirely from both diagrams
+- **Over**: Including it as described in issue #168
+- **Why**: `POST /v1/captures/{id}/share` does not exist in the codebase (confirmed by api-design-minion grep). Verify endpoint is public by design.
+
+## Scope of user interaction flows
+- **Chosen**: 5 interaction patterns (auth, single capture, batch, verification + certificate, account management)
+- **Over**: Including scheduled captures, diff, notifications, billing
+- **Why**: Architecture overview for evaluators — too many flows makes the sequence diagram unreadable. Secondary flows can be documented on their own pages.
+
+## Mermaid rendering approach
+- **Chosen**: Client-side CDN with inline `<script type="module">` and dynamic import
+- **Over**: (1) Build-time rendering via Eleventy plugin, (2) Separate mermaid-init.js file
+- **Why**: CDN approach fixes all existing and future diagrams with zero build complexity. Inline script per margo's simplification advisory. Aligns with project's "prefer lightweight, vanilla solutions" principle.
+
+## Mermaid version pinning
+- **Chosen**: Pin to exact version (11.4.1) with try/catch fallback
+- **Over**: Major version range (@11) without error handling
+- **Why**: Code review identified that unpinned version risks silent breakage. try/catch ensures CDN failure degrades gracefully to readable code blocks.
+
+## Prism grammar registration
+- **Chosen**: Register empty Prism grammar for `mermaid` language in eleventy.config.js
+- **Over**: Relying on default Prism behavior for unknown languages
+- **Why**: Code review BLOCK identified that Prism might strip language-mermaid class. Empty grammar ensures class is reliably preserved for client-side rendering.
+
+## Page placement
+- **Chosen**: After API Reference, before Security & Compliance
+- **Over**: Between Getting Started and Authentication
+- **Why**: Natural reading flow: onboarding → usage → reference → understanding → trust. Architecture is reference material that bridges API usage and security trust model.
+
+## Single page vs split
+- **Chosen**: Single page with both diagrams
+- **Over**: Separate pages for each diagram
+- **Why**: Content is complementary (user flows + internal pipeline). Nav already has 21 entries.

--- a/docs/evolution/0086-mermaid-architecture-diagrams/outcome.md
+++ b/docs/evolution/0086-mermaid-architecture-diagrams/outcome.md
@@ -1,0 +1,44 @@
+# Outcome — Mermaid Architecture Diagrams
+
+## What was produced
+
+### New files
+- `site/content/architecture.md` — Architecture documentation page with two Mermaid diagrams
+
+### Modified files
+- `site/_includes/layouts/base.njk` — Inline Mermaid rendering script (CDN, pinned v11.4.1, try/catch)
+- `site/_data/site.js` — Navigation entry after API Reference
+- `site/content/index.md` — Architecture card in Getting Started page
+- `site/eleventy.config.js` — Empty Prism grammar for mermaid passthrough
+
+### Diagram 1: User Interaction Flows (sequence diagram)
+Shows 5 interaction patterns: GitHub OAuth + API key auth, single/batch capture lifecycle with polling, public verification with 5 checks + PDF certificate, and account management (keys, webhooks, eIDAS opt-in).
+
+### Diagram 2: Capture Pipeline & Integrity Chain (flowchart)
+Shows 4 pipeline stages: Ingestion (auth → rate limiting → quota → URL validation → threat screening → queue → 202), Processing (browser rendering with dual screenshots + consent dismissal), WACZ Assembly (WARC → artifact hashes → datapackage.json → bundleHash → Ed25519 + RFC 3161 + eIDAS as siblings), Completion (storage → DB → webhook). Includes verification subgraph showing 5 independent checks with server-side key resolution.
+
+## Deviations from issue #168
+
+1. **Share links removed** — `POST /v1/captures/{id}/share` does not exist in the codebase. The verify endpoint is public by design and needs no share mechanism.
+2. **Scheduled captures excluded** — Exist in codebase but excluded for diagram clarity. Can be added later.
+3. **Conceptual level** — Used descriptive labels instead of endpoint-level detail, since API Reference already covers endpoints.
+
+## Side effects
+
+- **Existing whitepaper diagrams now render** — The 3 Mermaid blocks in `site/content/security/whitepaper.md` were previously displayed as raw code. The Mermaid rendering script fixes all Mermaid blocks site-wide.
+
+## Surface consistency
+
+| Surface | Action |
+|---------|--------|
+| OpenAPI spec | No update needed — no new endpoints |
+| Docs site | Updated (this IS the docs change) |
+| Landing page | No update needed — no pricing/capability changes |
+| MCP server | No update needed — no API changes |
+| Legal pages | No update needed — no new data collection or services |
+
+## Backlog changes
+
+- No items added to backlog
+- No items removed from backlog
+- Issue #168 resolved by this PR

--- a/docs/evolution/0086-mermaid-architecture-diagrams/process.md
+++ b/docs/evolution/0086-mermaid-architecture-diagrams/process.md
@@ -1,0 +1,72 @@
+# Process — Mermaid Architecture Diagrams
+
+## TL;DR
+
+Three planning specialists (security-minion, api-design-minion, software-docs-minion) analyzed the codebase to verify the proposed diagrams against reality, finding one critical inaccuracy in the issue description (share links don't exist) and producing a security redaction checklist. Five reviewers approved the plan with one ADVISE (margo: simplify). Execution produced two tasks — Mermaid rendering infrastructure and the architecture page — with code review catching a Prism compatibility issue that was auto-fixed. Two commits, 5 files changed, all from a single documentation page with two diagrams.
+
+## Phase 1: Meta-Plan
+
+Nefario identified 4 planning specialists. Lucy trimmed to 3, cutting ux-strategy-minion as disproportionate for constrained Mermaid output (a reasonable call — Mermaid diagrams have limited layout flexibility).
+
+**Team selected**: security-minion, api-design-minion, software-docs-minion.
+
+## Phase 2: Specialist Planning
+
+Three agents ran in parallel. Key findings by specialist:
+
+### security-minion
+Read 9 source files (`src/capture.js`, `src/wacz.js`, `src/signing.js`, `src/rfc3161.js`, `src/verify.js`, `src/rate-limits.js`, `src/url-validation.js`, `src/threat-check.js`, `src/index.js`) and produced the authoritative pipeline description. Most valuable output: the 8-item redaction checklist (don't expose rate limit thresholds, queue re-validation, fail-open behavior, internal binding names, etc.) and the clarification that signatures are siblings in an array, not a sequential chain.
+
+### api-design-minion
+Discovered the most impactful finding: the share link flow described in issue #168 (`POST /v1/captures/{id}/share` with `wrl_share_xxx` tokens) **does not exist anywhere in the codebase**. Grep confirmed zero matches. The verify endpoint is public by design and needs no share mechanism. Also identified 6 endpoint groups missing from the issue description (batch, diff, certificate, scheduled captures, billing, notifications) and recommended keeping diagrams at conceptual level.
+
+### software-docs-minion
+Analyzed the existing site structure (21 nav entries, Eleventy with doc.njk layout) and recommended placement after API Reference, single page, matching existing frontmatter conventions. Critically flagged that the docs site had no Mermaid rendering — the security whitepaper already had 3 unrendered Mermaid blocks showing as raw code.
+
+## Phase 3: Synthesis
+
+Nefario consolidated into a 3-task plan: (1) Mermaid rendering, (2) architecture page (gated), (3) navigation update. Key synthesis decisions:
+- Share links removed (doesn't exist)
+- 5 interaction patterns scoped (excluding scheduled captures, diff, notifications for clarity)
+- Client-side CDN over build-time plugin (lightweight, fixes all existing diagrams)
+
+## Phase 3.5: Architecture Review
+
+Lucy added gru and removed security-minion from the reviewer set (security had already contributed during planning; the docs site review doesn't need a second security pass).
+
+**5 reviewers**: gru, lucy, margo, test-minion, ux-strategy-minion.
+
+Results: 4 APPROVE, 1 ADVISE (margo). Margo's advice was concrete and correct:
+1. Inline the Mermaid init script instead of a separate JS file (eliminates extra file + HTTP request)
+2. Fold Task 3 (nav update) into Task 2 (it's two one-line edits)
+
+Both incorporated. Lucy reinforced the task consolidation at the plan approval gate.
+
+## Phase 4: Execution
+
+Consolidated to 2 tasks per margo/Lucy:
+
+**Task 1** (executed directly by orchestrator): Added inline `<script type="module">` to base.njk with conditional dynamic import. ~10 lines of vanilla JS.
+
+**Task 2** (software-docs-minion): Created `site/content/architecture.md` with both diagrams plus nav entry and card. The agent read all relevant source files before writing, confirming: queue re-validation exists but is correctly hidden, dual screenshots confirmed, signatures are siblings, key resolution is server-side.
+
+## Phase 5: Code Review
+
+Three reviewers found issues:
+
+**code-review-minion** (BLOCK): Identified that Prism's syntax highlight plugin might not reliably apply `language-mermaid` class to unknown language code blocks. Recommended registering an empty Prism grammar as a defensive fix. Also flagged: no version pinning on CDN, no try/catch, unused forEach parameter.
+
+**margo** (ADVISE): Aligned with code-review-minion on version pinning and try/catch. Noted the inline approach was correct (as margo had originally recommended).
+
+**lucy** (ADVISE): Noted convention difference (inline vs external JS pattern) but accepted the inline approach.
+
+**Auto-fix applied**: Pinned mermaid@11.4.1, added try/catch, registered empty Prism grammar, removed unused parameter. All three reviewers' concerns addressed in one commit.
+
+## Human Interventions
+
+None — this was an autonomous execution. All gate decisions made by Lucy agent.
+
+## Where to Read More
+
+- Evolution log: `docs/evolution/0086-mermaid-architecture-diagrams/`
+- Nefario report: `docs/history/nefario-reports/2026-03-26-021912-mermaid-architecture-diagrams.md`

--- a/docs/evolution/0086-mermaid-architecture-diagrams/prompt.md
+++ b/docs/evolution/0086-mermaid-architecture-diagrams/prompt.md
@@ -1,0 +1,24 @@
+Create two Mermaid diagrams for the documentation site (`site/content/`) and add them as a new page in the site navigation.
+
+## Diagram 1: User Interaction Flows
+
+A sequence diagram showing how different roles interact with the system:
+
+**Tenant (Capture Creator):**
+- Authentication: GitHub OAuth (PKCE) → session cookie, or API key (Bearer token)
+- Create capture: `POST /v1/captures` → 202 Accepted + statusUrl
+- Poll status: `GET /v1/captures/{id}/status`
+- Retrieve result: `GET /v1/captures/{id}` + download artifacts
+- Create share link: `POST /v1/captures/{id}/share` → token-based access for third parties
+
+**Verifier (public, no authentication required):**
+- `GET /v1/verify/{captureId}` → 5 integrity checks (artifactHashes, bundleHash, signature, timestamp, qualifiedTimestamp)
+- Alternatively: share link with `?token=wrl_share_xxx`
+
+Also show self-serve flows: tenant creates own API keys via `/v1/account/keys`, manages webhooks, and optional eIDAS opt-in.
+
+## Diagram 2: Capture Pipeline & Integrity Chain
+
+A flowchart or sequence diagram showing the entire capture process and all involved systems.
+
+Source: GitHub issue #168

--- a/docs/evolution/README.md
+++ b/docs/evolution/README.md
@@ -94,3 +94,4 @@ software development.
 | [0083-merge-timestamp-checks](0083-merge-timestamp-checks/) | Merge timestamp checks: single "Time verification" row replacing separate Timestamp imprint and Qualified timestamp rows (Issue #167) |
 | [0084-email-verify-tests](0084-email-verify-tests/) | Email verification flow tests: 31 tests for token generation, GET/POST handlers, resend, and notification continuity (Issue #199) |
 | [0085-mcp-api-sync](0085-mcp-api-sync/) | Sync MCP server with current API surface and establish drift prevention (Issue #202) |
+| [0086-mermaid-architecture-diagrams](0086-mermaid-architecture-diagrams/) | Add Mermaid architecture diagrams to docs site: user interaction flows + capture pipeline & integrity chain (Issue #168) |

--- a/docs/history/nefario-reports/2026-03-26-021912-mermaid-architecture-diagrams.md
+++ b/docs/history/nefario-reports/2026-03-26-021912-mermaid-architecture-diagrams.md
@@ -1,0 +1,80 @@
+---
+task: "Add Mermaid architecture diagrams to documentation site"
+date: 2026-03-26
+source-issue: 168
+status: complete
+agents: [software-docs-minion, frontend-minion, security-minion, api-design-minion, code-review-minion, lucy, margo, gru, test-minion, ux-strategy-minion]
+task-count: 2
+gate-count: 1
+mode: execution
+---
+
+## Summary
+
+Added two Mermaid architecture diagrams to the WRL documentation site: a sequence diagram showing user interaction flows (auth, capture lifecycle, verification, account management) and a flowchart showing the capture pipeline with the cryptographic integrity chain. Also added client-side Mermaid rendering via CDN, which fixed 3 existing unrendered diagrams in the security whitepaper.
+
+## Original Prompt
+
+GitHub Issue #168: Create two Mermaid diagrams for the documentation site and add them as a new page in the site navigation. Diagram 1 shows user interaction flows (tenant and verifier roles). Diagram 2 shows the capture pipeline and integrity chain with all involved systems.
+
+## Key Design Decisions
+
+### Conceptual flows over endpoint-level diagrams
+The API Reference page already covers endpoint details. Architecture diagrams use descriptive labels ("Create Capture") with endpoint paths in parentheses, explaining HOW the system works rather than repeating WHAT endpoints exist.
+
+### Share link flow removed
+The issue described `POST /v1/captures/{id}/share` with `wrl_share_xxx` tokens. api-design-minion confirmed this endpoint does not exist in the codebase. The verify endpoint is public by design — no share mechanism needed. Removed from both diagrams.
+
+### Client-side CDN rendering with inline script
+Used `<script type="module">` with dynamic `import()` from jsDelivr (mermaid@11.4.1, pinned). Chosen over build-time Eleventy plugin for simplicity and because it fixes all existing and future Mermaid blocks site-wide. Inline rather than separate file per margo's simplification advisory. try/catch ensures CDN failure degrades to readable code blocks.
+
+### Empty Prism grammar for mermaid
+Code review identified that the syntax highlight plugin (Prism) might not reliably preserve the `language-mermaid` class. Registering an empty grammar (`Prism.languages.mermaid = {}`) ensures passthrough with class intact — a defensive two-line fix.
+
+### Single page after API Reference
+Both diagrams on one page at `site/content/architecture.md`, placed after API Reference and before Security & Compliance. Natural reading flow: onboarding → usage → reference → understanding → trust.
+
+## Execution
+
+### Task 1: Add Mermaid JS rendering (inline, base.njk)
+Added inline `<script type="module">` to `site/_includes/layouts/base.njk` that conditionally loads Mermaid from CDN only when `pre code.language-mermaid` elements exist. Registered empty Prism grammar in `site/eleventy.config.js`. No separate JS file needed.
+
+### Task 2: Create architecture page + navigation
+Created `site/content/architecture.md` with two Mermaid diagrams verified against source code. Added navigation entry in `site/_data/site.js` and card in `site/content/index.md`. Key source files read: `src/index.js`, `src/capture.js`, `src/wacz.js`, `src/signing.js`, `src/rfc3161.js`, `src/verify.js`, `src/url-validation.js`, `src/threat-check.js`.
+
+## Verification
+
+Code review: 1 BLOCK auto-fixed (Prism grammar registration), 2 ADVISE auto-fixed (version pinning + try/catch, unused parameter). Tests: not applicable (docs-only changes). Documentation: this IS the documentation change.
+
+## Agent Contributions
+
+### Planning (Phase 2)
+- **security-minion**: Verified exact pipeline sequence and cryptographic proof chain from 9 source files. Produced 8-item redaction checklist for public diagrams. Confirmed signatures are siblings (not chain), bundleHash signed as UTF-8 string.
+- **api-design-minion**: Confirmed share link flow does not exist. Identified 6 missing endpoint groups. Recommended conceptual flows over endpoint-level detail.
+- **software-docs-minion**: Analyzed site structure, recommended placement after API Reference, single page, existing frontmatter conventions. Flagged Mermaid rendering as critical risk.
+
+### Review (Phase 3.5)
+- **gru**: APPROVE — technology choices sound, CDN approach appropriate
+- **lucy**: APPROVE — plan matches intent, conventions compliant
+- **margo**: ADVISE — inline init script, consolidate tasks (both incorporated)
+- **test-minion**: APPROVE — tests correctly excluded for docs-only changes
+- **ux-strategy-minion**: APPROVE — journey coherent, suggest details/summary for integrity chain
+
+### Code Review (Phase 5)
+- **code-review-minion**: BLOCK → fixed (Prism grammar + version pin + try/catch)
+- **margo**: ADVISE (version pin + try/catch — aligned with code-review-minion)
+- **lucy**: ADVISE (convention consistency — noted, inline approach accepted)
+
+## Files Changed
+
+| File | Action | Description |
+|------|--------|-------------|
+| `site/content/architecture.md` | created | Architecture page with 2 Mermaid diagrams |
+| `site/_includes/layouts/base.njk` | modified | Inline Mermaid rendering script |
+| `site/_data/site.js` | modified | Navigation entry |
+| `site/content/index.md` | modified | Architecture card in Getting Started |
+| `site/eleventy.config.js` | modified | Empty Prism grammar for mermaid |
+| `docs/evolution/0086-mermaid-architecture-diagrams/` | created | Evolution log |
+| `docs/evolution/README.md` | modified | Index entry |
+
+Resolves #168

--- a/docs/history/nefario-reports/2026-03-26-021912-mermaid-architecture-diagrams/phase1-metaplan.md
+++ b/docs/history/nefario-reports/2026-03-26-021912-mermaid-architecture-diagrams/phase1-metaplan.md
@@ -1,0 +1,77 @@
+# Meta-Plan: Mermaid Architecture Diagrams for WRL Documentation Site
+
+## Planning Consultations
+
+#### Consultation 1: Capture pipeline accuracy and integrity chain
+- **Agent**: security-minion
+- **Planning question**: Review the capture pipeline flow described in the issue against the actual codebase (`src/capture.js`, `src/wacz.js`, `src/signing.js`, `src/rfc3161.js`, `src/rate-limits.js`, `src/threat-check.js`, `src/url-validation.js`, `src/verify.js`). What is the exact sequence of operations, and what is the precise cryptographic proof chain? Which steps are optional vs mandatory? Are there any security-sensitive details that should NOT be exposed in a public-facing diagram (e.g., internal rate-limiting implementation details)?
+- **Context to provide**: The GitHub issue description, `src/` directory listing, existing verification docs at `site/content/verification.md`, `site/content/authentication.md`
+- **Why this agent**: The diagrams must accurately represent the cryptographic integrity chain and authentication flows. Security-minion can verify correctness and flag anything that shouldn't be publicly documented.
+
+#### Consultation 2: User interaction flow completeness
+- **Agent**: api-design-minion
+- **Planning question**: Review the API routes in `src/index.js` and the handler files (`src/capture.js`, `src/verify.js`, `src/account.js`, `src/oauth.js`, `src/auth.js`) to confirm the complete set of user-facing endpoints and interaction patterns. Does the issue description accurately capture all tenant and verifier flows? Are there flows missing (e.g., scheduled captures via `src/schedules.js`, rescan via `src/rescan.js`)? What level of endpoint detail is appropriate for an architecture overview diagram vs the existing API Reference page?
+- **Context to provide**: `src/index.js` (router), existing `site/content/api-reference.njk`, the issue description
+- **Why this agent**: API-design-minion can verify the completeness of the interaction flows against the actual route definitions and advise on appropriate abstraction level.
+
+#### Consultation 3: Documentation site integration and navigation placement
+- **Agent**: software-docs-minion
+- **Planning question**: Given the existing site navigation structure (Getting Started → Authentication → Verification → Legal Evidence → Batch Captures → Limits → Webhooks → MCP Server → API Reference → Security section), where should an "Architecture" page sit? Should it be a single page with both diagrams or split? What frontmatter and layout conventions does the site use? Review `site/content/` pages for consistent style, heading structure, and prose conventions to ensure the new page fits naturally.
+- **Context to provide**: `site/_data/site.js`, `site/content/index.md` (as style reference), all existing content page frontmatter, `site/` directory structure
+- **Why this agent**: Documentation structure and navigation flow are core documentation concerns. The page needs to fit the existing information architecture.
+
+#### Consultation 4: Diagram clarity and audience targeting
+- **Agent**: ux-strategy-minion
+- **Planning question**: The diagrams target two audiences: potential customers evaluating the product and technical evaluators assessing the integrity model. How should the two diagrams balance technical depth vs accessibility? Should Diagram 1 (user flows) be simplified for the customer audience while Diagram 2 (pipeline) targets evaluators? Are there cognitive load concerns with showing all flows in a single sequence diagram? Should the page include prose context between/around the diagrams?
+- **Context to provide**: The issue description, existing doc page styles, the two audience types mentioned
+- **Why this agent**: Every plan needs journey coherence review. The diagrams serve a specific user job (evaluate the product's architecture) and the strategy-minion can advise on how to structure them for clarity.
+
+### Cross-Cutting Checklist
+
+- **Testing**: Exclude from planning. This task produces documentation content (Markdown + Mermaid), not executable code. The site build (`eleventy`) will validate the page renders, but no test-minion planning input is needed.
+- **Security**: INCLUDE (Consultation 1). The diagrams depict the security model — security-minion must verify accuracy and flag anything that shouldn't be publicly exposed.
+- **Usability -- Strategy**: INCLUDE (Consultation 4). Diagram clarity and audience targeting are core UX-strategy concerns.
+- **Usability -- Design**: Exclude from planning. No UI components are being created — the diagrams render as standard Mermaid in Markdown. Visual hierarchy is handled by the existing site layout.
+- **Documentation**: INCLUDE (Consultation 3). This IS a documentation task — software-docs-minion is a natural planning participant.
+- **Observability**: Exclude. No runtime components are being created or modified.
+
+### Notable Exclusions
+
+- **frontend-minion**: The site uses Eleventy (static site generator) with existing layouts. No frontend component work is needed — this is a content page using the existing `layouts/doc.njk` template.
+- **ux-design-minion**: Mermaid diagrams have limited visual design flexibility. The rendering is handled by the existing site CSS/GitHub rendering. No custom visual design needed.
+- **mcp-minion**: While the site documents the MCP server, this task doesn't involve MCP implementation — it's documenting existing functionality.
+
+### Anticipated Approval Gates
+
+1. **Diagram content accuracy** (MUST gate): Before writing the final page, the diagram content (which endpoints, which systems, which flow steps) should be verified against the codebase. This is hard to reverse (wrong diagrams in published docs erode trust) and has downstream impact (the page content depends on accurate diagrams). Gate after the specialist planning contributions confirm the exact flows.
+
+### Rationale
+
+This task is primarily a documentation task that requires domain accuracy. The four consultations cover: (1) cryptographic/security accuracy of the pipeline diagram, (2) API completeness of the user flow diagram, (3) documentation site integration, and (4) audience-appropriate presentation. These four perspectives ensure the diagrams are both technically correct and useful to readers.
+
+The `mermaid` user-global skill is available and should be used during execution for Mermaid syntax reference, but it doesn't need to participate in planning — it's a LEAF skill providing syntax help.
+
+### Scope
+
+**In scope:**
+- Two Mermaid diagrams (sequence + flowchart) as described in the issue
+- A new content page in `site/content/` using the existing doc layout
+- Navigation entry in `site/_data/site.js`
+- Prose context around the diagrams for reader orientation
+
+**Out of scope:**
+- Changes to existing documentation pages
+- Any code changes to the API or worker
+- Custom CSS or layout changes for diagram rendering
+- Interactive diagrams or non-Mermaid visualizations
+
+### External Skill Integration
+
+#### Discovered Skills
+| Skill | Location | Classification | Domain | Recommendation |
+|-------|----------|---------------|--------|----------------|
+| ops-runbook | `.claude/skills/ops-runbook/` | LEAF | Operations/admin procedures | Not relevant to this task |
+| mermaid | `~/.claude/skills/mermaid/` (user-global) | LEAF | Mermaid diagram syntax reference | Include in execution task prompt as Available Skill |
+
+#### Precedence Decisions
+No conflicts. The `mermaid` skill is a syntax reference that complements rather than conflicts with any specialist. It will be listed as an Available Skill in the execution task prompt for the agent producing the diagrams.

--- a/docs/history/nefario-reports/2026-03-26-021912-mermaid-architecture-diagrams/phase2-api-design-minion.md
+++ b/docs/history/nefario-reports/2026-03-26-021912-mermaid-architecture-diagrams/phase2-api-design-minion.md
@@ -1,0 +1,156 @@
+# Domain Plan Contribution: api-design-minion
+
+## Recommendations
+
+### 1. The issue description has inaccuracies -- correct before diagramming
+
+**Share links do not exist.** The issue describes `POST /v1/captures/{id}/share` producing a `wrl_share_xxx` token. No such endpoint, handler, or token format exists anywhere in the codebase. Grep for `wrl_share`, `share`, and `POST.*share` across all source files returned zero matches on share-link functionality. The verify endpoint (`GET /v1/verify/{captureId}`) is public (rate-limited, no auth), so there is no need for share tokens -- anyone with the capture ID can verify. The diagrams must not include share links.
+
+**Batch captures are missing from the issue.** `POST /v1/captures/batch` is a real endpoint (route line 69) and represents a distinct interaction pattern (array of URLs in, array of capture IDs out). It should appear in the tenant flow diagram.
+
+**Diff endpoint is missing.** `GET /v1/captures/{baseId}/diff/{targetId}` (route line 76) compares two captures. This is a tenant-facing flow relevant to scheduled capture use cases (detecting changes over time).
+
+**Certificate endpoint is missing.** `GET /v1/captures/{captureId}/certificate` (route line 75) generates a signed PDF certificate for legal evidence use (FRE 902(13)). This is a verifier-adjacent flow and should be represented.
+
+**Billing flows are missing.** `POST /v1/billing/checkout` and `POST /v1/billing/portal` (route lines 120-121) plus `POST /v1/stripe/webhook` (line 123) form a complete billing lifecycle. This is a tenant self-serve flow.
+
+**Notification/email flows are missing.** Notification preferences (`GET/PUT /v1/account/notifications`), email verification (`GET/POST /v1/notifications/verify-email`), unsubscribe (`GET/POST /v1/notifications/unsubscribe`), and weekly digest (cron-triggered) form a distinct subsystem.
+
+### 2. Complete endpoint inventory (routes vs. issue vs. OpenAPI)
+
+| Endpoint | In Issue | In OpenAPI | In Routes | Notes |
+|---|---|---|---|---|
+| **Auth** | | | | |
+| `GET /auth/login` | Yes | No | Yes | OAuth PKCE initiation |
+| `GET /auth/callback` | Yes | No | Yes | OAuth callback |
+| `POST /auth/logout` | Implied | No | Yes | Session teardown |
+| `GET /auth/session` | No | No | Yes | Session validation |
+| **Captures** | | | | |
+| `POST /v1/captures` | Yes | Yes | Yes | |
+| `POST /v1/captures/batch` | No | Yes | Yes | **Missing from issue** |
+| `GET /v1/captures` | No | Yes | Yes | List captures (pagination) |
+| `GET /v1/captures/{id}/status` | Yes | Yes | Yes | |
+| `GET /v1/captures/{id}` | Yes | Yes | Yes | |
+| `GET /v1/captures/{id}/artifacts/{name}` | Implied | Yes | Yes | |
+| `GET /v1/captures/{id}/certificate` | No | Yes | Yes | **Missing from issue** |
+| `GET /v1/captures/{baseId}/diff/{targetId}` | No | Yes | Yes | **Missing from issue** |
+| **Verification** | | | | |
+| `GET /v1/verify/{captureId}` | Yes | Yes | Yes | |
+| `GET /.well-known/signing-key(s)` | No | Yes | Yes | Public key discovery |
+| **Share** | | | | |
+| `POST /v1/captures/{id}/share` | Yes | **No** | **No** | **Does not exist** |
+| **Account self-serve** | | | | |
+| `GET /v1/account/first-key` | No | No | Yes | Onboarding flow |
+| `POST /v1/account/first-key/ack` | No | No | Yes | Onboarding flow |
+| `GET/POST /v1/account/keys` | Yes | No | Yes | |
+| `DELETE /v1/account/keys/{hash}` | No | No | Yes | |
+| `POST /v1/account/tos` | No | No | Yes | ToS acceptance |
+| `GET /v1/account/usage` | No | Yes | Yes | |
+| `GET/PATCH /v1/account/settings` | No | No | Yes | eIDAS opt-in lives here |
+| `GET/PUT /v1/account/notifications` | No | Yes | Yes | Email preferences |
+| `POST /v1/account/notifications/resend-verification` | No | No | Yes | |
+| **Notifications (unauthenticated)** | | | | |
+| `GET/POST /v1/notifications/unsubscribe` | No | Yes | Yes | Token-based |
+| `GET/POST /v1/notifications/verify-email` | No | No | Yes | Token-based |
+| **Webhooks** | | | | |
+| `POST/GET /v1/webhooks` | Yes | Yes | Yes | |
+| `DELETE /v1/webhooks/{id}` | No | Yes | Yes | |
+| `POST /v1/webhooks/{id}/ping` | No | Yes | Yes | |
+| **Schedules** | | | | |
+| `POST/GET /v1/schedules` | No | Yes | Yes | **Missing from issue** |
+| `GET/DELETE /v1/schedules/{id}` | No | Yes | Yes | **Missing from issue** |
+| **Billing** | | | | |
+| `POST /v1/billing/checkout` | No | No | Yes | **Missing from issue** |
+| `POST /v1/billing/portal` | No | No | Yes | **Missing from issue** |
+| `POST /v1/stripe/webhook` | No | No | Yes | Stripe event ingestion |
+| **Admin** | | | | |
+| `POST/GET /v1/admin/keys` | No | Yes | Yes | Infrastructure keys |
+| `DELETE /v1/admin/keys/{hash}` | No | Yes | Yes | |
+| `GET /v1/admin/usage` | No | Yes | Yes | |
+| `POST /v1/admin/cache/purge` | No | No | Yes | |
+| `GET/PUT /v1/admin/tenants/{id}/config` | No | No | Yes | |
+| **Background** | | | | |
+| Queue: capture processing | Implied | N/A | Yes | Workers Queue consumer |
+| Queue: webhook dispatch + DLQ | No | N/A | Yes | |
+| Queue: email dispatch + DLQ | No | N/A | Yes | |
+| Cron: scheduled captures | No | N/A | Yes | `handleScheduledTick` |
+| Cron: weekly digest | No | N/A | Yes | Monday 9:00 UTC |
+| Cron: rescan | No | N/A | Yes | `RESCAN_CRON` |
+| Cron: meter reporting | No | N/A | Yes | Hourly Stripe meter events |
+| **Other** | | | | |
+| `GET /ui` | No | No | Yes | Web dashboard |
+| `GET /health` | No | Yes | Yes | |
+| MCP handler | No | No | Yes | `handleMcp` |
+
+### 3. Abstraction level guidance
+
+**Architecture diagrams should show conceptual flows, not endpoint inventories.** The existing API Reference page already serves as the endpoint-level documentation. The diagrams should operate one level above that.
+
+**Recommended groupings for the sequence diagram (User Interaction Flows):**
+
+Rather than showing every endpoint, group into these interaction patterns:
+
+1. **Onboarding flow**: OAuth login --> first-key generation --> ToS acceptance --> dashboard
+2. **Capture lifecycle**: Create capture (single or batch) --> queue processing --> poll status --> retrieve result + artifacts
+3. **Scheduled capture flow**: Create schedule --> cron tick --> automatic capture --> change detection (diff) --> webhook/email notification
+4. **Verification flow**: Public verify endpoint --> 5 integrity checks --> certificate download
+5. **Account management**: API key CRUD, settings (eIDAS opt-in), notification preferences, billing (checkout/portal)
+6. **Webhook delivery**: Capture completes --> webhook queue --> delivery with retry --> DLQ on failure
+
+**Recommended groupings for the flowchart (Capture Pipeline & Integrity Chain):**
+
+Show the data flow through the system, not the HTTP layer:
+
+1. **Ingestion**: HTTP request --> validation (URL, quota, rate limit, threat check) --> D1 row creation --> Queue enqueue --> 202 response
+2. **Processing**: Queue dequeue --> Browser Rendering (headless Chromium) --> artifact collection (HTML, headers, screenshot, WACZ) --> hashing --> Ed25519 signing --> R2 storage --> D1 status update
+3. **Integrity chain**: Content hash --> manifest hash --> signature --> verification (5 checks: existence, hash, signature, timestamp, R2 integrity)
+4. **Optional paths**: eIDAS qualified timestamp (external TSA) --> timestamp token stored alongside signature
+5. **Notifications**: Capture complete --> webhook dispatch queue --> HTTP delivery; email dispatch queue --> email delivery
+6. **Scheduled captures**: Cron trigger --> D1 schedule lookup --> capture enqueue --> diff against previous --> change summary
+
+### 4. What the diagrams should NOT include
+
+- **Admin endpoints**: These are infrastructure-internal (key provisioning, cache purge, tenant config). They are not part of the tenant or verifier experience.
+- **Individual endpoint paths**: The API Reference already covers this. Repeating `POST /v1/captures` in a sequence diagram adds noise. Use conceptual labels like "Create Capture" with a parenthetical reference to the endpoint.
+- **MCP handler**: This is an integration interface, not a user flow. Omit from architecture overview.
+- **Health check / favicon**: Infrastructure plumbing.
+
+### 5. OpenAPI spec is incomplete
+
+The OpenAPI spec is missing several routes that exist in `src/index.js`:
+- All auth routes (`/auth/*`)
+- Account key management, settings, ToS
+- Billing routes
+- Email verification
+- First-key onboarding
+- Admin tenant config and cache purge
+
+This is worth noting but does not affect the diagram task. The diagrams should reflect reality (the routes table), not the spec.
+
+## Proposed Tasks
+
+1. **Remove share link flow from both diagrams.** The `POST /v1/captures/{id}/share` endpoint does not exist. The verify endpoint is public and needs no share token.
+
+2. **Add scheduled capture flow to the sequence diagram.** This is a distinct tenant interaction pattern (create schedule, automatic captures, change detection via diff, notification delivery) that the issue completely omits.
+
+3. **Add batch capture as a variant in the capture lifecycle.** Show it as an alternative entry point alongside single capture, converging at the queue processing step.
+
+4. **Include certificate download in the verifier flow.** After verification succeeds, a verifier can download a signed PDF certificate -- this is the legal-evidence endpoint of the integrity chain.
+
+5. **Show the notification subsystem in the pipeline flowchart.** After capture completion, two parallel paths: webhook dispatch queue and email dispatch queue. Both have retry logic and DLQ. This is a significant part of the system architecture.
+
+6. **Show billing as a self-contained box in account management.** Stripe checkout creates a subscription, Stripe webhooks update tenant state, portal provides self-serve billing management. Keep it simple -- one box with three arrows.
+
+7. **Use conceptual labels, not endpoint paths, as primary labels.** Reference endpoints in parentheses where helpful (e.g., "Create Capture (POST /v1/captures)") but keep the diagram readable at a conceptual level. The API Reference page is already the endpoint inventory.
+
+## Risks and Concerns
+
+1. **The issue's share link flow is fictional.** If someone implements the diagram as described in the issue, it will depict functionality that does not exist and may confuse users who try to find the endpoint. This must be caught before the diagrams are created.
+
+2. **Diagram scope creep.** The system has 40+ routes, 3 queue consumers, 4+ cron jobs, and multiple subsystems (billing, notifications, schedules, webhooks). Trying to show everything in two diagrams will produce unreadable output. The groupings I recommended above are the right abstraction level -- resist the temptation to add more detail.
+
+3. **OpenAPI drift.** The spec is significantly behind the implementation. If someone references the spec to build the diagrams, they will miss half the system. The route table in `src/index.js` (lines 64-124) is the authoritative source.
+
+## Additional Agents Needed
+
+None. The diagram implementation is a documentation/visualization task. The API design analysis above provides the factual foundation needed.

--- a/docs/history/nefario-reports/2026-03-26-021912-mermaid-architecture-diagrams/phase2-security-minion.md
+++ b/docs/history/nefario-reports/2026-03-26-021912-mermaid-architecture-diagrams/phase2-security-minion.md
@@ -1,0 +1,179 @@
+# Domain Plan Contribution: security-minion
+
+## Verified Capture Pipeline Sequence (from source code)
+
+The actual flow, confirmed by reading `src/index.js`, `src/capture.js`, `src/wacz.js`, `src/signing.js`, `src/rfc3161.js`, `src/verify.js`, `src/url-validation.js`, `src/threat-check.js`, and `src/rate-limits.js`:
+
+### Pre-Capture (API Request Handler -- `handleCreateCapture` in index.js)
+
+1. **Content-Type check** -- must be `application/json`
+2. **Authentication** -- dual-path: session cookie (OAuth) OR API key (Bearer token, SHA-256 hash lookup in D1)
+3. **Rate limiting** -- per-tenant KV counter + per-IP secondary guard + global capacity limiter
+4. **Quota check** -- monthly capture/storage quota (D1), free tier enforcement
+5. **URL validation** -- SSRF prevention (`validateUrl` in url-validation.js):
+   - Length limit (2048 chars)
+   - WHATWG URL parsing
+   - Scheme allowlist (http/https only)
+   - Credential rejection (no userinfo)
+   - IPv4 all-encoding normalization (hex, octal, decimal integer, shorthand)
+   - IPv6 parsing including IPv4-mapped forms
+   - DNS resolution (both A and AAAA records)
+   - Private/reserved IP blocklist check on ALL resolved addresses (fail-closed: unrecognized formats treated as private)
+   - Double-encoding detection in path and query
+6. **Threat check** -- Google Web Risk API (`checkUrl` in threat-check.js): MALWARE, SOCIAL_ENGINEERING, UNWANTED_SOFTWARE. **Fails open** on API errors/timeouts (degraded mode).
+7. **Create capture record** -- D1 insert with `pending` status
+8. **Enqueue** -- `CAPTURE_QUEUE.send()` with captureId, validated URL, IP, tenantId, cip, eIDAS flag
+
+### Capture Execution (Queue Consumer -- `handleCaptureMessage` in index.js, `performCapture` in capture.js)
+
+1. **Message validation** -- defense-in-depth structure check on dequeued message
+2. **Re-validate URL** -- second SSRF check on the URL from the queue message (defense-in-depth against queue poisoning)
+3. **Idempotency guard** -- skip if capture is already terminal (complete/failed/quarantined)
+4. **Browser rendering** (concurrent with header fetch):
+   - Acquire/connect to Cloudflare Browser Rendering session
+   - Fresh BrowserContext per capture (cookie/storage isolation)
+   - Cross-domain main-frame navigation blocked via `context.route()`
+   - Service workers blocked
+   - Screenshot before consent
+   - Cookie consent dismissal via `@duckduckgo/autoconsent` (server-controlled, not caller-supplied)
+   - Screenshot after consent (if CMP found)
+   - HTML content extraction
+5. **Header fetch** -- separate `fetch()` with `redirect:'manual'`, Set-Cookie values redacted
+6. **Store individual artifacts** in R2 (`captures/{captureId}/screenshot.png`, `rendered.html`, `headers.json`, optionally `screenshot-before.png`)
+
+### Cryptographic Proof Chain (WACZ Assembly -- `buildWacz` in wacz.js)
+
+This is the exact chain, confirmed from source:
+
+1. **Get signing keys** -- `getSigningKeys(env)` lazily imports Ed25519 private key from `env.SIGNING_KEY` (PKCS8 base64). Derives public key bytes and computes `keyId` = first 8 hex chars of SHA-256(raw 32-byte public key). **MANDATORY** -- returns null (no WACZ) if signing key absent.
+2. **Build WARC** -- `buildWarc()` creates WARC records from artifacts
+3. **Build CDXJ index** -- `buildCdxj()` creates index from WARC record metadata
+4. **Build pages.jsonl** -- capture metadata
+5. **Compute SHA-256 hashes** of each artifact file (WARC, CDXJ, pages.jsonl). **MANDATORY.**
+6. **Assemble datapackage.json** -- manifest with artifact paths, hashes, byte sizes, capture metadata, captureSettings
+7. **Compute bundleHash** = `sha256(canonicalize(datapackage))` -- canonical JSON (sorted keys, no whitespace), NOT the pretty-printed version stored in the ZIP. **MANDATORY.** Verifiers must re-canonicalize to validate.
+8. **Sign bundleHash** -- `signBytes(privateKey, UTF-8 bytes of "sha256:{hex}")`. Ed25519 signature over the literal string. **MANDATORY.**
+9. **RFC 3161 timestamp** -- `requestTimestamp(env.TSA_URL, bundleHash)`. Builds DER TimeStampReq with SHA-256 messageImprint and 128-bit nonce. Validates response: PKIStatus=0, nonce match, messageImprint match. **OPTIONAL** -- graceful degradation, logged as `capture.tsa_fail` on error.
+10. **eIDAS qualified timestamp** -- `requestTimestamp(env.QUALIFIED_TSA_URL, bundleHash)` with HTTP Basic auth. Same validation. **OPTIONAL** -- requires both account-level opt-in AND `QUALIFIED_TSA_URL` configured.
+11. **Assemble datapackage-digest.json** -- contains `signedData.hash` (bundleHash), `signedData.signatures[]` array with:
+    - `type:"self"` -- Ed25519 signature, publicKey (base64), keyId. **Always present.**
+    - `type:"rfc3161"` -- TSA token (base64 DER), TSA URL. **Present only if TSA succeeded.**
+    - `type:"rfc3161_qualified"` -- eIDAS TSA token, TSA URL. **Present only if requested AND succeeded.**
+12. **ZIP assembly** -- fflate STORE mode (level 0), all files uncompressed
+13. **Compute waczHash** = `sha256(final WACZ bytes)` -- used as content-addressed R2 key
+14. **Archive signing key** in D1 -- `archiveSigningKey(env.DB, keyId, publicKeyBase64)` before `completeCapture()` (no race window)
+15. **Store WACZ** in R2 at `captures/{waczHash}.wacz`
+16. **Complete capture** -- D1 update with artifact paths, WACZ info (key, bundleHash, size, keyId, timestamp statuses), render quality, captureSettings
+
+### Verification Flow (verify.js)
+
+Five checks, all run independently (no short-circuiting):
+
+1. **artifactHashes** -- SHA-256 of each resource file matches hash in datapackage.json
+2. **bundleHash** -- `sha256(canonicalize(datapackage))` matches `signedData.hash`
+3. **signature** -- Ed25519 signature verification using SERVER's public key (NOT the embedded key)
+4. **timestamp** (v0.2.0 only) -- RFC 3161 messageImprint matches bundleHash. Status `skip` if absent (tolerated). Status `fail` if present but invalid.
+5. **qualifiedTimestamp** (v0.2.0 only) -- same as above. Silently omitted if not present. `fail` if present but invalid.
+
+**Critical security property**: verification uses the server's signing key resolved via `keyId` from the D1 capture record (server-controlled), NEVER from the WACZ's embedded `signedData`. The embedded publicKey is informational only for offline/third-party verifiers.
+
+### Mandatory vs Optional Steps
+
+| Step | Status | Notes |
+|------|--------|-------|
+| URL validation (SSRF) | MANDATORY | Blocks capture if failed |
+| Threat check (Web Risk) | MANDATORY but **fails open** | Degraded mode on API error -- capture proceeds |
+| Rate limiting | MANDATORY | 429 on exceed |
+| Quota check | MANDATORY (KV auth) | Legacy auth exempt |
+| Browser rendering | MANDATORY | Core capture function |
+| Header fetch | OPTIONAL | Capture succeeds without headers |
+| WACZ signing (Ed25519) | OPTIONAL | Graceful degradation if no SIGNING_KEY; also skipped for partial captures |
+| RFC 3161 standard timestamp | OPTIONAL | Capture succeeds without it; status tracked as 'skipped' or 'error' |
+| RFC 3161 qualified (eIDAS) | OPTIONAL | Requires account opt-in + QUALIFIED_TSA_URL configured |
+| Cookie consent dismissal | OPTIONAL | Skipped for partial captures; 2s hard timeout |
+
+## Recommendations
+
+### 1. Redact specific rate limit values from public diagrams
+
+The source reveals exact rate limit numbers (10 captures/60s per tenant, 50/60s IP guard, 100/60s binding ceiling). **Do NOT include these numbers** in public-facing diagrams. Show "Rate Limiting" as a step without exposing the thresholds. Exposing limits helps attackers optimize their request patterns to stay just under the threshold.
+
+### 2. Do not expose the dual-validation pattern (queue re-validation)
+
+The queue consumer re-validates the URL via `validateUrl()` as defense-in-depth against queue poisoning. This is a valuable security control. **Do NOT show it in the diagram** -- it reveals that queue messages are a trust boundary and that poisoning the queue bypasses the first validation. Show a single "URL Validation" step at API entry. The re-validation is an implementation detail that benefits from obscurity.
+
+### 3. Do not expose error categorization or retry logic
+
+The source has detailed error categorization (`categorizeError`) with retryable vs non-retryable classifications, exponential backoff constants, and max retry counts. **None of this belongs in public diagrams.** Show "Queue (with retries)" as a single box.
+
+### 4. Do not expose the threat check fail-open behavior
+
+The Google Web Risk API integration **fails open** on errors/timeouts (capture proceeds in degraded mode). This is a reasonable operational choice, but advertising it publicly tells attackers that they can reliably bypass threat screening by making the API unreachable from the Worker. Diagram should show "Threat Screening" as a step without indicating the degradation behavior.
+
+### 5. The signing key trust model IS safe to show publicly
+
+The Ed25519 signing approach, keyId derivation (SHA-256 fingerprint of public key), bundleHash computation (canonical JSON), and the `.well-known/signing-key` endpoint are all designed to be public. The cryptographic proof chain is a selling point and should be shown accurately. The fact that verification uses server-side key resolution (not embedded keys) is also safe and good to highlight.
+
+### 6. TSA/eIDAS details are safe to show
+
+The RFC 3161 timestamping flow (including the distinction between standard and qualified/eIDAS timestamps) is safe to document. The TSA URLs themselves are public infrastructure. The DER encoding details are unnecessary for an architecture diagram but the conceptual flow is fine.
+
+### 7. Do not expose internal service names or bindings
+
+Avoid naming specific Cloudflare bindings (`CAPTURE_QUEUE`, `CAPTURE_RATE_LIMITER`, `GLOBAL_CAPTURE_LIMITER`, `BROWSER`), KV key patterns, D1 table names, or R2 key naming conventions. Use generic labels: "Queue", "Rate Limiter", "Browser Rendering", "Object Storage", "Database".
+
+### 8. Verification page is unauthenticated -- this is correct and safe to show
+
+The `/v1/verify/{captureId}` endpoint is intentionally unauthenticated (rate-limited at 60/60s per-IP). This is by design for third-party verification. Safe to show in the verifier flow diagram.
+
+### 9. The `.well-known/signing-key` and `.well-known/signing-keys` endpoints are public
+
+These expose the current and archived public keys. Safe to reference in diagrams as the trust anchor for offline verification.
+
+## Proposed Tasks
+
+### Task 1: Define diagram content boundaries (security review gate)
+
+Before any diagram is committed, verify that it does not contain:
+- Exact rate limit numbers or thresholds
+- Internal binding names or key patterns
+- Error handling specifics (retry counts, backoff values, fail-open behavior)
+- Queue message structure details
+- Defense-in-depth measures that benefit from non-disclosure (queue re-validation)
+- Internal IP blocklist details (specific CIDR ranges)
+
+### Task 2: Verify the cryptographic proof chain in the diagram matches source
+
+The diagram must accurately represent:
+- `artifact hashes (SHA-256)` --> `datapackage.json` --> `bundleHash = sha256(canonicalize(datapackage))` --> `Ed25519 signature over UTF-8 bytes of bundleHash string` --> `optional RFC 3161 timestamp over bundleHash` --> `optional eIDAS qualified timestamp over bundleHash`
+- All signatures and timestamps cover the SAME bundleHash (they are siblings in the signatures array, not a chain)
+- The signed payload is the literal string `"sha256:{hex}"` encoded as UTF-8 bytes, not raw hash bytes
+
+### Task 3: Ensure verification diagram shows correct trust model
+
+The diagram must clearly show that:
+- Verification uses the SERVER's public key (resolved via keyId from DB record), not the WACZ-embedded key
+- The `.well-known/signing-key(s)` endpoint is the public trust anchor
+- Third-party verifiers can verify offline by pinning the public key
+
+## Risks and Concerns
+
+### Risk 1: Over-detailed diagrams expose attack surface (MEDIUM)
+
+Architecture diagrams often reveal more than intended. The biggest risk is showing the exact sequence of security controls in a way that helps an attacker identify which to target. Mitigation: abstract the security controls into high-level boxes ("Authentication", "Validation", "Threat Screening") without showing the implementation order or fallback behavior.
+
+### Risk 2: Showing the queue as a separate component implies a trust boundary (LOW)
+
+If the diagram shows the queue between API and capture execution, a sophisticated attacker might reason about queue poisoning. The defense-in-depth re-validation in the queue consumer mitigates this, but we should not advertise the trust boundary. Mitigation: show the queue as an internal implementation detail of "Capture Pipeline", not as a separately targetable component. However, the queue is already well-known from the Cloudflare Workers architecture, so this is low risk.
+
+### Risk 3: TSA URLs in diagrams could be targeted for DoS (LOW)
+
+If the diagram shows specific TSA endpoint URLs, an attacker could target them to force degraded-mode captures (since threat check and TSA both fail open). Mitigation: use generic labels ("RFC 3161 TSA", "eIDAS Qualified TSA") without specific URLs.
+
+### Risk 4: Inaccurate diagram creates false security assurance (MEDIUM)
+
+If the cryptographic proof chain is drawn incorrectly (e.g., showing timestamps as chained rather than parallel, or showing the wrong signing input), users may develop incorrect trust assumptions. Mitigation: Task 2 above -- verify against source before merging.
+
+## Additional Agents Needed
+
+None. The security review scope is complete. The implementation agent should use the verified flow above as the source of truth for diagram content, applying the redaction guidelines from the recommendations.

--- a/docs/history/nefario-reports/2026-03-26-021912-mermaid-architecture-diagrams/phase2-software-docs-minion.md
+++ b/docs/history/nefario-reports/2026-03-26-021912-mermaid-architecture-diagrams/phase2-software-docs-minion.md
@@ -1,0 +1,93 @@
+# Domain Plan Contribution: software-docs-minion
+
+## Recommendations
+
+### Navigation placement
+
+The current nav has a clear structure: **Getting Started > feature guides > API Reference > Security & Compliance**. The flow is onboarding-first, then usage topics, then reference, then trust/compliance.
+
+An "Architecture" page fits best **after API Reference and before Security & Compliance**. Rationale:
+
+- Architecture is a reference/understanding topic, not a usage guide. Placing it between Getting Started and Authentication would interrupt the "do things" flow with a "understand things" page.
+- Readers who reach API Reference have already learned the endpoints. Architecture explains *how those endpoints work internally* -- the natural next question.
+- It sits as a bridge between "how to use it" (API Reference) and "why to trust it" (Security), which is exactly what an integrity chain diagram addresses.
+
+The nav entry should be:
+
+```js
+{ title: "Architecture", url: "/architecture/" },
+```
+
+Inserted at line 13 in `site/_data/site.js`, after `{ title: "API Reference", url: "/api-reference/" }` and before the Security & Compliance comment.
+
+### Single page, not split
+
+Both diagrams belong on a single page. Reasons:
+
+1. **The existing pages are substantial single-topic pages** (Verification is ~148 lines, Authentication is ~167 lines). Two Mermaid diagrams with explanatory prose will be well within the same range -- no need to split.
+2. **The diagrams are complementary**: the sequence diagram shows the user-facing flow, the flowchart shows the internal pipeline. A reader interested in architecture wants both. Splitting forces navigation for no benefit.
+3. **The nav is already 21 entries.** Adding one entry is fine; adding two for closely related content creates clutter.
+
+Structure the page with a brief intro, then two H2 sections -- one per diagram.
+
+### Frontmatter conventions
+
+Every content page follows the same pattern:
+
+```yaml
+---
+layout: layouts/doc.njk
+title: Page Title
+description: One-sentence description used for SEO/meta.
+---
+```
+
+The `doc.njk` layout expects only `content` (rendered from markdown). It wraps output in `<div class="docs-content"><article class="docs-prose">`. No additional frontmatter fields are needed.
+
+### Heading and prose conventions
+
+From the existing pages:
+
+- **H1 matches `title`** exactly (e.g., `title: Authentication` / `# Authentication`)
+- **H2 for major sections** (e.g., `## Using Your API Key`, `## How to verify`)
+- **H3 for subsections** within an H2 (e.g., `### Scopes`, `### Command-line`)
+- **Opening paragraph** immediately after H1: a concise 1-2 sentence summary of what the page covers and why it matters
+- **Cross-links** use relative URLs with trailing slash (e.g., `[Authentication](/authentication/)`)
+- **Code blocks** use language-tagged fences
+- **Tables** use standard GFM pipe syntax
+- **`<details>/<summary>`** used for deep-dive content that most readers can skip (see Verification and Authentication pages)
+- **Blockquote notes** use `> **Note:**` prefix
+- **Horizontal rules** (`---`) separate major topic shifts
+- **No "What's next" cards** on interior pages -- only on the Getting Started (index) page
+
+### Content file
+
+Create `site/content/architecture.md`. The URL will be `/architecture/` based on Eleventy's default behavior (consistent with all other pages).
+
+## Proposed Tasks
+
+1. **Create `site/content/architecture.md`** with:
+   - Frontmatter: `layout: layouts/doc.njk`, `title: Architecture`, `description` summarizing both diagrams
+   - `# Architecture` heading
+   - Brief intro paragraph (2-3 sentences: "This page shows how WRL processes captures and maintains the integrity chain. Two diagrams: user interaction flow and internal pipeline.")
+   - `## User Interaction Flow` -- sequence diagram + explanatory prose
+   - `## Capture Pipeline & Integrity Chain` -- flowchart + explanatory prose
+   - Cross-links to Verification and API Reference pages where relevant
+
+2. **Update `site/_data/site.js`** -- add `{ title: "Architecture", url: "/architecture/" }` after API Reference, before the Security comment
+
+3. **Update the "What's next" card grid on `site/content/index.md`** -- add an Architecture card. Suggested position: after API Reference, before Security. Text: `**[Architecture](/architecture/)**\nHow WRL processes captures, signs bundles, and maintains the integrity chain.`
+
+## Risks and Concerns
+
+1. **Mermaid rendering in the docs site**: The docs site uses Eleventy with the `doc.njk` layout. Mermaid code fences (` ```mermaid `) will render as plain `<code>` blocks unless the site has Mermaid JS loaded or a build plugin. **Check whether the site includes Mermaid rendering** (look for `mermaid.min.js` or a markdown-it-mermaid plugin in the Eleventy config). If not, rendering must be added -- either client-side (Mermaid JS script tag) or build-time (plugin). This is a blocker that needs resolution before the diagrams will display.
+
+2. **Diagram accuracy**: The diagrams must reflect the actual system behavior. The implementation minion creating the diagrams needs to read the actual capture pipeline code (queue handling, WACZ assembly, signing, timestamping) to ensure accuracy. Do not diagram from documentation alone -- read the source.
+
+3. **Diagram complexity**: Mermaid diagrams that try to show everything become unreadable. Each diagram should show the essential flow (5-8 steps) with annotations pointing to detailed docs pages. The `<details>` pattern used on other pages could work for additional technical detail beneath each diagram.
+
+4. **Mobile rendering**: Mermaid diagrams can overflow on narrow screens. The `docs-prose` CSS may need a horizontal scroll wrapper for the diagram containers.
+
+## Additional Agents Needed
+
+None -- the implementation can be handled by the agents already involved. The Mermaid rendering question (Risk 1) should be investigated during implementation by whoever creates the page.

--- a/docs/history/nefario-reports/2026-03-26-021912-mermaid-architecture-diagrams/phase3-synthesis.md
+++ b/docs/history/nefario-reports/2026-03-26-021912-mermaid-architecture-diagrams/phase3-synthesis.md
@@ -1,0 +1,313 @@
+# Phase 3: Synthesis — Mermaid Architecture Diagrams
+
+## Delegation Plan
+
+**Team name**: mermaid-architecture-diagrams
+**Description**: Create two Mermaid architecture diagrams (user interaction flows + capture pipeline/integrity chain) as a new Architecture page on the WRL documentation site, with Mermaid JS rendering support.
+
+### Task 1: Add Mermaid JS rendering to docs site
+- **Agent**: frontend-minion
+- **Delegation type**: standard
+- **Model**: sonnet
+- **Mode**: default
+- **Blocked by**: none
+- **Approval gate**: no
+- **Prompt**: |
+    Add client-side Mermaid rendering to the WRL documentation site.
+
+    ## Context
+
+    The docs site at `site/` uses Eleventy with the `layouts/doc.njk` layout.
+    The base layout is at `site/_includes/layouts/base.njk`. Mermaid code fences
+    (` ```mermaid `) are already used in `site/content/security/whitepaper.md`
+    (3 diagrams) but there is NO Mermaid JS loaded anywhere -- these diagrams
+    currently render as plain code blocks.
+
+    ## What to do
+
+    Add a client-side Mermaid initialization script that:
+    1. Loads Mermaid from CDN (use `https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js`)
+    2. Finds all `<pre><code class="language-mermaid">` blocks (this is how markdown-it renders fenced code blocks with the `mermaid` language tag)
+    3. Replaces them with rendered Mermaid diagrams
+    4. Uses `mermaid.initialize({ startOnLoad: false, theme: 'neutral' })` and then `mermaid.run()` targeting the identified elements
+
+    Create a new file `site/js/mermaid-init.js` with the initialization logic.
+    Add a `<script>` tag in `site/_includes/layouts/base.njk` to load the CDN
+    script (with `type="module"`) and then the init script.
+
+    ## What NOT to do
+
+    - Do not install Mermaid as an npm dependency or build-time plugin
+    - Do not modify any content files
+    - Do not add Mermaid CSS -- the library handles its own styling
+    - Do not use a framework or complex setup -- vanilla JS only
+
+    ## Files to modify
+
+    - `site/_includes/layouts/base.njk` -- add script tags before `</body>`
+    - `site/js/mermaid-init.js` -- new file with init logic
+
+    ## Success criteria
+
+    - Mermaid fenced code blocks render as SVG diagrams on all doc pages
+    - Existing whitepaper diagrams (3 Mermaid blocks) render correctly
+    - No console errors on pages without Mermaid diagrams
+    - Script loads defer/async so it doesn't block page rendering
+
+- **Deliverables**: `site/js/mermaid-init.js` (new), `site/_includes/layouts/base.njk` (modified)
+- **Success criteria**: Mermaid code fences render as SVG diagrams; no console errors on pages without diagrams
+
+### Task 2: Create Architecture page with Mermaid diagrams
+- **Agent**: software-docs-minion
+- **Delegation type**: standard
+- **Model**: sonnet
+- **Mode**: default
+- **Blocked by**: Task 1
+- **Approval gate**: yes
+- **Gate reason**: The diagrams define how the system is publicly described. Inaccurate or over-detailed diagrams expose attack surface or create false trust assumptions. The content needs review before merging.
+- **Gate rationale**: |
+    Chosen: Two conceptual-level diagrams on a single Architecture page (sequence diagram for user flows, flowchart for capture pipeline + integrity chain)
+    Over: (1) Endpoint-level diagrams mirroring API Reference (rejected: redundant, unreadable at that detail level); (2) Split across multiple pages (rejected: content is complementary, nav already has 21 entries)
+    Why: Conceptual level matches audience (evaluators, potential customers) and avoids duplicating the existing API Reference. Single page keeps nav clean and serves readers who want the full architecture picture.
+- **Prompt**: |
+    Create the Architecture documentation page for the WRL docs site with two Mermaid diagrams.
+
+    ## Context
+
+    This page explains how WRL works at the architecture level -- the user interaction
+    flows and the internal capture pipeline with its cryptographic integrity chain.
+    The audience is potential customers and technical evaluators. The diagrams should
+    be clear, conceptual, and accurate.
+
+    Source: GitHub issue #168. The issue description has inaccuracies (noted below).
+    The codebase is the source of truth.
+
+    ## What to create
+
+    Create `site/content/architecture.md` with:
+
+    ### Frontmatter
+    ```yaml
+    ---
+    layout: layouts/doc.njk
+    title: Architecture
+    description: How WRL captures web pages, builds cryptographic proof bundles, and enables independent verification.
+    ---
+    ```
+
+    ### Page structure
+
+    1. `# Architecture` heading
+    2. Brief intro (2-3 sentences): what this page shows and who it's for
+    3. `## User Interaction Flows` -- sequence diagram + explanatory prose
+    4. `## Capture Pipeline & Integrity Chain` -- flowchart + explanatory prose
+    5. Cross-links to [Verification](/verification/), [API Reference](/api-reference/), [Security & Compliance](/security/) where relevant
+
+    ### Diagram 1: User Interaction Flows (sequence diagram)
+
+    Show these interaction patterns at a CONCEPTUAL level (use descriptive labels
+    like "Create Capture", not endpoint paths as primary labels; endpoint paths
+    can appear in parentheses):
+
+    **Actors**: Tenant (API Consumer), WRL API, Browser Rendering, Storage, Verifier
+
+    **Flows to include:**
+    1. **Authentication** (two paths): GitHub OAuth PKCE flow OR API key (Bearer token)
+    2. **Capture lifecycle**: Create capture (single) --> 202 Accepted --> Queue processing --> Poll status --> Retrieve result + artifacts
+    3. **Batch capture**: Show as variant entry point alongside single capture, converging at queue processing
+    4. **Verification**: Public verify endpoint --> 5 integrity checks --> Certificate download (PDF)
+    5. **Account management**: API key CRUD, webhook setup, eIDAS opt-in (brief, not detailed)
+
+    **Flows to EXCLUDE:**
+    - Share links (`POST /v1/captures/{id}/share`) -- THIS DOES NOT EXIST in the codebase. Do not include it.
+    - Scheduled captures -- exists but out of scope for this page (keep diagrams focused)
+    - Admin endpoints -- infrastructure-internal, not user-facing
+    - Billing/Stripe flows -- internal, not architecturally interesting for evaluators
+    - Notification/email subsystem -- secondary, keep diagrams clean
+    - MCP handler -- integration interface, not core architecture
+
+    ### Diagram 2: Capture Pipeline & Integrity Chain (flowchart)
+
+    Show the data flow through the system internals:
+
+    **Components** (use generic labels, NOT internal binding names):
+    - API Worker, Queue, Browser Rendering, Object Storage (R2), Database (D1), Rate Limiter (KV)
+    - External: Threat Screening (Google Web Risk), RFC 3161 TSA, eIDAS Qualified TSA
+
+    **Flow:**
+    1. **Ingestion**: HTTP request --> Authentication --> Rate Limiting --> Quota Check --> URL Validation (SSRF prevention) --> Threat Screening --> Database record (pending) --> Queue --> 202 response
+    2. **Processing**: Queue --> Browser Rendering (headless Chromium) --> Screenshot + DOM + Headers --> Cookie Consent Dismissal
+    3. **WACZ Assembly & Signing**: Build WARC --> SHA-256 hashes of artifacts --> datapackage.json manifest --> bundleHash = SHA-256(canonical JSON) --> Ed25519 signature --> Optional RFC 3161 timestamp --> Optional eIDAS qualified timestamp
+    4. **Storage & Completion**: Object Storage (hash-addressed) --> Database update (complete) --> Webhook dispatch
+
+    **Integrity chain visualization** -- this is the key selling point, highlight it clearly:
+    - Each artifact --> SHA-256 hash --> datapackage.json --> canonical JSON --> bundleHash
+    - bundleHash --> Ed25519 signature (using server signing key)
+    - bundleHash --> RFC 3161 timestamp (independent time attestation) [optional]
+    - bundleHash --> eIDAS qualified timestamp (legally binding) [optional]
+    - ALL signatures/timestamps cover the SAME bundleHash (siblings in array, NOT a sequential chain)
+    - The signed payload is the UTF-8 string representation of bundleHash, not raw bytes
+
+    **Verification** (5 independent checks):
+    1. artifactHashes -- each file matches its hash in datapackage.json
+    2. bundleHash -- SHA-256 of canonical datapackage matches signedData.hash
+    3. signature -- Ed25519 verification using SERVER's public key (resolved via keyId from DB, NOT the embedded key)
+    4. timestamp -- RFC 3161 messageImprint matches bundleHash (skip if absent, fail if present but invalid)
+    5. qualifiedTimestamp -- same as above for eIDAS
+
+    Show that verification uses server-side key resolution (via `.well-known/signing-key(s)`) as the trust anchor.
+
+    ## SECURITY REDACTION RULES (MANDATORY)
+
+    The following details MUST NOT appear in the diagrams or prose:
+
+    1. **No rate limit numbers or thresholds** -- show "Rate Limiting" as a step without values
+    2. **No queue re-validation** -- show URL validation once at API entry only. Do NOT show the defense-in-depth re-validation in the queue consumer
+    3. **No error categorization or retry logic details** -- show "Queue (with retries)" as a single concept
+    4. **No threat check fail-open behavior** -- show "Threat Screening" without indicating degradation behavior
+    5. **No internal binding names** -- use "Queue" not "CAPTURE_QUEUE", "Database" not "D1", "Object Storage" not "R2", "Rate Limiter" not "CAPTURE_RATE_LIMITER"
+    6. **No KV key patterns, D1 table names, or R2 key naming conventions**
+    7. **No internal IP blocklist CIDR ranges**
+    8. **No retry counts, backoff values, or max retry constants**
+
+    **SAFE to show:**
+    - Ed25519 signing model, keyId derivation, bundleHash computation
+    - `.well-known/signing-key(s)` endpoint as public trust anchor
+    - RFC 3161 / eIDAS timestamping conceptual flow
+    - That verification uses server-side key resolution (not embedded keys)
+    - That the verify endpoint is unauthenticated (by design, for third-party verification)
+    - Cookie consent dismissal via autoconsent
+
+    ## Writing conventions (match existing docs)
+
+    - H1 matches `title` exactly
+    - Opening paragraph immediately after H1: concise summary
+    - Cross-links use relative URLs with trailing slash (e.g., `[Verification](/verification/)`)
+    - Use `<details>/<summary>` for deep-dive content most readers can skip
+    - Use `> **Note:**` for callouts
+    - Keep each diagram to 5-12 participants/nodes -- if larger, simplify
+    - Add brief explanatory prose (2-4 sentences) after each diagram explaining what it shows
+
+    ## Available Skills
+    The following project skills are available for this task. Read and follow
+    their instructions when they are relevant to your work:
+    - mermaid: `~/.claude/skills/mermaid/SKILL.md` (Mermaid diagram syntax reference for all 23 diagram types)
+
+- **Deliverables**: `site/content/architecture.md` (new file with two Mermaid diagrams)
+- **Success criteria**: Both diagrams render correctly; no redacted details exposed; prose matches existing doc conventions; diagrams are readable at conceptual level (not cluttered with endpoint-level detail)
+
+### Task 3: Add Architecture to site navigation
+- **Agent**: software-docs-minion
+- **Delegation type**: standard
+- **Model**: sonnet
+- **Mode**: default
+- **Blocked by**: Task 2
+- **Approval gate**: no
+- **Prompt**: |
+    Add the Architecture page to the WRL docs site navigation.
+
+    ## What to do
+
+    1. **Update `site/_data/site.js`**: Add `{ title: "Architecture", url: "/architecture/" }`
+       after `{ title: "API Reference", url: "/api-reference/" }` (line 13) and before
+       the `// Security & Compliance` comment (line 14).
+
+    2. **Update `site/content/index.md`**: Add an Architecture card to the "What's next"
+       card grid at the bottom of the Getting Started page. Place it after the API Reference
+       card and before the Security card. Card text:
+       ```
+       **[Architecture](/architecture/)**
+       How WRL processes captures, signs bundles, and maintains the integrity chain.
+       ```
+
+    ## What NOT to do
+
+    - Do not modify any other navigation or content files
+    - Do not reorder existing nav entries
+    - Do not modify `architecture.md` (created in a prior task)
+
+    ## Files to modify
+
+    - `site/_data/site.js`
+    - `site/content/index.md`
+
+- **Deliverables**: Updated `site/_data/site.js` (nav entry), updated `site/content/index.md` (card link)
+- **Success criteria**: Architecture appears in sidebar navigation between API Reference and Security & Compliance; card appears on Getting Started page
+
+### Cross-Cutting Coverage
+
+- **Testing**: Excluded. This task produces static documentation (Markdown + a small JS init script). No executable business logic. The Mermaid init script is trivial (~15 lines) and will be visually verified. Phase 6 test execution will run existing tests to confirm no regressions.
+- **Security**: Covered. Security-minion provided a comprehensive redaction list (9 items) that is embedded directly in the Task 2 prompt. No separate security review task needed -- the redaction rules are constraints on the content, not a review gate.
+- **Usability -- Strategy**: Covered implicitly. The page placement decision (after API Reference, before Security) follows the natural reading flow identified by software-docs-minion: onboarding --> usage --> reference --> understanding --> trust. No separate UX strategy task needed for a single documentation page.
+- **Usability -- Design**: Excluded. No custom UI components or interaction patterns. The page uses the existing `doc.njk` layout with standard Markdown rendering.
+- **Documentation**: This IS the documentation task. software-docs-minion is the primary agent.
+- **Observability**: Excluded. No runtime components, APIs, or background processes.
+
+### Architecture Review Agents
+
+- **Mandatory** (5): security-minion, test-minion, ux-strategy-minion, lucy, margo
+- **Discretionary picks**:
+  - None selected. Rationale: No UI components produced (excludes ux-design-minion, accessibility-minion). No web-facing runtime code (excludes sitespeed-minion). No runtime components needing coordinated logging (excludes observability-minion). No end-user workflow changes (excludes user-docs-minion -- this is reference documentation, not a how-to guide).
+- **Not selected**:
+  - ux-design-minion: No custom UI components; page uses existing doc layout
+  - accessibility-minion: Mermaid diagrams have known a11y limitations (SVG without alt text), but this is a Mermaid-wide issue, not something solvable at the page level. The existing whitepaper already uses Mermaid with the same limitations.
+  - sitespeed-minion: Adding a CDN script (~160KB gzipped) is notable but standard; the script loads async/defer and won't block rendering
+  - observability-minion: No runtime components
+  - user-docs-minion: This is architecture reference documentation, not user-facing guides or tutorials
+
+### Decisions
+
+- **Diagram abstraction level**
+  Chosen: Conceptual flows with descriptive labels (e.g., "Create Capture") and endpoint paths only in parentheses
+  Over: Endpoint-level diagrams showing every route path (api-design-minion recommendation aligned)
+  Why: The API Reference page already serves as the endpoint inventory. Architecture diagrams should explain HOW the system works, not repeat WHAT endpoints exist.
+
+- **Share link flow**
+  Chosen: Remove entirely from both diagrams
+  Over: Including it as a "planned feature" or "future" flow
+  Why: `POST /v1/captures/{id}/share` does not exist in the codebase (confirmed by api-design-minion). The verify endpoint is public and needs no share token. Diagramming non-existent features misleads users.
+
+- **Scope of user interaction flows**
+  Chosen: 5 interaction patterns (auth, single capture, batch, verification+certificate, account management)
+  Over: 6 patterns including scheduled captures + diff + notifications (api-design-minion recommendation)
+  Why: The issue asks for two diagrams on an architecture overview page. Scheduled captures, diff, and notifications are real features but including them makes the sequence diagram too complex for the "clear enough for potential customers and technical evaluators" goal. These can be added later or documented on their own pages.
+
+- **Mermaid rendering approach**
+  Chosen: Client-side CDN script (async load + init)
+  Over: Build-time rendering via Eleventy plugin (e.g., eleventy-plugin-mermaid)
+  Why: The site already has 3 unrendered Mermaid blocks in the whitepaper. Client-side rendering fixes all existing and future diagrams with zero build complexity. Aligns with project's "prefer lightweight, vanilla solutions" principle.
+
+### Risks and Mitigations
+
+1. **Mermaid CDN availability** (LOW): If jsdelivr is down, diagrams render as code blocks. Mitigation: acceptable degradation -- content remains readable as text. No build dependency means no build failures.
+
+2. **Diagram inaccuracy** (MEDIUM): The diagrams must reflect actual system behavior, not the (partially inaccurate) issue description. Mitigation: Task 2 prompt embeds the verified pipeline sequence from security-minion's source code analysis. The approval gate catches inaccuracies before merge.
+
+3. **Security information leakage** (MEDIUM): Over-detailed diagrams could expose attack surface. Mitigation: 8-item redaction checklist embedded in Task 2 prompt, derived from security-minion's analysis. Phase 3.5 security review will verify compliance.
+
+4. **Mobile overflow** (LOW): Wide Mermaid diagrams may overflow on narrow screens. Mitigation: Mermaid generates responsive SVGs by default. If overflow occurs, a CSS `overflow-x: auto` wrapper can be added in a follow-up.
+
+### Execution Order
+
+```
+Batch 1: Task 1 (Mermaid JS rendering)
+         ↓
+Batch 2: Task 2 (Architecture page with diagrams) [APPROVAL GATE]
+         ↓
+Batch 3: Task 3 (Navigation update)
+```
+
+All tasks are sequential. Task 2 has an approval gate because the diagram content
+defines the public description of the system's architecture and security model.
+
+### Verification Steps
+
+1. Build the docs site locally (`cd site && npx @11ty/eleventy --serve`) and verify:
+   - Architecture page renders at `/architecture/`
+   - Both Mermaid diagrams render as SVG (not code blocks)
+   - Existing whitepaper Mermaid diagrams also render correctly
+   - Navigation shows "Architecture" between "API Reference" and "Security & Compliance"
+   - Getting Started page shows Architecture card
+2. Review diagram content against the 8-item redaction checklist
+3. Verify no share link flow appears in either diagram
+4. Check that the cryptographic proof chain correctly shows signatures/timestamps as siblings (not sequential chain)

--- a/docs/history/nefario-reports/2026-03-26-021912-mermaid-architecture-diagrams/phase3.5-gru.md
+++ b/docs/history/nefario-reports/2026-03-26-021912-mermaid-architecture-diagrams/phase3.5-gru.md
@@ -1,0 +1,21 @@
+## Gru Review — Technology Radar
+
+**Verdict: APPROVE**
+
+### Mermaid v11 from jsDelivr CDN
+
+Sound. Mermaid v11 is current stable (released 2024). jsDelivr is production-grade with multi-CDN redundancy. Using `mermaid@11` (semver range rather than pinned patch) is appropriate for a docs site -- minor/patch updates flow through automatically without manual maintenance.
+
+### Client-side rendering vs build-time
+
+The rationale holds. Build-time rendering via an Eleventy plugin would pull in a Puppeteer/Chromium build dependency -- directly contradicting the project's "lean and mean" and "prefer vanilla solutions" principles. Client-side CDN rendering also fixes the three already-broken Mermaid blocks in the existing whitepaper at zero additional cost. This is the correct tradeoff.
+
+### CDN dependency risk
+
+Acceptable. The degradation path is correct: jsDelivr unavailability → diagrams render as readable code blocks. No build dependency means no build failures from CDN issues. For a documentation site this is standard practice.
+
+### One minor note (no action required)
+
+The plan uses `type="module"` for the CDN script load -- correct for Mermaid v10+. SRI hashing is omitted, which is a minor omission but incompatible with the `mermaid@11` semver range (SRI requires a pinned hash tied to a specific file). Not a blocker for a docs site.
+
+No technology concerns. Proceed.

--- a/docs/history/nefario-reports/2026-03-26-021912-mermaid-architecture-diagrams/phase3.5-lucy.md
+++ b/docs/history/nefario-reports/2026-03-26-021912-mermaid-architecture-diagrams/phase3.5-lucy.md
@@ -1,0 +1,50 @@
+# Lucy Review: mermaid-architecture-diagrams
+
+## Verdict: APPROVE
+
+## Requirements Traceability
+
+| Requirement (from issue #168) | Plan Element | Status |
+|-------------------------------|-------------|--------|
+| Diagram 1: User Interaction Flows (sequence diagram) | Task 2, Diagram 1 | Covered |
+| Diagram 2: Capture Pipeline & Integrity Chain (flowchart) | Task 2, Diagram 2 | Covered |
+| Output as Markdown with mermaid code blocks | Task 1 (Mermaid JS rendering) + Task 2 | Covered |
+| New content page using `layouts/doc.njk` | Task 2 frontmatter specifies `layouts/doc.njk` | Covered |
+| Add to site navigation in `site/_data/site.js` | Task 3 | Covered |
+| Read the codebase to verify all details | Task 2 prompt: "codebase is the source of truth" | Covered |
+| Diagrams clear for customers and technical evaluators | Task 2 prompt: conceptual-level abstraction | Covered |
+| Share links (`POST /v1/captures/{id}/share`) | Correctly excluded -- does not exist in codebase | Good catch |
+
+## Scope Assessment
+
+No scope creep detected. Three findings worth noting:
+
+1. **Task 1 (Mermaid JS rendering) is additive but justified.** The issue implicitly assumes Mermaid rendering works. It does not -- the whitepaper already has 3 unrendered Mermaid blocks. Adding client-side rendering is a prerequisite, not scope creep. The approach (CDN + vanilla JS init script) is proportional and aligns with CLAUDE.md's "prefer lightweight, vanilla solutions" directive.
+
+2. **Exclusion of scheduled captures, diff, notifications from Diagram 1.** The issue does not mention these features. The plan correctly keeps scope to what was asked. No drift.
+
+3. **Getting Started page card (Task 3).** The issue says "add them as a new page in the site navigation." Adding a card to the Getting Started page is a minor extension of "site navigation" but reasonable -- it follows the existing pattern on that page. Not flagging as scope creep.
+
+## CLAUDE.md Compliance
+
+| Directive | Status |
+|-----------|--------|
+| "Prefer lightweight, vanilla solutions" | Compliant. CDN + vanilla JS, no npm dependency, no framework. |
+| "YAGNI" | Compliant. No speculative features. |
+| "KISS" | Compliant. Three focused tasks, sequential. |
+| Mermaid skill preference (use skill for generation, MCP for preview) | Compliant. Task 2 references the mermaid skill for diagram syntax. |
+| Evolution log requirement | Not in plan scope -- this is nefario's responsibility at PR time. Noting for completeness, not blocking. |
+
+## Redaction Rules vs "Fail Loudly" Principle
+
+The redaction rules (8 items) restrict what appears in **public-facing documentation**. This is not in tension with the "fail loudly, degrade intentionally" engineering principle. That principle governs runtime error handling in code, not what security details appear in marketing documentation. The redaction list appropriately hides operational details (rate limit thresholds, retry logic, fail-open behavior, internal binding names, CIDR ranges) that would inform attackers without helping evaluators.
+
+The "SAFE to show" list correctly preserves the cryptographic model details that evaluators need for trust assessment.
+
+No concern here.
+
+## Minor Observations (non-blocking)
+
+- **ADVISE [CONVENTION]**: Task 3 places Architecture "after API Reference (line 13) and before the `// Security & Compliance` comment (line 14)." The actual line numbers in `site/_data/site.js` are line 13 (`API Reference`) and line 14 (`// Security & Compliance`). These match. However, note the issue offered two placements ("between Getting Started and Authentication" OR "after API Reference"). The plan chose "after API Reference" which reads better given the nav structure flows from onboarding to usage to reference to understanding to trust. Good choice, no action needed.
+
+- **ADVISE [TRACE]**: The plan mentions "Phase 3.5 security review will verify compliance" (line 286) and "Phase 6 test execution will run existing tests" (line 239). These are framework-level verification steps outside this plan's scope. Noting for nefario's awareness -- these steps must actually happen.

--- a/docs/history/nefario-reports/2026-03-26-021912-mermaid-architecture-diagrams/phase3.5-margo.md
+++ b/docs/history/nefario-reports/2026-03-26-021912-mermaid-architecture-diagrams/phase3.5-margo.md
@@ -1,0 +1,66 @@
+# Margo — Complexity Review
+
+## Verdict: ADVISE
+
+The plan is proportional to the problem. Two concerns worth addressing before execution.
+
+---
+
+### Finding 1: Separate `mermaid-init.js` file is unnecessary overhead
+
+**What**: Task 1 creates a new file `site/js/mermaid-init.js` for ~15 lines of Mermaid initialization logic, then adds two script tags to `base.njk` (one for CDN, one for init).
+
+**Why it is accidental complexity**: The init logic (find `pre > code.language-mermaid` blocks, replace them, call `mermaid.run()`) is trivially small. A separate file means an extra HTTP request, an extra file to maintain, and two script tags instead of one. The existing `clipboard.js` is a reasonable precedent for small standalone scripts, but the Mermaid init is even simpler and tightly coupled to the CDN load -- it has no reason to exist independently.
+
+**Simpler alternative**: Inline the init logic as a single `<script type="module">` block in `base.njk` that imports Mermaid from CDN and runs init. One script tag, zero extra files, zero extra requests. Example shape:
+
+```html
+<script type="module">
+  const nodes = document.querySelectorAll('pre code.language-mermaid');
+  if (nodes.length) {
+    const { default: mermaid } = await import('https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs');
+    mermaid.initialize({ startOnLoad: false, theme: 'neutral' });
+    // ... replace nodes, call mermaid.run()
+  }
+</script>
+```
+
+This also gets lazy loading for free -- the 160KB Mermaid library is only fetched on pages that actually have Mermaid blocks. The plan's current approach loads the CDN script on every page regardless.
+
+**Severity**: Non-blocking. Either approach works. The inline version is simpler, smaller, and avoids loading Mermaid on pages that don't need it.
+
+---
+
+### Finding 2: Three sequential tasks for a single-PR change
+
+**What**: The plan splits work into 3 tasks with sequential dependencies (Task 1 -> Task 2 -> Task 3), requiring 3 agent invocations.
+
+**Why it is accidental complexity**: Task 1 is ~15 lines of JS + 2 lines in a template. Task 3 is adding one line to a JS array and one card to a markdown file. Neither justifies a separate agent delegation. The overhead of agent startup, context loading, and handoff coordination exceeds the work itself.
+
+**Simpler alternative**: Merge Tasks 1 and 3 into Task 2. The software-docs-minion creating the architecture page can also add the inline Mermaid init script and the nav entry -- these are mechanically simple changes that require no specialized frontend knowledge. This reduces to 1 task with 1 approval gate.
+
+However, if nefario's orchestration model requires distinct tasks for distinct files, keeping Task 1 separate is defensible (it touches the base layout, which affects all pages). Task 3 as a separate task is harder to justify -- it is two one-line edits.
+
+**Severity**: Non-blocking. The 3-task split works but pays unnecessary coordination cost. At minimum, fold Task 3 into Task 2.
+
+---
+
+### What the plan gets right
+
+- **CDN over npm dependency**: Correct call. No build-time Mermaid plugin, no new npm dependency, no build complexity. Aligns with the project's vanilla-first principle.
+- **Client-side over build-time rendering**: Fixes the 3 existing unrendered Mermaid blocks in the whitepaper for free. Zero build pipeline changes.
+- **Single page over multiple pages**: One page with two diagrams is proportional. No unnecessary page hierarchy.
+- **Conceptual level over endpoint-level**: Avoids duplicating the API Reference. Right abstraction level for the audience.
+- **No test task**: Correct exclusion for static documentation content.
+- **Redaction rules embedded in prompt**: Security constraints are inline, not a separate review layer. Efficient.
+
+---
+
+### Complexity Budget
+
+| Item | Column | Cost |
+|------|--------|------|
+| Mermaid CDN (external dependency) | Managed | 1 |
+| **Total** | | **1** |
+
+Proportional. This is a documentation page with a rendering dependency, not an architectural change.

--- a/docs/history/nefario-reports/2026-03-26-021912-mermaid-architecture-diagrams/phase3.5-test-minion.md
+++ b/docs/history/nefario-reports/2026-03-26-021912-mermaid-architecture-diagrams/phase3.5-test-minion.md
@@ -1,0 +1,20 @@
+# Test Minion Review — Mermaid Architecture Diagrams
+
+**Verdict: APPROVE**
+
+## Assessment
+
+**Excluding tests from this phase is appropriate.**
+
+The deliverables are:
+1. A static Markdown content page (`architecture.md`) — no executable logic
+2. A ~15-line vanilla JS init script (`mermaid-init.js`) — wires Mermaid CDN to existing DOM elements
+3. Nav/copy changes to two existing files — no logic
+
+The init script does not contain business logic, data transformations, or branching behavior worth unit testing. It does three things: query the DOM for code blocks, transform them into Mermaid-renderable elements, and call `mermaid.run()`. Unit testing DOM manipulation at this level with JSDOM would test the browser API, not any logic written here. The value is zero and the maintenance cost is non-zero.
+
+**Regression verification is handled correctly.** The plan references "Phase 6 test execution will run existing tests to confirm no regressions." The plan's verification steps also call for a local Eleventy build to confirm rendering. This is the right form of verification for this type of change — visual confirmation that Mermaid diagrams render as SVG, not unit assertions.
+
+**One note for execution:** The existing test suite (`npm test` via `@cloudflare/vitest-pool-workers`) covers the Worker runtime, not the docs site. No existing test is at risk from changes to `site/`. Running the test suite would not add confidence here and would consume ~8 GB of memory for no benefit. The plan's verification approach (local Eleventy build) is correctly scoped.
+
+No concerns within test domain.

--- a/docs/history/nefario-reports/2026-03-26-021912-mermaid-architecture-diagrams/phase3.5-ux-strategy-minion.md
+++ b/docs/history/nefario-reports/2026-03-26-021912-mermaid-architecture-diagrams/phase3.5-ux-strategy-minion.md
@@ -1,0 +1,39 @@
+---
+reviewer: ux-strategy-minion
+verdict: APPROVE
+---
+
+## Assessment
+
+### Journey coherence
+
+Architecture placed after API Reference is the right call. The reading flow — onboarding → usage → reference → understanding → trust — is sound. Evaluators and potential customers will naturally ask "how does this actually work?" after exploring the API surface. Placing Architecture there satisfies that job without interrupting the task-oriented flow of earlier sections.
+
+The Getting Started card is a good progressive disclosure mechanism: it surfaces Architecture to readers who aren't yet browsing the nav, without forcing it into the primary path.
+
+### Cognitive load: two diagrams on one page
+
+Two diagrams on one page is justified here because the two diagrams serve different cognitive jobs:
+
+- Diagram 1 (sequence) answers "how do I interact with the system?" — an actor-oriented mental model
+- Diagram 2 (flowchart) answers "what happens inside when I do that?" — a systems-oriented mental model
+
+They are complementary, not competing. An evaluator needs both to form a complete picture, and they build on each other in the right order (outside-in → inside-out). The plan's existing guidance to cap each diagram at 5-12 participants/nodes and add 2-4 sentences of explanatory prose after each diagram will carry most of the cognitive load management.
+
+One risk: Diagram 2 (integrity chain) is dense by design. The plan correctly notes this is "the key selling point" — but dense and clear are in tension. The `<details>/<summary>` guidance for deep-dive content is the right mitigation. The software-docs-minion should be encouraged to use it for the detailed integrity chain breakdown, keeping the primary flowchart at the conceptual level.
+
+### Simplification opportunities
+
+None that don't already involve trade-offs the team has consciously made. The scope reductions (dropping scheduled captures, share links, diff, notifications) are correct calls. Including non-existent features or rarely-used flows would dilute what evaluators actually need to assess.
+
+The 5 interaction patterns in Diagram 1 are at the outer edge of working memory capacity (7±2). The prose after each diagram will help chunk the information. No further cuts recommended without knowing what the rendered output looks like.
+
+### JTBD alignment
+
+The primary job: "When evaluating WRL as a capture and verification solution, I want to understand how the system works end-to-end, so I can assess whether I can trust it and integrate it."
+
+The plan serves this job directly. The integrity chain visualization in Diagram 2 is the highest-value element for the trust dimension of that job. The approval gate before merge is appropriate given that diagram inaccuracies or redaction failures would undermine exactly the trust this page is meant to build.
+
+### No blocking issues
+
+The plan is coherent, the placement is defensible, the scope is right-sized, and the cognitive load mitigations are in place. Proceed.

--- a/docs/history/nefario-reports/2026-03-26-021912-mermaid-architecture-diagrams/prompt.md
+++ b/docs/history/nefario-reports/2026-03-26-021912-mermaid-architecture-diagrams/prompt.md
@@ -1,0 +1,46 @@
+Create two Mermaid diagrams for the documentation site (`site/content/`) and add them as a new page in the site navigation.
+
+## Diagram 1: User Interaction Flows
+
+A sequence diagram showing how different roles interact with the system:
+
+**Tenant (Capture Creator):**
+- Authentication: GitHub OAuth (PKCE) → session cookie, or API key (Bearer token)
+- Create capture: `POST /v1/captures` → 202 Accepted + statusUrl
+- Poll status: `GET /v1/captures/{id}/status`
+- Retrieve result: `GET /v1/captures/{id}` + download artifacts
+- Create share link: `POST /v1/captures/{id}/share` → token-based access for third parties
+
+**Verifier (public, no authentication required):**
+- `GET /v1/verify/{captureId}` → 5 integrity checks (artifactHashes, bundleHash, signature, timestamp, qualifiedTimestamp)
+- Alternatively: share link with `?token=wrl_share_xxx`
+
+Also show self-serve flows: tenant creates own API keys via `/v1/account/keys`, manages webhooks, and optional eIDAS opt-in.
+
+## Diagram 2: Capture Pipeline & Integrity Chain
+
+A flowchart or sequence diagram showing the entire capture process and all involved systems:
+
+**Systems:** Cloudflare Worker (API), Cloudflare Queue, Cloudflare Browser Rendering, R2 Storage, D1 Database, KV (rate limits), Google Web Risk API, RFC 3161 TSA, eIDAS Qualified TSA, Stripe (metering)
+
+**Flow:**
+1. API receives request → authentication → rate limiting (3 layers: CF ceiling, KV counter, IP guard) → quota check → SSRF validation → Google Web Risk check
+2. Generate capture ID → D1 pending record → queue dispatch → return 202
+3. Queue consumer: browser rendering (screenshot + DOM + headers) → cookie consent dismissal (autoconsent)
+4. Build WACZ bundle: SHA-256 hashes of all artifacts → datapackage.json → canonicalize → bundleHash → Ed25519 signature → RFC 3161 timestamp (optional) → eIDAS qualified timestamp (optional)
+5. R2 storage (hash-named) → D1 update (complete) → Stripe metering → webhook dispatch
+
+**Integrity visualization — highlight the cryptographic proof chain:**
+- Each artifact → SHA-256 hash → datapackage.json → canonical JSON → bundleHash
+- bundleHash → Ed25519 signature (server key)
+- bundleHash → RFC 3161 timestamp (independent time attestation)
+- bundleHash → eIDAS qualified timestamp (legally binding)
+- Verification: all hashes + signature + timestamps independently verifiable via `/v1/verify`
+
+## Implementation notes
+
+- Output as Markdown with ` ```mermaid ` code blocks (GitHub renders natively)
+- Place as a new content page (e.g. `site/content/architecture.md`) using the `layouts/doc.njk` layout
+- Add to site navigation in `site/_data/site.js` — between "Getting Started" and "Authentication" or after "API Reference", whichever reads better
+- Read the codebase to verify all details — the description above is directional, the code is the source of truth
+- Diagrams should be clear enough for potential customers and technical evaluators

--- a/site/_data/site.js
+++ b/site/_data/site.js
@@ -11,6 +11,7 @@ export default {
     { title: "Webhooks", url: "/webhooks/" },
     { title: "MCP Server", url: "/mcp/" },
     { title: "API Reference", url: "/api-reference/" },
+    { title: "Architecture", url: "/architecture/" },
     // Security & Compliance
     { title: "Security & Compliance", url: "/security/" },
     { title: "Security Whitepaper", url: "/security/whitepaper/" },

--- a/site/_includes/layouts/base.njk
+++ b/site/_includes/layouts/base.njk
@@ -67,5 +67,20 @@
       </footer>
     </main>
   </div>
+  <script type="module">
+    // tva
+    const nodes = document.querySelectorAll('pre code.language-mermaid');
+    if (nodes.length) {
+      const { default: mermaid } = await import('https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs');
+      mermaid.initialize({ startOnLoad: false, theme: 'neutral' });
+      nodes.forEach((node, i) => {
+        const container = document.createElement('div');
+        container.className = 'mermaid';
+        container.textContent = node.textContent;
+        node.closest('pre').replaceWith(container);
+      });
+      await mermaid.run({ nodes: document.querySelectorAll('.mermaid') });
+    }
+  </script>
 </body>
 </html>

--- a/site/_includes/layouts/base.njk
+++ b/site/_includes/layouts/base.njk
@@ -71,15 +71,19 @@
     // tva
     const nodes = document.querySelectorAll('pre code.language-mermaid');
     if (nodes.length) {
-      const { default: mermaid } = await import('https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs');
-      mermaid.initialize({ startOnLoad: false, theme: 'neutral' });
-      nodes.forEach((node, i) => {
-        const container = document.createElement('div');
-        container.className = 'mermaid';
-        container.textContent = node.textContent;
-        node.closest('pre').replaceWith(container);
-      });
-      await mermaid.run({ nodes: document.querySelectorAll('.mermaid') });
+      try {
+        const { default: mermaid } = await import('https://cdn.jsdelivr.net/npm/mermaid@11.4.1/dist/mermaid.esm.min.mjs');
+        mermaid.initialize({ startOnLoad: false, theme: 'neutral' });
+        nodes.forEach((node) => {
+          const container = document.createElement('div');
+          container.className = 'mermaid';
+          container.textContent = node.textContent;
+          node.closest('pre').replaceWith(container);
+        });
+        await mermaid.run({ nodes: document.querySelectorAll('.mermaid') });
+      } catch (e) {
+        console.error('Mermaid rendering failed:', e);
+      }
     }
   </script>
 </body>

--- a/site/content/architecture.md
+++ b/site/content/architecture.md
@@ -1,0 +1,152 @@
+---
+layout: layouts/doc.njk
+title: Architecture
+description: How WRL captures web pages, builds cryptographic proof bundles, and enables independent verification.
+---
+
+# Architecture
+
+This page explains how WRL works under the hood -- the flows a tenant API consumer sees, and the internal pipeline that produces tamper-evident captures. It is aimed at technical evaluators who want to understand the system before integrating or before presenting captures as evidence.
+
+## User Interaction Flows
+
+The sequence diagram below shows the four interaction patterns available to API consumers: authenticating (via GitHub OAuth or API key), submitting captures (single or batch), polling for results, and verifying a completed capture.
+
+```mermaid
+sequenceDiagram
+    actor Tenant as Tenant (API Consumer)
+    participant API as WRL API
+    participant DB as Database
+    participant Q as Queue
+    participant Browser as Browser Rendering
+    participant Storage as Object Storage
+    participant Verifier as Verifier
+
+    note over Tenant,API: Authentication -- two paths
+
+    alt GitHub OAuth (interactive / web UI)
+        Tenant->>API: GET /auth/login
+        API-->>Tenant: Redirect to GitHub (PKCE)
+        Tenant->>API: GET /auth/callback?code=...
+        API-->>Tenant: Session cookie
+    else API Key (programmatic)
+        note over Tenant,API: Bearer token in Authorization header
+    end
+
+    note over Tenant,Q: Capture lifecycle (single or batch)
+
+    alt Single capture
+        Tenant->>API: POST /v1/captures
+    else Batch capture
+        Tenant->>API: POST /v1/captures/batch
+    end
+
+    API->>DB: Record capture(s) as pending
+    API->>Q: Enqueue capture job(s)
+    API-->>Tenant: 202 Accepted + capture ID(s)
+
+    note over Q,Storage: Async processing (see pipeline diagram)
+    Q->>Browser: Render URL
+    Browser->>Storage: Store artifacts
+    Q->>DB: Mark complete
+
+    Tenant->>API: GET /v1/captures/{id}/status
+    API-->>Tenant: {status: "complete"}
+    Tenant->>API: GET /v1/captures/{id}
+    API-->>Tenant: Capture record + artifact URLs + verifyUrl
+
+    note over Tenant,Verifier: Verification (unauthenticated by design)
+
+    Verifier->>API: GET /v1/verify/{id}
+    API->>Storage: Fetch WACZ bundle
+    API->>DB: Resolve signing key by keyId
+    API-->>Verifier: 5 check results + verified flag
+
+    opt Download certificate (PDF)
+        Verifier->>API: GET /v1/captures/{id}/certificate
+        API-->>Verifier: PDF certificate
+    end
+
+    note over Tenant,API: Account management (brief)
+    note over Tenant,API: API key CRUD: /v1/account/keys
+    note over Tenant,API: Webhooks: /v1/webhooks
+    note over Tenant,API: eIDAS opt-in: PATCH /v1/account/settings
+```
+
+The verify endpoint is intentionally unauthenticated -- any third party can verify a capture without an account. The verification decision is driven by five independent checks run against the WACZ bundle itself (see [Verification](/verification/) for details). Signing key resolution uses the server's authoritative key store via `/.well-known/signing-key(s)`, not the key embedded in the bundle.
+
+## Capture Pipeline & Integrity Chain
+
+The flowchart below traces a single capture from HTTP ingestion through browser rendering to the final signed WACZ bundle in storage.
+
+```mermaid
+flowchart TD
+    subgraph Ingestion
+        A([HTTP Request]) --> B[Authentication]
+        B --> C[Rate Limiting]
+        C --> D[Quota Check]
+        D --> E[URL Validation\nSSRF prevention]
+        E --> F[Threat Screening\nGoogle Web Risk]
+        F --> G[(Database\npending record)]
+        G --> H[Queue]
+        H --> I([202 Accepted])
+    end
+
+    subgraph Processing
+        H --> J[Browser Rendering\nheadless Chromium]
+        J --> K[Screenshot before consent]
+        K --> L[Cookie Consent Dismissal\nautoconsent]
+        L --> M[Screenshot after consent]
+        M --> N[Rendered HTML + HTTP Headers]
+    end
+
+    subgraph WACZ["WACZ Assembly & Integrity Chain"]
+        N --> O[Build WARC archive]
+        O --> P[SHA-256 each artifact\nWARC · CDXJ · pages.jsonl]
+        P --> Q[datapackage.json manifest\nresources array with hashes]
+        Q --> R[bundleHash =\nSHA-256 of canonical JSON]
+        R --> S[Ed25519 signature\nover bundleHash bytes]
+        R --> T[RFC 3161 timestamp\nfrom independent TSA]
+        R --> U[eIDAS qualified timestamp\nfrom qualified TSA]
+        S --> V[datapackage-digest.json\nsignatures array]
+        T --> V
+        U --> V
+        V --> W[WACZ ZIP bundle]
+    end
+
+    subgraph Completion
+        W --> X[(Object Storage\nhash-addressed)]
+        X --> Y[(Database\ncomplete record)]
+        Y --> Z([Webhook dispatch])
+    end
+
+    subgraph Verification
+        W -.->|independent check| AA{5 checks}
+        AA --> AB[1. artifactHashes\neach file matches manifest hash]
+        AA --> AC[2. bundleHash\nSHA-256 of canonical manifest]
+        AA --> AD[3. signature\nEd25519 via server key lookup]
+        AA --> AE[4. timestamp\nRFC 3161 messageImprint]
+        AA --> AF[5. qualifiedTimestamp\neIDAS messageImprint]
+        AD -.->|key resolved from| AG[/.well-known/signing-key]
+    end
+
+    style WACZ fill:#f0f4ff,stroke:#6b7adc
+    style Verification fill:#f0fff4,stroke:#4caf7d
+```
+
+The diagram highlights two design decisions that matter for trust.
+
+**The integrity chain.** Every artifact file is hashed individually. Those hashes go into `datapackage.json`. The canonical JSON of that manifest is hashed to produce `bundleHash`. Then `bundleHash` is signed and timestamped. All three attestations (Ed25519 signature, RFC 3161 timestamp, and optional eIDAS qualified timestamp) cover the same `bundleHash` -- they are siblings in the `signatures` array, not a sequential chain. Any modification to any artifact at any level breaks the `bundleHash` and invalidates all attestations at once.
+
+**Key resolution.** Verification uses the server's current public key (fetched from `/.well-known/signing-key`) to verify the signature. The public key embedded in the WACZ bundle is informational only and is never trusted for the verification decision. Historical keys remain available at `/.well-known/signing-keys` so that captures signed under a rotated key continue to verify indefinitely.
+
+<details>
+<summary>eIDAS qualified timestamps</summary>
+
+RFC 3161 timestamps are included in every capture by default. The eIDAS qualified timestamp is opt-in and can be enabled account-wide via `PATCH /v1/account/settings`. When enabled, the capture pipeline requests a second timestamp from a qualified trust service provider in addition to the standard RFC 3161 timestamp. Both timestamps cover the same `bundleHash`, so both are independently verifiable. The qualified timestamp carries the legal weight of a qualified electronic timestamp under eIDAS Article 41 and is relevant for evidence in EU legal proceedings. See [Legal Evidence](/legal-evidence/) for how this maps to specific legal standards.
+
+</details>
+
+---
+
+For detailed endpoint documentation see [API Reference](/api-reference/). For how these properties map to legal authentication standards see [Legal Evidence](/legal-evidence/). For the full verification protocol see [Verification](/verification/). For security architecture and threat model see [Security & Compliance](/security/).

--- a/site/content/index.md
+++ b/site/content/index.md
@@ -134,6 +134,9 @@ Receive real-time notifications when captures complete or fail.
 **[API Reference](/api-reference/)**
 Full endpoint details, request and response schemas, status codes, and rate limits.
 
+**[Architecture](/architecture/)**
+How WRL processes captures, signs bundles, and maintains the integrity chain.
+
 **[Security and Compliance](/security/)**
 Security whitepaper, DPA, subprocessor list, incident response policy, and data retention policy for enterprise buyers.
 

--- a/site/eleventy.config.js
+++ b/site/eleventy.config.js
@@ -8,7 +8,11 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default function (eleventyConfig) {
   // Syntax highlighting (Prism, build-time)
-  eleventyConfig.addPlugin(syntaxHighlight);
+  eleventyConfig.addPlugin(syntaxHighlight, {
+    init({ Prism }) {
+      Prism.languages.mermaid = {}; // passthrough — preserves class for client-side rendering
+    },
+  });
 
   // Copy site CSS, JS, and assets
   eleventyConfig.addPassthroughCopy("css");


### PR DESCRIPTION
## Summary

Add two Mermaid architecture diagrams to the WRL documentation site:
1. **User Interaction Flows** — sequence diagram showing auth (OAuth PKCE + API key), capture lifecycle (single + batch), verification (5 checks + PDF certificate), and account management
2. **Capture Pipeline & Integrity Chain** — flowchart showing ingestion, browser rendering, WACZ assembly with cryptographic proof chain (Ed25519 + RFC 3161 + eIDAS as siblings), and 5-check verification model

Also adds client-side Mermaid rendering via CDN (mermaid@11.4.1, pinned) which fixes 3 existing unrendered diagrams in the security whitepaper.

## Key decisions
- Share link flow (`POST /v1/captures/{id}/share`) removed — endpoint does not exist in codebase
- Conceptual-level diagrams (not endpoint-level) — API Reference already covers endpoints
- Inline `<script type="module">` with dynamic import — loads Mermaid only on pages with diagrams
- Empty Prism grammar registered for mermaid — ensures `language-mermaid` class preserved

## Files changed
| File | Action |
|------|--------|
| `site/content/architecture.md` | New architecture page with 2 Mermaid diagrams |
| `site/_includes/layouts/base.njk` | Inline Mermaid rendering script |
| `site/_data/site.js` | Navigation entry after API Reference |
| `site/content/index.md` | Architecture card in Getting Started |
| `site/eleventy.config.js` | Empty Prism grammar for mermaid passthrough |

## Verification
- Code review: 1 BLOCK auto-fixed (Prism grammar), 2 ADVISE auto-fixed (version pin + try/catch)
- Tests: not applicable (docs-only changes)

Resolves #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)
