### PR TITLE
Create LLM-oriented developer reference for WRL internals

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -7,6 +7,8 @@
 | Production  | `https://api.webresourceledger.com` | `wrl` |
 | Staging     | `https://staging.webresourceledger.com` | `wrl-staging` |
 
+For D1 schema, binding names, KV/R2 key patterns, and API route map, see [`docs/INTERNALS.md`](docs/INTERNALS.md).
+
 ---
 
 ## Monitoring

--- a/docs/INTERNALS.md
+++ b/docs/INTERNALS.md
@@ -1,0 +1,436 @@
+# WRL Worker Internals Reference
+
+**Last verified:** 2026-03-26
+
+**Source files:** `wrangler.toml`, `src/index.js`, `migrations/0001–0016`, `src/db.js`, `src/kv.js`, `src/oauth.js`, `src/stripe-webhook.js`, `src/capture.js`, `src/rate-limits.js`
+
+For request/response schemas, see `openapi.yaml`. For operational procedures, see `OPERATIONS.md`. For audit log events, see `docs/audit-log-schema.md`.
+
+---
+
+## System Overview
+
+WRL is a single Cloudflare Worker (`src/index.js`) that captures web pages via a headless browser and provides a tamper-evident ledger of those captures. It exposes a REST API, a browser-based dashboard, and an MCP endpoint. Bindings: 1 D1 database (12 active tables), 1 R2 bucket, 1 KV namespace, 6 rate limiters, 1 browser binding, 6 queue producers, 6 queue consumers (3 main + 3 DLQ queues). Three cron triggers drive scheduled captures, nightly URL rescans, and weekly email digests. Staging is a fully isolated duplicate with separate resources.
+
+---
+
+## Bindings
+
+| Binding Name | Type | Resource | Purpose |
+|---|---|---|---|
+| `DB` | D1 | `wrl-metadata` | All structured metadata (tenants, captures, keys, sessions, etc.) |
+| `BUCKET` | R2 | `wrl-captures` | Capture artifacts (screenshots, HTML, headers, WACZ files) |
+| `KV` | KV | `b5cd6168...` | Rate limit counters, OAuth state, first-key one-time display, Stripe event dedup |
+| `CAPTURE_RATE_LIMITER` | Rate Limiter | ns `1001` | Per-tenant capture ceiling: 100 req/60s (hard backstop) |
+| `VERIFY_RATE_LIMITER` | Rate Limiter | ns `1002` | Per-IP verify ceiling: 60 req/60s |
+| `GLOBAL_CAPTURE_LIMITER` | Rate Limiter | ns `1003` | Global capture ceiling: 200 req/60s |
+| `ADMIN_RATE_LIMITER` | Rate Limiter | ns `1004` | Per-IP admin ceiling: 5 req/60s |
+| `CAPTURE_IP_GUARD` | Rate Limiter | ns `1005` | Per-IP secondary abuse guard: 50 req/60s |
+| `AUTH_RATE_LIMITER` | Rate Limiter | ns `1006` | Per-IP auth/account ceiling: 10 req/60s |
+| `BROWSER` | Browser | — | Puppeteer headless browser for page rendering |
+| `CAPTURE_QUEUE` | Queue Producer | `wrl-captures` | Enqueue capture jobs |
+| `CAPTURE_DLQ` | Queue Producer | `wrl-captures-dlq` | Enqueue to capture dead-letter queue |
+| `WEBHOOK_QUEUE` | Queue Producer | `wrl-webhooks` | Enqueue outbound webhook deliveries |
+| `WEBHOOK_DLQ` | Queue Producer | `wrl-webhooks-dlq` | Enqueue to webhook dead-letter queue |
+| `EMAIL_QUEUE` | Queue Producer | `wrl-emails` | Enqueue outbound email notifications |
+| `EMAIL_DLQ` | Queue Producer | `wrl-emails-dlq` | Enqueue to email dead-letter queue |
+
+---
+
+## Secrets and Variables
+
+### Secrets (set via `wrangler secret put`)
+
+| Name | Purpose |
+|---|---|
+| `CAPTURE_API_KEY` | Legacy API key for initial/admin capture auth |
+| `SIGNING_KEY` | Ed25519 PKCS8 private key for WACZ signing |
+| `ADMIN_KEY` | Admin endpoint authentication key |
+| `CORALOGIX_SEND_KEY` | Coralogix log ingestion key |
+| `IP_HASH_SEED` | HMAC seed for IP pseudonymization |
+| `GITHUB_CLIENT_SECRET` | GitHub OAuth App client secret |
+| `SESSION_SECRET` | Hex-encoded 32+ bytes for session cookie HMAC signing |
+| `STRIPE_SECRET_KEY` | Stripe secret key (`sk_live_...`) |
+| `STRIPE_WEBHOOK_SECRET` | Stripe webhook signing secret (`whsec_...`) |
+| `RESEND_API_KEY` | Resend API key for transactional email delivery |
+| `GOOGLE_WEB_RISK_API_KEY` | Google Web Risk API key (optional; degrades gracefully if absent) |
+| `CLOUDFLARE_CACHE_PURGE_TOKEN` | CF API token with Cache Purge permission for the zone |
+| `QUALIFIED_TSA_AUTH` | Base64-encoded `user:pass` for eIDAS-qualified TSA HTTP Basic auth |
+
+### Variables (from `wrangler.toml [vars]`)
+
+| Name | Value | Purpose |
+|---|---|---|
+| `ENABLE_EDGE_CACHE` | `"true"` | Enable Cloudflare edge caching for capture responses |
+| `CLOUDFLARE_ZONE_ID` | `9b1b321a...` | Zone ID for cache purge API calls |
+| `CORALOGIX_ENDPOINT` | `https://ingress.eu2.coralogix.com/logs/v1/singles` | Log ingestion endpoint |
+| `APPLICATION_NAME` | `"wrl"` | Application label in Coralogix log payloads |
+| `TSA_URL` | `https://timestamp.digicert.com` | Standard timestamp authority |
+| `QUALIFIED_TSA_URL` | `https://timestamp.sectigo.com/qualified` | eIDAS-qualified TSA for qualified timestamps |
+| `GITHUB_CLIENT_ID` | `Ov23liIG5Of9wSbgcFqW` | GitHub OAuth App client ID (public) |
+| `STRIPE_PUBLISHABLE_KEY` | `pk_live_51T...` | Stripe publishable key (public) |
+| `STRIPE_CAPTURE_PRICE_ID` | `price_1TE4aAR...` | Stripe price ID for capture volume |
+| `RESCAN_CRON` | `"0 3 * * *"` | Cron expression for nightly URL re-scan (must match `[triggers].crons`) |
+| `CORS_ORIGINS` | _(unset)_ | Comma-separated allowed origins for CORS preflight; empty = CORS disabled |
+
+---
+
+## D1 Schema
+
+### Core Tables
+
+#### `tenants`
+
+| Column | Type | Constraints | Notes |
+|---|---|---|---|
+| `id` | TEXT | PK, `GLOB '[a-z0-9_-]*'`, length 1–64 | Matches `TENANT_ID_RE`. Self-serve format: `gh-{github_numeric_id}` |
+| `config` | TEXT | nullable | JSON: `{ rateLimit: { capture: { limit, period } } }`. Per-tenant rate limit overrides |
+| `created_at` | TEXT | NOT NULL, default now | ISO 8601 |
+| `updated_at` | TEXT | nullable | ISO 8601 |
+| `updated_by` | TEXT | nullable | Who last updated |
+| `tier` | TEXT | NOT NULL, default `'free'` | App-layer valid values: `VALID_TIERS = ['free', 'pro']` |
+| `stripe_customer_id` | TEXT | nullable | Stripe `cus_xxx`. NULL until billing initiated |
+| `billing_status` | TEXT | NOT NULL, default `'active'` | App-layer valid values: `VALID_BILLING_STATUSES = ['active', 'grace_period', 'blocked']` |
+| `grace_period_end` | TEXT | nullable | ISO 8601. Non-null only when `billing_status = 'grace_period'` |
+| `payment_method_added_at` | TEXT | nullable | ISO 8601. Set once when `checkout.session.completed` fires; never unset |
+| `eidas_qualified` | INTEGER | NOT NULL, default `0` | App-layer 0/1. Per-tenant opt-in for eIDAS qualified timestamps |
+
+#### `captures`
+
+| Column | Type | Constraints | Notes |
+|---|---|---|---|
+| `id` | TEXT | PK, `GLOB 'cap_[a-f0-9]*'`, length 36 | Format: `cap_` + 32 lowercase hex |
+| `tenant_id` | TEXT | NOT NULL, FK → `tenants(id)` | |
+| `status` | TEXT | NOT NULL, CHECK IN `('pending','complete','failed')` | API maps `quarantined=1` → `status:'quarantined'` in responses; DB remains `'complete'` |
+| `url` | TEXT | NOT NULL | Target URL |
+| `ip` | TEXT | nullable | Requester IP (pseudonymized) |
+| `created_at` | TEXT | NOT NULL | ISO 8601 |
+| `completed_at` | TEXT | nullable | ISO 8601 |
+| `failed_at` | TEXT | nullable | ISO 8601 |
+| `error` | TEXT | nullable | Error message string |
+| `retryable` | INTEGER | nullable, CHECK IN `(0,1)` | Whether failure is retryable |
+| `render_quality` | TEXT | nullable, CHECK IN `('full','partial')` | |
+| `artifacts` | TEXT | nullable | JSON: `{ screenshot, screenshotBefore?, html, headers? }` — R2 key paths |
+| `wacz` | TEXT | nullable | JSON: `{ key, bundleHash, publicKeyBase64, keyId, timestampStatus, qualifiedTimestampStatus }` |
+| `render` | TEXT | nullable | JSON: browser render metadata |
+| `capture_settings` | TEXT | nullable | JSON: `{ version, consent: { library, libraryVersion, action, result, cmpDetected? } }` |
+| `schedule_id` | TEXT | nullable, FK → `schedules(id)` | Added in 0007. NULL for on-demand captures |
+| `quarantined` | INTEGER | NOT NULL, default `0` | App-layer 0/1. Artifact access gate; `1` blocks artifact retrieval |
+| `quarantine_reason` | TEXT | nullable | Threat type string, e.g. `'MALWARE'` |
+| `quarantined_at` | TEXT | nullable | ISO 8601 |
+| `last_threat_check_at` | TEXT | nullable | ISO 8601. Used by re-scan cron |
+| `threat_check` | TEXT | nullable | Pre-capture URL check result: `'pass'`, `'unavailable'`, or NULL (pre-0009 rows) |
+| `change_summary` | TEXT | nullable | JSON: change detection vs. previous scheduled capture. NULL for non-scheduled or first-in-schedule |
+
+#### `api_keys`
+
+| Column | Type | Constraints | Notes |
+|---|---|---|---|
+| `key_hash` | TEXT | PK, length 64 | SHA-256 hex of raw key. Raw key never stored |
+| `tenant_id` | TEXT | NOT NULL, FK → `tenants(id)` | |
+| `scopes` | TEXT | NOT NULL | JSON array, e.g. `["capture","read"]` |
+| `name` | TEXT | NOT NULL | Human-readable label |
+| `created_at` | TEXT | NOT NULL | ISO 8601 |
+| `created_by` | TEXT | NOT NULL | Who created the key |
+| `revoked` | INTEGER | NOT NULL, default `0`, CHECK IN `(0,1)` | |
+| `revoked_at` | TEXT | nullable | ISO 8601 |
+
+#### `signing_keys`
+
+| Column | Type | Constraints | Notes |
+|---|---|---|---|
+| `id` | TEXT | PK, length 8 | First 8 hex chars of SHA-256(raw public key bytes) |
+| `algorithm` | TEXT | NOT NULL, default `'Ed25519'` | |
+| `public_key` | TEXT | NOT NULL | Base64-encoded Ed25519 public key |
+| `archived_at` | TEXT | NOT NULL | ISO 8601 |
+
+### Billing Tables
+
+#### `usage_counters`
+
+| Column | Type | Constraints | Notes |
+|---|---|---|---|
+| `tenant_id` | TEXT | NOT NULL, FK → `tenants(id)`, PK part | |
+| `period` | TEXT | NOT NULL, PK part, GLOB `'[0-9]{4}-[0-9]{2}'`, length 7 | Format: `YYYY-MM` |
+| `capture_count` | INTEGER | NOT NULL, default `0`, ≥ 0 | Total captures this period |
+| `storage_bytes` | INTEGER | NOT NULL, default `0`, ≥ 0 | Total R2 storage this period |
+| `api_call_count` | INTEGER | NOT NULL, default `0`, ≥ 0 | |
+| `created_at` | TEXT | NOT NULL, default now | ISO 8601 |
+| `updated_at` | TEXT | nullable | ISO 8601 |
+| `reported_capture_count` | INTEGER | NOT NULL, default `0` | Stripe meter watermark — value at last successful report |
+| `last_reported_at` | TEXT | nullable | ISO 8601 of last successful Stripe meter report |
+| `eidas_capture_count` | INTEGER | NOT NULL, default `0` | Captures that received a qualified eIDAS timestamp |
+| `reported_eidas_count` | INTEGER | NOT NULL, default `0` | Stripe meter watermark for eIDAS captures |
+
+### Auth Tables
+
+#### `github_users`
+
+| Column | Type | Constraints | Notes |
+|---|---|---|---|
+| `github_id` | INTEGER | PK | GitHub's stable numeric user ID |
+| `github_login` | TEXT | NOT NULL | Mutable display name, refreshed on each OAuth callback |
+| `tenant_id` | TEXT | NOT NULL, FK → `tenants(id)`, UNIQUE | One GitHub account per tenant |
+| `tos_accepted_at` | TEXT | nullable | ISO 8601. NULL until ToS accepted |
+| `tos_version` | TEXT | nullable | Retained so future ToS revisions can trigger re-consent |
+| `created_at` | TEXT | NOT NULL, default now | ISO 8601 |
+| `updated_at` | TEXT | nullable | ISO 8601 |
+
+#### `sessions`
+
+| Column | Type | Constraints | Notes |
+|---|---|---|---|
+| `id_hash` | TEXT | PK, length 64 | SHA-256 hex of raw session cookie value. Raw cookie never stored |
+| `github_id` | INTEGER | NOT NULL, FK → `github_users(github_id)` | |
+| `tenant_id` | TEXT | NOT NULL, FK → `tenants(id)` | Denormalized from `github_users` to avoid JOIN on hot path |
+| `created_at` | TEXT | NOT NULL, default now | ISO 8601 |
+| `expires_at` | TEXT | NOT NULL | ISO 8601. Expired rows cleaned up by cron |
+
+### Scheduling Tables
+
+#### `schedules`
+
+| Column | Type | Constraints | Notes |
+|---|---|---|---|
+| `id` | TEXT | PK, `GLOB 'sch_[a-f0-9]*'`, length 36 | Format: `sch_` + 32 lowercase hex |
+| `tenant_id` | TEXT | NOT NULL, FK → `tenants(id)` | |
+| `url` | TEXT | NOT NULL, length ≤ 2048 | Target URL |
+| `name` | TEXT | NOT NULL, length 1–128 | |
+| `cron` | TEXT | NOT NULL, length ≤ 128 | Cron expression for recurrence |
+| `next_run_at` | TEXT | NOT NULL | ISO 8601. Updated after each run |
+| `paused` | INTEGER | NOT NULL, default `0`, CHECK IN `(0,1)` | |
+| `last_run_at` | TEXT | nullable | ISO 8601 |
+| `last_capture_id` | TEXT | nullable | Most recent capture from this schedule |
+| `last_capture_status` | TEXT | nullable | Status of most recent capture |
+| `created_at` | TEXT | NOT NULL, default now | ISO 8601 |
+| `updated_at` | TEXT | nullable | ISO 8601 |
+
+### Webhook Tables
+
+#### `webhooks`
+
+| Column | Type | Constraints | Notes |
+|---|---|---|---|
+| `id` | TEXT | PK, `GLOB 'whk_[a-f0-9]*'`, length 36 | Format: `whk_` + 32 lowercase hex |
+| `tenant_id` | TEXT | NOT NULL, FK → `tenants(id)` | |
+| `url` | TEXT | NOT NULL, length ≤ 2048 | Delivery endpoint |
+| `name` | TEXT | NOT NULL | Human label |
+| `secret` | TEXT | NOT NULL | HMAC signing secret for delivery payloads |
+| `events` | TEXT | NOT NULL | JSON array, e.g. `["capture.complete","capture.failed"]` |
+| `active` | INTEGER | NOT NULL, default `1`, CHECK IN `(0,1)` | |
+| `created_at` | TEXT | NOT NULL, default now | ISO 8601 |
+| `updated_at` | TEXT | nullable | ISO 8601 |
+
+### Notification Tables
+
+#### `notification_preferences`
+
+| Column | Type | Constraints | Notes |
+|---|---|---|---|
+| `tenant_id` | TEXT | PK, FK → `tenants(id)` | Row created lazily on first PUT |
+| `email` | TEXT | nullable, length 3–320 | Notification address |
+| `email_verified` | INTEGER | NOT NULL, default `0`, CHECK IN `(0,1)` | |
+| `email_source` | TEXT | NOT NULL, default `'github'`, CHECK IN `('github','manual')` | Origin of email address |
+| `notify_capture_failure` | INTEGER | NOT NULL, default `1`, CHECK IN `(0,1)` | |
+| `notify_approaching_limit` | INTEGER | NOT NULL, default `1`, CHECK IN `(0,1)` | |
+| `notify_limit_reached` | INTEGER | NOT NULL, default `1`, CHECK IN `(0,1)` | |
+| `notify_invoice_generated` | INTEGER | NOT NULL, default `1`, CHECK IN `(0,1)` | |
+| `notify_payment_failure` | INTEGER | NOT NULL, default `1`, CHECK IN `(0,1)` | |
+| `notify_weekly_digest` | INTEGER | NOT NULL, default `1`, CHECK IN `(0,1)` | |
+| `created_at` | TEXT | NOT NULL, default now | ISO 8601 |
+| `updated_at` | TEXT | nullable | ISO 8601 |
+| `pending_email` | TEXT | nullable | New address awaiting verification. NULL when no verification in flight |
+| `verification_sent_at` | TEXT | nullable | ISO 8601. Used to enforce 60-second resend cooldown |
+
+#### `notification_sent`
+
+| Column | Type | Constraints | Notes |
+|---|---|---|---|
+| `tenant_id` | TEXT | NOT NULL, FK → `tenants(id)`, PK part | |
+| `period` | TEXT | NOT NULL, PK part, GLOB `'[0-9]{4}-[0-9]{2}'`, length 7 | Format: `YYYY-MM` |
+| `event_type` | TEXT | NOT NULL, PK part | e.g. `'approaching_limit'`, `'limit_reached'` |
+| `sent_at` | TEXT | NOT NULL, default now | ISO 8601. Dedup: at most one send per (tenant, period, event_type) |
+
+### Threat Intelligence Tables
+
+#### `threat_checks`
+
+| Column | Type | Constraints | Notes |
+|---|---|---|---|
+| `id` | INTEGER | PK AUTOINCREMENT | |
+| `capture_id` | TEXT | NOT NULL, FK → `captures(id)` | |
+| `checked_at` | TEXT | NOT NULL | ISO 8601 |
+| `verdict` | TEXT | NOT NULL, CHECK IN `('safe','threat')` | |
+| `threat_types` | TEXT | nullable | Raw threat type string(s) from provider. NULL on safe |
+| `source` | TEXT | NOT NULL, default `'web_risk'` | Provider identifier |
+
+### ID Format Conventions
+
+| Entity | Format | Example |
+|---|---|---|
+| Tenant (self-serve) | `gh-{github_numeric_id}` | `gh-12345678` |
+| Tenant (admin-provisioned) | `[a-z0-9_-]{1,64}` | `acme-corp` |
+| Capture | `cap_` + 32 hex | `cap_a1b2c3d4...` |
+| Webhook | `whk_` + 32 hex | `whk_e5f6a7b8...` |
+| Schedule | `sch_` + 32 hex | `sch_c9d0e1f2...` |
+| API key hash | 64 hex (SHA-256) | `a1b2c3...` (64 chars) |
+| Session hash | 64 hex (SHA-256) | `d4e5f6...` (64 chars) |
+| Signing key ID | 8 hex | `a1b2c3d4` |
+
+---
+
+## API Routes
+
+Special-case routes handled before the regex router: `POST /mcp`, `OPTIONS /mcp`, `OPTIONS /v1/captures`.
+
+For request/response schemas, see `openapi.yaml`.
+
+| Method | Path | Auth | Rate Limit | Surface |
+|---|---|---|---|---|
+| GET | `/favicon.ico` | none | — | infra |
+| GET | `/health` | none | — | infra |
+| GET | `/ui` | none | — | ui |
+| POST | `/mcp` | api-key | — | infra |
+| POST | `/v1/captures/batch` | dual | capture | public-api |
+| POST | `/v1/captures` | dual | capture | public-api |
+| GET | `/v1/captures` | dual | — | public-api |
+| GET | `/v1/captures/{captureId}/status` | none (optional dual) | — | public-api |
+| GET | `/v1/captures/{captureId}` | none (optional dual) | — | public-api |
+| GET | `/v1/captures/{captureId}/artifacts/{type}` | none (optional dual) | — | public-api |
+| GET | `/v1/captures/{captureId}/certificate` | none (optional dual) | — | public-api |
+| GET | `/v1/captures/{captureId}/diff/{baseId}` | none (optional dual) | — | public-api |
+| GET | `/v1/verify/{captureId}` | none | verify | public-api |
+| GET | `/.well-known/signing-key` | none | verify | public-api |
+| GET | `/.well-known/signing-keys` | none | verify | public-api |
+| POST | `/v1/admin/keys` | admin-key | admin | admin |
+| GET | `/v1/admin/keys` | admin-key | admin | admin |
+| DELETE | `/v1/admin/keys/{keyHash}` | admin-key | admin | admin |
+| GET | `/v1/admin/usage` | admin-key | admin | admin |
+| POST | `/v1/admin/cache/purge` | admin-key | admin | admin |
+| GET | `/v1/admin/tenants/{tenantId}/config` | admin-key | admin | admin |
+| PUT | `/v1/admin/tenants/{tenantId}/config` | admin-key | admin | admin |
+| POST | `/v1/webhooks` | dual | — | public-api |
+| GET | `/v1/webhooks` | dual | — | public-api |
+| DELETE | `/v1/webhooks/{webhookId}` | dual | — | public-api |
+| POST | `/v1/webhooks/{webhookId}/ping` | dual | — | public-api |
+| POST | `/v1/schedules` | dual | capture | public-api |
+| GET | `/v1/schedules` | dual | — | public-api |
+| GET | `/v1/schedules/{scheduleId}` | dual | — | public-api |
+| DELETE | `/v1/schedules/{scheduleId}` | dual | — | public-api |
+| GET | `/auth/login` | none | auth | auth |
+| GET | `/auth/callback` | none | auth | auth |
+| POST | `/auth/logout` | none | auth | auth |
+| GET | `/auth/session` | none | auth | auth |
+| GET | `/v1/account/first-key` | session | auth | account |
+| POST | `/v1/account/first-key/ack` | session | auth | account |
+| GET | `/v1/account/keys` | session | auth | account |
+| POST | `/v1/account/keys` | session | auth | account |
+| DELETE | `/v1/account/keys/{keyHash}` | session | auth | account |
+| POST | `/v1/account/tos` | session | auth | account |
+| GET | `/v1/account/usage` | session | auth | account |
+| GET | `/v1/account/settings` | session | auth | account |
+| PATCH | `/v1/account/settings` | session | auth | account |
+| GET | `/v1/account/notifications` | session | auth | notification |
+| PUT | `/v1/account/notifications` | session | auth | notification |
+| POST | `/v1/account/notifications/resend-verification` | session | auth | notification |
+| GET | `/v1/notifications/unsubscribe` | none | auth | notification |
+| POST | `/v1/notifications/unsubscribe` | none | auth | notification |
+| GET | `/v1/notifications/verify-email` | none | auth | notification |
+| POST | `/v1/notifications/verify-email` | none | auth | notification |
+| POST | `/v1/billing/checkout` | session | auth | billing |
+| POST | `/v1/billing/portal` | session | auth | billing |
+| POST | `/v1/stripe/webhook` | signature | — | billing |
+
+**Auth values:** `api-key` = `Authorization: Bearer {key}`; `admin-key` = admin key from `ADMIN_KEY` secret; `session` = `__Host-wrl_session` cookie (HMAC-signed); `dual` = session cookie first, then API key fallback; `signature` = Stripe webhook signature verification; `none` = unauthenticated; `none (optional dual)` = public access unless credentials presented (bad credentials → 401).
+
+---
+
+## KV Key Patterns
+
+| Pattern | Value | TTL | Purpose | Module |
+|---|---|---|---|---|
+| `rl:{tenantId}:{group}:{windowId}` | Integer string | `period * 2` seconds | Per-tenant sliding window rate limit counter | `src/kv.js` |
+| `oauth_state:{state}` | JSON `{ codeVerifier, createdAt }` | 600s | OAuth PKCE state and code verifier, single-use | `src/oauth.js` |
+| `first_key:{tenantId}` | Raw API key string | 3600s | One-time first API key display for new self-serve tenants | `src/oauth.js` |
+| `stripe_evt:{eventId}` | `'1'` | 604800s (7 days) | Stripe webhook event idempotency dedup | `src/stripe-webhook.js` |
+
+---
+
+## R2 Object Key Patterns
+
+| Key Pattern | Content Type | Purpose |
+|---|---|---|
+| `captures/{captureId}/screenshot.png` | `image/png` | Post-interaction screenshot |
+| `captures/{captureId}/screenshot-before.png` | `image/png` | Pre-interaction screenshot (when cookie consent dialog dismissed) |
+| `captures/{captureId}/rendered.html` | `text/plain` | Rendered HTML source (`Content-Disposition: attachment`) |
+| `captures/{captureId}/headers.json` | `application/json` | HTTP response headers from capture |
+| `captures/{waczHash}.wacz` | `application/wacz+zip` | WACZ bundle (keyed by content hash, not capture ID) |
+
+---
+
+## Queues
+
+| Queue Name | Binding | Max Batch | Max Retries | DLQ | Handler |
+|---|---|---|---|---|---|
+| `wrl-captures` | `CAPTURE_QUEUE` | 1 | 3 | `wrl-captures-dlq` | `handleCaptureMessage` |
+| `wrl-captures-dlq` | `CAPTURE_DLQ` | 1 | 0 | — | `handleDlqMessage` |
+| `wrl-webhooks` | `WEBHOOK_QUEUE` | 1 | 3 | `wrl-webhooks-dlq` | `handleWebhookMessage` |
+| `wrl-webhooks-dlq` | `WEBHOOK_DLQ` | 1 | 0 | — | `handleWebhookDlqMessage` |
+| `wrl-emails` | `EMAIL_QUEUE` | 1 | 3 | `wrl-emails-dlq` | `handleEmailMessage` |
+| `wrl-emails-dlq` | `EMAIL_DLQ` | 1 | 0 | — | `handleEmailDlqMessage` |
+
+`max_concurrency`: captures = 10, webhooks = 20, emails = 5. `max_batch_size = 1` on all queues to isolate failures per message.
+
+---
+
+## Cron Triggers
+
+| Expression | Handler | Purpose |
+|---|---|---|
+| `*/1 * * * *` | `handleScheduledTick` + hourly `reportPendingMeterEvents` | Evaluate due tenant schedules; enqueue capture jobs. On the hour: flush pending Stripe meter events |
+| `0 3 * * *` | `handleRescanTick` | Nightly re-scan of complete non-quarantined captures for threat changes |
+| `0 9 * * 1` | `handleWeeklyDigest` | Weekly email digest (Monday 09:00 UTC) |
+
+---
+
+## Rate Limiters
+
+| Binding | Limit | Purpose |
+|---|---|---|
+| `CAPTURE_RATE_LIMITER` | 100 req/60s | Per-tenant hard ceiling for capture endpoints. Application KV counters enforce lower per-tenant defaults (10 req/60s). Tenant `config.rateLimit.capture` may override the KV default up to 100. |
+| `VERIFY_RATE_LIMITER` | 60 req/60s | Per-IP ceiling for verify and signing-key endpoints |
+| `GLOBAL_CAPTURE_LIMITER` | 200 req/60s | Global capture ceiling across all tenants |
+| `ADMIN_RATE_LIMITER` | 5 req/60s | Per-IP ceiling for admin and account/billing endpoints |
+| `CAPTURE_IP_GUARD` | 50 req/60s | Secondary per-IP abuse guard on capture endpoints (layer 3 of 3-layer check) |
+| `AUTH_RATE_LIMITER` | 10 req/60s | Per-IP ceiling for OAuth, unsubscribe, and verify-email endpoints |
+
+**Application-layer defaults** (KV counters, overridable per tenant via `tenants.config`):
+
+| Group | Default | Overridable |
+|---|---|---|
+| `capture` | 10 req/60s | Yes (ceiling: `BINDING_CEILING = 100`) |
+| `verify` | 60 req/60s | No |
+| `admin` | 5 req/60s | No |
+| `auth` | 20 req/60s | No |
+| `account` | 30 req/60s | No |
+
+---
+
+## Staging Differences
+
+| Item | Production | Staging |
+|---|---|---|
+| Worker name | `wrl` | `wrl` (env: `staging`) |
+| D1 database | `wrl-metadata` | `wrl-metadata-staging` |
+| R2 bucket | `wrl-captures` | `wrl-captures-staging` |
+| KV namespace | `b5cd6168...` | `ed564f8e...` |
+| Queue names | `wrl-captures`, `wrl-webhooks`, `wrl-emails` (+ DLQs) | `wrl-captures-staging`, `wrl-webhooks-staging`, `wrl-emails-staging` (+ DLQs) |
+| Rate limiter namespace IDs | `1001`–`1006` | `2001`–`2006` |
+| Domains | `api.webresourceledger.com`, `verify.webresourceledger.com` | `staging.webresourceledger.com`, `verify-staging.webresourceledger.com` |
+| `APPLICATION_NAME` | `"wrl"` | `"wrl-staging"` |
+| `STRIPE_PUBLISHABLE_KEY` | `pk_live_51T...` (live) | `pk_test_51T...` (test) |
+| `STRIPE_CAPTURE_PRICE_ID` | `price_1TE4aAR...` | `price_1TE3yVJ...` |
+| `GITHUB_CLIENT_ID` | `Ov23liIG5Of9wSbgcFqW` | `Ov23li0lii7I7Y43lbUs` |
+| `RESCAN_CRON` | `"0 3 * * *"` | `"0 4 * * *"` |
+| Captures queue `max_concurrency` | 10 | 2 (constrained by browser session pool) |
+| Emails queue `max_concurrency` | 5 | 2 |

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -55,6 +55,12 @@ Expand WRL into a platform that other tools and agents build on.
 
 Deferred items with explicit activation triggers. Revisit when condition is met.
 
+### Developer Tooling
+
+| Item | Condition | Source |
+|------|-----------|--------|
+| [consider] Automated INTERNALS.md generation script | When D1 schema changes become frequent (>2 migrations per month) or staleness causes a dev incident | Phase 0087 |
+
 ### Auth (R12 shipped -- next wave)
 
 | Item | Condition | Source |

--- a/docs/evolution/0087-llm-developer-reference/decisions.md
+++ b/docs/evolution/0087-llm-developer-reference/decisions.md
@@ -1,0 +1,48 @@
+# Decisions: LLM Developer Reference
+
+## Document Location: `docs/INTERNALS.md`
+
+**Chosen:** `docs/INTERNALS.md` with a 3-line pointer in `.claude/rules/wrl-internals.md`
+
+**Over:**
+- Placing full content in `.claude/rules/` (always-loaded) — rejected because rules files are 4-12 lines each; a ~250-line doc would waste ~2,500 tokens on sessions that never touch schema/routes
+- Using `llms.txt` at repo root — rejected because `llms.txt` is a web-crawler convention, not applicable to internal dev refs
+- Embedding in CLAUDE.md — rejected because CLAUDE.md is process philosophy, not technical reference
+
+**Why:** All five planning specialists converged on this. The pointer pattern costs ~40 tokens always-loaded; the full doc is loaded on-demand when needed. The `.claude/rules/` pointer was blocked by Claude Code's sensitive file protections — flagged as HUMAN_ACTION_REQUIRED.
+
+## Schema Format: Hand-Written Tables
+
+**Chosen:** Hand-written current-state tables grouped by domain, with JSON column shapes and app-layer constraints documented inline (in Notes column)
+
+**Over:**
+- Raw CREATE TABLE DDL — tables can include what DDL cannot: JSON column shapes, app-layer-only constraints, ID format conventions
+- Auto-generated from migrations — ALTER TABLE parsing across 16 migrations is fragile; maintenance burden of the script exceeds the doc itself
+
+## Route Table: Single Flat Table
+
+**Chosen:** One flat route table with columns: Method, Path, Auth, Rate Limit, Surface
+
+**Over:** Separate tables per domain or a two-table split (public vs internal) — flat table is most scannable, Surface column provides grouping signal without requiring multiple tables
+
+## Section Ordering: Frequency of Access
+
+**Chosen:** System overview → bindings → secrets/vars → D1 schema → routes → KV → R2 → queues → crons → rate limiters → staging differences
+
+**Why:** ux-strategy-minion's analysis showed bindings (`env.SOMETHING`) are the most frequent lookup in code-writing sessions, followed by schema, then routes.
+
+## No Generation Script
+
+**Chosen:** Hand-written doc with "Last verified" date and source file pointers
+
+**Over:** `scripts/generate-internals.sh` — the schema has 10 tables and changes infrequently; a generation script handling ALTER TABLE, CHECK constraints, and JSON column annotations would be more complex than the doc itself. Deferred to backlog.
+
+## Merging Skeleton + Content Tasks
+
+**Chosen:** Single execution task (structure + content together)
+
+**Over:** Original plan had Task 1 (skeleton) with approval gate, then Task 2 (content) — margo's Phase 3.5 ADVISE correctly identified the gate as over-engineering for a markdown file where wrong headings are trivially fixed in-place.
+
+## Token Budget Exceeded but Accepted
+
+The 3K token target was aspirational. Final document is ~5,200 tokens (~3,954 words). The content is entirely dense tables with no prose bloat — the 12-table D1 schema, 52+ routes, and extensive binding/queue/cron detail simply requires this space. Cutting would reduce accuracy.

--- a/docs/evolution/0087-llm-developer-reference/outcome.md
+++ b/docs/evolution/0087-llm-developer-reference/outcome.md
@@ -1,0 +1,51 @@
+# Outcome: LLM Developer Reference
+
+## What Was Built
+
+A structured reference document (`docs/INTERNALS.md`) that gives LLMs and developers the context needed to operate on WRL without codebase archaeology. The document covers:
+
+- **System Overview** — one-paragraph mental model scaffold
+- **Bindings** — all 16 wrangler.toml bindings (D1, R2, KV, 6 rate limiters, browser, 6 queue producers)
+- **Secrets** — 13 secrets (names only, no values)
+- **Variables** — 11 vars from `[vars]` section
+- **D1 Schema** — 12 active tables across 7 domains with column types, constraints, JSON column shapes, and app-layer constraints inline
+- **API Routes** — 52 router entries + 3 special-case routes, with auth type, rate limit group, and surface classification
+- **KV Key Patterns** — 4 patterns with TTLs, purposes, and source modules
+- **R2 Object Key Patterns** — 5 patterns including content-addressed WACZ distinction
+- **Queues** — 6 queues (3 main + 3 DLQ) with batch size, retry, and concurrency settings
+- **Cron Triggers** — 3 triggers with handlers and purposes
+- **Rate Limiters** — 6 binding-level + 5 application-layer defaults
+- **Staging Differences** — 14 items that differ from production
+
+Additionally:
+- Cross-reference added to `OPERATIONS.md` line 10
+- `.claude/rules/wrl-internals.md` pointer file — blocked by Claude Code sensitive file protections, flagged as HUMAN_ACTION_REQUIRED
+
+## Validation Results
+
+1. Route count: 52 tuples in `routes[]` + 3 special-case = 55 total. Match confirmed.
+2. D1 tables: 12 active (not 10 as initially estimated). All documented. `share_tokens` absent. Correct.
+3. KV patterns: 4 found via grep, all documented.
+4. R2 patterns: 5 found via grep, all documented.
+5. No secret values in document.
+
+## What Deviated from Plan
+
+- **Table count**: Planning estimated 10 active D1 tables; actual count is 12 (notification_preferences and notification_sent were added in later migrations and not counted in the planning phase estimate).
+- **Token budget**: Target was 3K tokens; actual is ~5,200 tokens (~3,954 words). The dense table format with 12 schema tables and 55 routes simply requires this space. No prose bloat.
+- **`.claude/rules/` pointer**: Could not be created automatically due to Claude Code treating `.claude/rules/` as a sensitive directory. Flagged for manual creation.
+
+## Surface Consistency
+
+| Surface | Action |
+|---------|--------|
+| OpenAPI spec | No update needed — no new/changed endpoints |
+| Docs site | No update needed — INTERNALS.md is for developers/LLMs, not end users |
+| Landing page | No update needed — no pricing/feature changes |
+| MCP server | No update needed — no API changes |
+| Legal pages | No update needed — no new data collection or services |
+
+## Backlog Changes
+
+- **Added**: "Automated INTERNALS.md generation script" — deferred from this phase. A script that parses migrations, routes array, and wrangler.toml to regenerate INTERNALS.md would reduce staleness risk but is more complex than the doc itself. Low priority.
+- No items removed or completed.

--- a/docs/evolution/0087-llm-developer-reference/process.md
+++ b/docs/evolution/0087-llm-developer-reference/process.md
@@ -1,0 +1,85 @@
+# Process: LLM Developer Reference
+
+## TL;DR
+
+Five planning specialists converged on a single recommendation with zero conflicts: place a dense, table-based reference document at `docs/INTERNALS.md` with a `.claude/rules/` pointer for discoverability. Margo's Phase 3.5 review eliminated an unnecessary approval gate, collapsing 3 tasks to 2. The executing agent discovered 12 active D1 tables (not 10 as planned) and 55 routes (not 50+). Total document: 437 lines, ~3,954 words. The `.claude/rules/` pointer could not be created due to Claude Code's sensitive file protections.
+
+## Planning Phase
+
+### Meta-Plan (Phase 1)
+
+Nefario identified 5 specialists for planning:
+
+1. **ai-modeling-minion** — how LLMs consume context, format/placement decisions
+2. **api-spec-minion** — route table design, avoiding OpenAPI duplication
+3. **data-minion** — D1 schema documentation strategy
+4. **ux-strategy-minion** — information hierarchy for dual audiences (LLM + human)
+5. **software-docs-minion** — placement in existing docs ecosystem
+
+**Notable exclusions**: security-minion (no attack surface — listing names not values), iac-minion (documenting wrangler.toml, not modifying it), devx-minion (DX concern is content/placement, covered by ai-modeling + ux-strategy).
+
+The meta-plan also discovered one external skill (`ops-runbook`, classified as LEAF — operational procedures, not directly relevant but referenced to avoid content duplication).
+
+### Specialist Consultations (Phase 2)
+
+All 5 specialists ran in parallel. Key findings from each:
+
+**ai-modeling-minion** read the existing `.claude/rules/` files (4-12 lines each) and CLAUDE.md structure. Recommended `docs/INTERNALS.md` as on-demand reference with a tiny pointer in `.claude/rules/`. Estimated the document at ~2,400 tokens and suggested a 3K ceiling. Flagged staleness as the primary risk.
+
+**api-spec-minion** read `src/index.js` and found 61 routes in the array plus 2 special-case routes. Identified 4 auth mechanisms dispatched by URL prefix in the fetch handler. Recommended a single flat route table with auth type, rate limit group, and surface classification columns. Noted that the auth dispatch model is undocumented anywhere.
+
+**data-minion** read all 16 migrations and found 10 active tables (later corrected to 12 during execution). Recommended hand-written current-state tables over DDL blocks or auto-generation. Identified key documentation pitfalls: the quarantined virtual status, content-addressed WACZ keys, JSON column shapes defined only in code.
+
+**ux-strategy-minion** recommended random access over narrative, frequency-of-access section ordering (bindings first), and a sub-200-word mental model scaffold. Argued that the highest-ROI artifact is a bindings summary table mapping every `env.*` name to its type and purpose.
+
+**software-docs-minion** read the full docs structure and recommended `docs/INTERNALS.md` (matching peers like `docs/mcp.md` and `docs/audit-log-schema.md`). Specified what NOT to duplicate: openapi.yaml, OPERATIONS.md, audit-log-schema.md.
+
+**Zero conflicts across specialists.** All 5 independently arrived at the same placement decision and table-based format.
+
+### Synthesis (Phase 3)
+
+Nefario's synthesis made 5 decisions, all ratifying specialist consensus:
+
+1. `docs/INTERNALS.md` with `.claude/rules/` pointer (unanimous)
+2. Hand-written tables with inline JSON shapes and app-layer constraints (data-minion + ai-modeling-minion)
+3. Single flat route table (api-spec-minion's recommendation, endorsed by ux-strategy-minion for scannability)
+4. Frequency-of-access section ordering (ux-strategy-minion's analysis, adopted unanimously)
+5. No generation script for MVP (all agreed: maintenance burden of script exceeds doc)
+
+Original plan: 3 tasks with 1 approval gate on the skeleton.
+
+### Architecture Review (Phase 3.5)
+
+5 mandatory reviewers, no discretionary (pure documentation task):
+
+- **security-minion**: APPROVE. Secret safeguards adequate.
+- **test-minion**: APPROVE. Validation steps in Task 2 sufficient.
+- **ux-strategy-minion**: APPROVE. Suggested collocating JSON/constraint annotations in per-table Notes columns instead of separate sub-tables. Incorporated.
+- **lucy**: ADVISE. Flagged evolution log and backlog update as orchestrator responsibilities. Correct — handled post-execution.
+- **margo**: ADVISE. Two findings: (1) merge Tasks 1+2 — the skeleton approval gate overstates rework cost for a markdown file. (2) Five reviewers for markdown-only deliverable is disproportionate process overhead. Finding 1 was accepted (tasks merged, gate removed). Finding 2 was acknowledged but not actionable — mandatory reviewers are not user-adjustable.
+
+**Margo's gate elimination was the most impactful review action.** It removed a blocking dependency and a round-trip for zero risk reduction.
+
+## Execution Phase
+
+### What Changed from Plan
+
+- Tasks collapsed from 3 to 2 (margo's ADVISE)
+- Approval gate removed (margo's ADVISE)
+- JSON/constraint annotations moved into per-table Notes columns (ux-strategy-minion's ADVISE)
+- D1 table count corrected from 10 to 12 (discovered during execution)
+- Token budget exceeded: target was 3K, actual ~5.2K. The 12-table schema with 55 routes and extensive binding detail simply requires this space. No prose bloat was present to cut.
+
+### What the Human Did NOT Intervene On
+
+This was an autonomous execution (no human at the gates). Lucy served as the gate proxy throughout:
+- Team approval: APPROVE (no changes)
+- Reviewer approval: auto-approved (no discretionary reviewers)
+- Execution plan approval: APPROVE (flagged OPERATIONS.md existence concern — false negative, file exists)
+
+### Where to Read More
+
+- Full specialist contributions: `docs/history/nefario-reports/2026-03-26-043000-llm-developer-reference/`
+- Meta-plan: `phase1-metaplan.md` in companion directory
+- Synthesis: `phase3-synthesis.md` in companion directory
+- Review verdicts: `phase3.5-*.md` files in companion directory

--- a/docs/evolution/0087-llm-developer-reference/prompt.md
+++ b/docs/evolution/0087-llm-developer-reference/prompt.md
@@ -1,0 +1,11 @@
+**Outcome**: A structured reference document exists that gives LLMs (and developers) the context needed to operate on WRL — D1 schema, API routes, KV namespaces, R2 buckets, env vars, and wrangler config — so that AI-assisted development sessions don't start with 10 minutes of codebase archaeology.
+
+**Success criteria**:
+- Document covers: D1 tables and columns, all API routes with methods, KV/R2 namespace names and purposes, environment variables and secrets (names only, not values), wrangler.toml bindings
+- Clear separation between dev-only internals and public API surface
+- Document lives in a location discoverable by LLMs (e.g., `llms.txt`, `CLAUDE.md` reference, or `docs/`)
+- Accurate against current codebase (not stale)
+
+**Scope**:
+- In: D1 schema, API routes, bindings (KV, R2, DO), env vars, worker config
+- Out: Public-facing API documentation (already on docs site), operational runbooks, architecture narratives

--- a/docs/evolution/README.md
+++ b/docs/evolution/README.md
@@ -95,3 +95,4 @@ software development.
 | [0084-email-verify-tests](0084-email-verify-tests/) | Email verification flow tests: 31 tests for token generation, GET/POST handlers, resend, and notification continuity (Issue #199) |
 | [0085-mcp-api-sync](0085-mcp-api-sync/) | Sync MCP server with current API surface and establish drift prevention (Issue #202) |
 | [0086-mermaid-architecture-diagrams](0086-mermaid-architecture-diagrams/) | Add Mermaid architecture diagrams to docs site: user interaction flows + capture pipeline & integrity chain (Issue #168) |
+| [0087-llm-developer-reference](0087-llm-developer-reference/) | LLM-oriented developer reference for WRL internals: D1 schema, API routes, bindings, secrets, queues, crons (Issue #201) |

--- a/docs/history/nefario-reports/2026-03-26-043000-llm-developer-reference.md
+++ b/docs/history/nefario-reports/2026-03-26-043000-llm-developer-reference.md
@@ -1,0 +1,107 @@
+---
+task: "Create LLM-oriented developer reference for WRL internals"
+source-issue: 201
+date: 2026-03-26
+status: complete
+agents: [ai-modeling-minion, api-spec-minion, data-minion, ux-strategy-minion, software-docs-minion, security-minion, test-minion, lucy, margo]
+task-count: 2
+gate-count: 0
+mode: execution
+---
+
+## Summary
+
+Created `docs/INTERNALS.md` — a dense, table-based reference document covering WRL's D1 schema (12 tables), API routes (55 total), KV/R2 key patterns, all bindings, secrets, queues, crons, rate limiters, and staging differences. Added cross-reference from `OPERATIONS.md` and a `.claude/rules/` pointer file (pending manual creation due to sensitive file protections).
+
+## Original Prompt
+
+Create a structured reference document that gives LLMs and developers the context needed to operate on WRL — D1 schema, API routes, KV namespaces, R2 buckets, env vars, and wrangler config — so that AI-assisted development sessions don't start with 10 minutes of codebase archaeology.
+
+## Key Design Decisions
+
+1. **Location: `docs/INTERNALS.md`** — on-demand reference, not always-loaded in `.claude/rules/`. Five specialists converged: a ~250-line doc would waste tokens on sessions that never touch schema/routes. A 3-line pointer in `.claude/rules/wrl-internals.md` provides discoverability.
+
+2. **Hand-written tables over DDL or auto-generation** — tables can encode JSON column shapes, app-layer constraints, and ID conventions that raw SQL cannot. Auto-generation deferred (migration parsing complexity exceeds doc maintenance burden).
+
+3. **Single flat route table** — with auth type, rate limit group, and surface classification columns. Flat is most scannable; Surface column provides domain grouping without separate sub-tables.
+
+4. **Frequency-of-access section ordering** — bindings first (most common lookup), then schema, then routes. Matches actual code-writing session patterns.
+
+5. **Tasks 1+2 merged** — margo's review correctly identified the skeleton approval gate as over-engineering. Wrong headings in markdown are trivially fixed in-place.
+
+## Execution
+
+### Task 1: Create docs/INTERNALS.md + pointer file
+- **Agent**: software-docs-minion (sonnet)
+- **Outcome**: Complete reference document with all 11 sections populated from source code
+- **Files**: `docs/INTERNALS.md` (new, 437 lines), `.claude/rules/wrl-internals.md` (blocked — HUMAN_ACTION_REQUIRED)
+- **Validation**: Route count matched (52 router + 3 special-case), all 12 D1 tables documented, all KV/R2 patterns verified via grep
+
+### Task 2: OPERATIONS.md cross-reference
+- **Agent**: software-docs-minion (sonnet)
+- **Outcome**: One-line cross-reference added at line 10
+- **Files**: `OPERATIONS.md` (modified, 1 line added)
+
+## Verification
+
+Verification: code review passed (docs/INTERNALS.md, OPERATIONS.md). Tests: not applicable — docs-only changes. Doc assessment: 0 items identified.
+
+## Agent Contributions
+
+### Planning Agents (Phase 2)
+
+| Agent | Key Contribution |
+|-------|-----------------|
+| ai-modeling-minion | Recommended `docs/` placement with `.claude/rules/` pointer; dense tables; 3K token target |
+| api-spec-minion | Mapped 61 routes + 2 special-case from src/index.js; identified auth dispatch model as undocumented |
+| data-minion | Analyzed 16 migrations to determine 10 active tables (actual: 12); recommended hand-written tables with JSON shapes |
+| ux-strategy-minion | Frequency-of-access section ordering; random access over narrative; collocate annotations in Notes columns |
+| software-docs-minion | `docs/INTERNALS.md` placement; avoid duplicating openapi.yaml, OPERATIONS.md, audit-log-schema.md |
+
+### Architecture Reviewers (Phase 3.5)
+
+| Agent | Verdict | Key Finding |
+|-------|---------|-------------|
+| security-minion | APPROVE | Adequate secret safeguards baked in |
+| test-minion | APPROVE | Validation steps in Task 2 sufficient for documentation |
+| ux-strategy-minion | APPROVE | Consider collocating JSON/constraint annotations in per-table Notes |
+| lucy | ADVISE | Evolution log and backlog update are orchestrator responsibilities |
+| margo | ADVISE | Merge Tasks 1+2; 5 reviewers disproportionate for markdown |
+
+## Working Files
+
+Companion directory: `docs/history/nefario-reports/2026-03-26-043000-llm-developer-reference/`
+
+<details><summary>Files</summary>
+
+- `prompt.md` — original task description
+- `phase1-metaplan-prompt.md` — meta-plan input
+- `phase1-metaplan.md` — meta-plan output
+- `phase2-ai-modeling-minion.md` — AI modeling specialist contribution
+- `phase2-api-spec-minion.md` — API spec specialist contribution
+- `phase2-data-minion.md` — Data specialist contribution
+- `phase2-ux-strategy-minion.md` — UX strategy specialist contribution
+- `phase2-software-docs-minion.md` — Software docs specialist contribution
+- `phase3-synthesis.md` — Synthesized execution plan
+- `phase3.5-security-minion.md` — Security review verdict
+- `phase3.5-test-minion.md` — Test review verdict
+- `phase3.5-ux-strategy-minion.md` — UX strategy review verdict
+- `phase3.5-lucy.md` — Lucy review verdict
+- `phase3.5-margo.md` — Margo review verdict
+
+</details>
+
+## Session Resources
+
+<details><summary>Skills and context</summary>
+
+### Skills Invoked
+- `/nefario` — orchestration workflow
+
+### External Skills Discovered
+- `ops-runbook` (LEAF) — operational procedures. Not used in execution; referenced to avoid content duplication.
+
+### Compaction Events
+0 compaction events (autonomous mode — checkpoints skipped)
+
+</details>

--- a/docs/history/nefario-reports/2026-03-26-043000-llm-developer-reference/phase1-metaplan-prompt.md
+++ b/docs/history/nefario-reports/2026-03-26-043000-llm-developer-reference/phase1-metaplan-prompt.md
@@ -1,0 +1,37 @@
+MODE: META-PLAN
+
+You are creating a meta-plan — a plan for who should help plan.
+
+## Task
+<github-issue>
+**Outcome**: A structured reference document exists that gives LLMs (and developers) the context needed to operate on WRL — D1 schema, API routes, KV namespaces, R2 buckets, env vars, and wrangler config — so that AI-assisted development sessions don't start with 10 minutes of codebase archaeology.
+
+**Success criteria**:
+- Document covers: D1 tables and columns, all API routes with methods, KV/R2 namespace names and purposes, environment variables and secrets (names only, not values), wrangler.toml bindings
+- Clear separation between dev-only internals and public API surface
+- Document lives in a location discoverable by LLMs (e.g., `llms.txt`, `CLAUDE.md` reference, or `docs/`)
+- Accurate against current codebase (not stale)
+
+**Scope**:
+- In: D1 schema, API routes, bindings (KV, R2, DO), env vars, worker config
+- Out: Public-facing API documentation (already on docs site), operational runbooks, architecture narratives
+</github-issue>
+
+## Working Directory
+/Users/ben/github/benpeter/web-resource-ledger/.claude/worktrees/snuggly-watching-perlis
+
+## External Skill Discovery
+Before analyzing the task, scan for project-local skills. If skills are
+discovered, include an "External Skill Integration" section in your meta-plan.
+
+Discovered skills:
+- ops-runbook: WRL operational procedures — tenant management, D1 queries, secret rotation, Coralogix, Resend, Stripe, captures, deploys. Classification: LEAF (operational reference, not orchestration). Not directly relevant to this task but may contain useful D1/binding references.
+
+## Instructions
+1. Read relevant files to understand the codebase context
+2. The external skill discovery is complete (see above)
+3. Analyze the task against your delegation table
+4. Identify which specialists should be CONSULTED FOR PLANNING (not execution — planning)
+5. For each specialist, write a specific planning question
+6. Return the meta-plan in the structured format
+7. Write your complete meta-plan to `/var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-Y7yIa9/llm-developer-reference/phase1-metaplan.md`

--- a/docs/history/nefario-reports/2026-03-26-043000-llm-developer-reference/phase1-metaplan.md
+++ b/docs/history/nefario-reports/2026-03-26-043000-llm-developer-reference/phase1-metaplan.md
@@ -1,0 +1,68 @@
+## Meta-Plan
+
+### Planning Consultations
+
+#### Consultation 1: Document Structure and LLM Discoverability
+- **Agent**: ai-modeling-minion
+- **Planning question**: What is the optimal format, structure, and placement for an LLM-consumable developer reference document? Should this be an `llms.txt`, a `CLAUDE.md` rules file, a standalone markdown doc in `docs/`, or something else? Consider: how LLMs discover context (CLAUDE.md includes, `.claude/rules/`, `docs/` scans), token budget constraints (the document needs to fit in context windows without truncation), and the separation between "always loaded" reference (rules files) vs "on-demand" reference (docs). The codebase already has `.claude/rules/wrl-domain-ids.md`, `.claude/rules/wrl-urls.md`, and `.claude/rules/wrl-keys-cache.md` as compact reference snippets -- should this new document follow that pattern or take a different approach?
+- **Context to provide**: Current `.claude/rules/` files, CLAUDE.md structure, the scope of information to include (D1 schema with 16 migrations, ~50+ API routes, 6+ bindings, 12+ secrets, queue architecture, cron triggers)
+- **Why this agent**: This is fundamentally about prompt engineering and LLM context design. The document's primary consumer is LLMs in future development sessions, so its format, density, and discoverability are AI-modeling concerns.
+
+#### Consultation 2: API Surface Extraction Strategy
+- **Agent**: api-spec-minion
+- **Planning question**: The codebase has both an `openapi.yaml` (public API spec) and internal routes (admin, account, auth, billing, notifications, UI) that are not in the OpenAPI spec. How should the internal reference document represent the full route table vs. the public API surface? Should we extract route information programmatically from `src/index.js` (the routes array is machine-readable), reference the existing `openapi.yaml` for public routes, or document everything in a flat table? What level of detail per route (method, path, auth type, rate limit group) is useful for developer context without duplicating the OpenAPI spec?
+- **Context to provide**: `src/index.js` routes array (lines 64-124), `openapi.yaml`, the distinction between public API (captures, verify, signing, webhooks, schedules) and internal routes (admin, account, auth, billing, notifications, UI)
+- **Why this agent**: Expertise in API surface documentation, avoiding spec drift, and knowing what level of route detail is useful vs. redundant when an OpenAPI spec already exists.
+
+#### Consultation 3: Data Layer Documentation
+- **Agent**: data-minion
+- **Planning question**: The D1 schema spans 16 migrations. What is the most maintainable way to document the current schema state in a reference document? Options: (a) a generated "current state" table list extracted from the migrations, (b) a hand-written summary of tables with key columns and relationships, (c) a script that queries `PRAGMA table_info` from a local D1 database. Also: should KV key patterns (the `kv.js` module likely defines key naming conventions) and R2 object key patterns be documented alongside the schema, or separately?
+- **Context to provide**: The 16 migration files in `migrations/`, `src/db.js` (the data access layer), `src/kv.js`, wrangler.toml bindings
+- **Why this agent**: Database schema documentation and data model representation are core data-minion concerns. They'll know what schema details are load-bearing for developers vs. noise.
+
+### Cross-Cutting Checklist
+
+- **Testing**: No. This task produces a reference document, not executable code or configuration. No tests needed.
+- **Security**: No. The document explicitly excludes secret values (names only). However, the executing agent must be careful not to accidentally include secret values from wrangler.toml or `.secrets`. This is a simple instruction, not a planning consultation.
+- **Usability -- Strategy**: Include. **Planning question for ux-strategy-minion**: This document serves two distinct user journeys: (1) an LLM starting a development session and needing codebase orientation, and (2) a human developer looking up a binding name or route. Should the document be optimized for sequential reading (narrative) or random access (tables/lists)? Are there information hierarchy decisions (what goes first, what's most frequently needed) that would reduce the "10 minutes of codebase archaeology" the issue describes?
+- **Usability -- Design**: No. No UI components or visual interfaces are produced.
+- **Documentation**: Include. **Planning question for software-docs-minion**: Where should this document live relative to the existing documentation structure (`docs/`, `.claude/rules/`, `CLAUDE.md` references)? The project already has `docs/mcp.md`, `OPERATIONS.md`, `.claude/rules/` snippets, and the `docs/operations/` directory. What is the right home for a developer reference that is primarily LLM-consumed but also human-readable? Should it cross-reference or replace any existing documentation?
+- **Observability**: No. No runtime components are produced.
+
+### Notable Exclusions
+
+- **iac-minion**: The wrangler.toml is being documented, not modified. No infrastructure changes are in scope.
+- **security-minion**: The document lists secret names only (not values) and doesn't create new attack surface. A simple "no values" instruction to the executing agent is sufficient.
+- **devx-minion**: While this document improves the developer experience, the DX concern here is about content and placement (covered by ai-modeling-minion and ux-strategy-minion), not CLI design or SDK ergonomics.
+
+### Anticipated Approval Gates
+
+1. **Document structure and placement decision** (MUST gate): Before writing the actual content, the document's format (single file vs. split), location (`.claude/rules/` vs. `docs/` vs. root), and scope boundaries need approval. This is hard to reverse (moving a document after it's referenced from CLAUDE.md and habits form) and all content tasks depend on it. This gate consolidates the recommendations from ai-modeling-minion, software-docs-minion, and ux-strategy-minion.
+
+No other gates anticipated. Once structure is decided, the content is largely mechanical extraction from the codebase -- low ambiguity, easy to revise.
+
+### Rationale
+
+This task is primarily about **information architecture for LLM consumption**. The core question is not "what information exists" (it's all in the codebase) but "how to structure and place a reference document so LLMs and developers find it efficiently." Three specialists bring distinct expertise:
+
+- **ai-modeling-minion** understands how LLMs consume context and what document formats work best in AI-assisted development workflows
+- **api-spec-minion** knows how to document API surfaces without creating drift against existing specs
+- **data-minion** knows how to represent database schemas concisely and what details matter for development context
+
+The cross-cutting consultations (ux-strategy-minion for information hierarchy, software-docs-minion for placement in the docs ecosystem) round out the planning. The actual content extraction is mechanical and can be done by a single agent during execution.
+
+### Scope
+
+**In scope**: Creating a structured reference document covering D1 tables/columns, all API routes with methods, KV/R2 namespace names and purposes, environment variables and secrets (names only), wrangler.toml bindings (queues, rate limiters, browser, cron triggers), and clear separation between public API surface and dev-only internals.
+
+**Out of scope**: Public-facing API documentation (already on docs site via OpenAPI), operational runbooks (already in OPERATIONS.md and ops-runbook skill), architecture narratives (covered by evolution logs), modifying any existing code or configuration.
+
+### External Skill Integration
+
+#### Discovered Skills
+| Skill | Location | Classification | Domain | Recommendation |
+|-------|----------|---------------|--------|----------------|
+| ops-runbook | `.claude/skills/ops-runbook` | LEAF | Operational procedures | Not used in planning. May be referenced by executing agent to avoid duplicating operational content. |
+
+#### Precedence Decisions
+No precedence conflicts. The ops-runbook skill covers operational procedures (how to do things), while this task produces a structural reference (what exists). No overlap.

--- a/docs/history/nefario-reports/2026-03-26-043000-llm-developer-reference/phase2-ai-modeling-minion.md
+++ b/docs/history/nefario-reports/2026-03-26-043000-llm-developer-reference/phase2-ai-modeling-minion.md
@@ -1,0 +1,103 @@
+## Domain Plan Contribution: ai-modeling-minion
+
+### Recommendations
+
+**Placement: `docs/internals.md` -- not `.claude/rules/`**
+
+The existing `.claude/rules/` files are 4-12 lines each and serve as "always loaded" behavioral directives -- things the LLM must know on every request regardless of task (URLs, domain IDs, credential locations). They work precisely because they are tiny and unconditional.
+
+The proposed reference document is fundamentally different: it is a large factual lookup (D1 schema with ~10 tables, 50+ routes, 12+ secrets, 6 queue configurations, 3 cron triggers). Loading all of this into every conversation unconditionally would waste ~2,000-3,000 tokens on sessions that never touch the database or routing layer. That is the wrong tradeoff.
+
+The right placement is `docs/internals.md` -- an on-demand reference that LLMs and developers pull in when they need it. Claude Code agents can read it with a single tool call when they encounter a task involving schema, routes, or bindings. The file is discoverable via a one-line pointer in `.claude/rules/`.
+
+**Add a pointer rule file: `.claude/rules/wrl-internals-ref.md`**
+
+A compact (3-5 line) rules file that tells the LLM where to find the reference:
+
+```
+For WRL internals (D1 schema, API routes, bindings, secrets, queues, crons),
+read `docs/internals.md`. Always consult it before modifying database queries,
+adding routes, changing env vars, or touching queue/cron configuration.
+```
+
+This pattern is optimal because:
+1. The pointer costs ~40 tokens and is always loaded -- negligible overhead
+2. The full reference is loaded only when relevant -- saves ~2,500 tokens on unrelated tasks
+3. The LLM knows *where* to look without needing to grep the codebase
+4. The document can grow without bloating the always-loaded context budget
+
+**Do NOT use `llms.txt`**
+
+`llms.txt` is a convention for external discovery (placed at website root for crawlers). This is an internal development reference. Using `llms.txt` would be semantically wrong and would not integrate with Claude Code's context loading machinery (CLAUDE.md, `.claude/rules/`).
+
+**Document structure: dense tables over prose**
+
+LLMs parse tables faster and more accurately than prose paragraphs. The document should be structured as:
+
+1. **D1 Schema** -- One table per DB table: column name, type, constraints, notes. Not raw DDL (too verbose and forces the LLM to parse SQL). Not migration-by-migration (forces the LLM to mentally apply diffs). A single consolidated "current state" view.
+
+2. **API Routes** -- Table with columns: Method, Path, Auth, Handler file, Brief description. Grouped by domain (captures, admin, account, webhooks, schedules, billing, auth, notifications, public). Regex patterns simplified to readable path templates (e.g., `/v1/captures/:captureId` not the regex).
+
+3. **Bindings & Environment** -- Table listing each wrangler binding: name, type, resource, notes. Separate section for secrets (name, how to set, what it's for) and vars (name, value/source, purpose).
+
+4. **Queue Architecture** -- Table: queue name, binding, max_batch_size, max_retries, DLQ, max_concurrency, handler function. One row per queue.
+
+5. **Cron Triggers** -- Table: expression, handler, purpose.
+
+6. **KV Key Patterns** -- Table: key prefix/pattern, purpose, TTL.
+
+7. **R2 Object Key Patterns** -- Table: key format, content type, when written.
+
+Each section should have a 1-2 sentence intro and then a table. No filler, no tutorials, no "getting started" framing. This is a lookup document, not a guide.
+
+**Token budget estimate**
+
+Based on the scope:
+- D1 schema (10 tables, ~60 columns): ~800 tokens as tables
+- API routes (~50 routes): ~600 tokens as a table
+- Bindings/secrets/vars (~25 entries): ~400 tokens
+- Queues (6 queue pairs): ~200 tokens
+- Crons, KV patterns, R2 patterns: ~200 tokens
+- Section headers and intros: ~200 tokens
+
+Total: ~2,400 tokens. Well within a single context window read. Under 3K tokens keeps it efficient even if loaded on every call (though the pointer pattern avoids that).
+
+**Maintenance: generation over authoring**
+
+The document should be generated from source files (wrangler.toml, migrations/*.sql, src/index.js route table) rather than hand-authored. A script (`scripts/generate-internals.sh` or similar) can parse these sources and produce the markdown. This prevents drift -- the single biggest risk for reference docs. The generation script itself serves as documentation of where each fact comes from.
+
+Alternatively, if a generation script is too heavy for MVP, include a "Last verified" date at the top and a checklist comment in wrangler.toml / migrations / index.js reminding developers to update `docs/internals.md` when those files change.
+
+### Proposed Tasks
+
+1. **Create consolidated D1 schema view** -- Read all 16 migrations, mentally apply them in order, produce a single "current state" table set. This is the hardest task because migrations may ALTER, DROP, or CREATE tables.
+
+2. **Extract and format API route table** -- Parse the `routes` array in `src/index.js`, map each regex to a readable path template, identify auth requirements from the fetch handler logic, and note the handler file.
+
+3. **Document bindings, secrets, and vars** -- Consolidate from wrangler.toml `[vars]`, secret comments, and binding declarations into a single reference table.
+
+4. **Document queue architecture** -- Extract from wrangler.toml queue producer/consumer blocks.
+
+5. **Document cron triggers and KV/R2 key patterns** -- Extract crons from wrangler.toml, grep for KV key patterns in src/, grep for R2 put/get patterns in src/.
+
+6. **Write `docs/internals.md`** -- Assemble all sections into the final document.
+
+7. **Create `.claude/rules/wrl-internals-ref.md`** -- The compact pointer file.
+
+8. **Evaluate generation script feasibility** -- Decide whether an automated generation approach is worth the investment now or should be deferred to the backlog.
+
+### Risks and Concerns
+
+1. **Staleness is the primary risk.** A reference document that falls out of sync with the code is worse than no reference document -- it actively misleads the LLM. Mitigation: either a generation script or a "last verified" date with explicit review triggers. A CI check that flags `docs/internals.md` for review when wrangler.toml or migrations change would be ideal but may be over-engineering for now.
+
+2. **Migration consolidation errors.** Manually applying 16 migrations to produce a current schema view is error-prone. The implementer should validate the consolidated schema against a live D1 instance (`wrangler d1 execute wrl-metadata-staging --command "SELECT sql FROM sqlite_master WHERE type='table'"`) rather than relying on mental application of migration diffs.
+
+3. **Route table completeness.** The route array in index.js has ~50 entries. Missing a route or mischaracterizing its auth model would be a silent error. Validation: the final route count in the doc should match `routes.length` in index.js.
+
+4. **Over-documentation.** Adding too much detail (full column constraints, exact regex patterns, implementation notes) inflates the token count without proportional value. The document should answer "what exists and where" not "how it works internally." Keep it under 3K tokens.
+
+5. **Token budget creep.** If the document grows beyond ~3K tokens over time, it should be split into domain-specific files (e.g., `docs/internals/schema.md`, `docs/internals/routes.md`) with individual pointer rules. But start with one file -- premature splitting adds navigation overhead.
+
+### Additional Agents Needed
+
+None. This is primarily a data extraction and formatting task. The codebase-minion (or equivalent implementation agent) can read the source files and produce the document. No security, frontend, infrastructure, or MCP expertise is needed.

--- a/docs/history/nefario-reports/2026-03-26-043000-llm-developer-reference/phase2-api-spec-minion.md
+++ b/docs/history/nefario-reports/2026-03-26-043000-llm-developer-reference/phase2-api-spec-minion.md
@@ -1,0 +1,109 @@
+# Domain Plan Contribution: api-spec-minion
+
+## Recommendations
+
+### 1. Use a single flat route table, not two separate views
+
+The reference document should have **one complete route table** covering all routes from `src/index.js` lines 64-124, plus the two special-case routes handled before the regex router (`/mcp` at line 494, CORS preflight for `/v1/captures` at line 511). Each route gets a row with these columns:
+
+| Column | Why it matters for developers/LLMs |
+|--------|-------------------------------------|
+| Method | Required for any API call |
+| Path | The URL pattern (use OpenAPI-style `{param}` syntax, not regex) |
+| Auth type | One of: `api-key`, `admin-key`, `session`, `signature` (Stripe), `none` |
+| Rate limit group | Maps to `RATE_LIMITS` object in `rate-limits.js` (capture/verify/admin/auth/account/none) |
+| Surface | `public-api`, `admin`, `account`, `auth`, `billing`, `notification`, `ui`, `infra` |
+| OpenAPI | `yes` or blank -- whether the route is documented in `openapi.yaml` |
+
+This avoids duplication with `openapi.yaml` because the table only carries **routing metadata** (auth, rate limits, surface classification) -- not request/response schemas. For schema details, the document should point to `openapi.yaml` with a one-liner like: "For request/response schemas, see `openapi.yaml`."
+
+### 2. Do NOT duplicate OpenAPI content into the reference doc
+
+The `openapi.yaml` is 5,197 lines and covers 23 path items with full request/response schemas. Copying any of that into the reference doc creates drift. The reference doc should:
+
+- State that `openapi.yaml` is the source of truth for public API schemas
+- List which routes are NOT in `openapi.yaml` (these are the ones that need extra attention)
+- For routes missing from the spec, provide a one-line description of purpose and auth mechanism
+
+### 3. Extract route data programmatically from `src/index.js`
+
+The routes array (lines 64-124) is machine-readable: each entry is `[method, regex, handler]`. A simple script can extract this and cross-reference against `openapi.yaml` paths to identify gaps. This should be done once during document creation -- not as ongoing automation (the reference doc is a snapshot, and the routes array changes infrequently).
+
+### 4. Document the auth model in a dedicated section
+
+The fetch handler (lines 468-600+) implements a layered auth model that is NOT fully captured by the routes array:
+
+- **Admin routes** (`/v1/admin/*`): `verifyAdminKey()` checked in fetch handler before route dispatch
+- **Account/billing routes** (`/v1/account/*`, `/v1/billing/*`): `verifySession()` checked in fetch handler, with ToS enforcement and CSRF checks
+- **Auth routes** (`/auth/*`): No auth required, but rate-limited via `AUTH_RATE_LIMITER`
+- **Notification action routes** (`/v1/notifications/unsubscribe`, `/v1/notifications/verify-email`): No auth, rate-limited via `AUTH_RATE_LIMITER`
+- **Capture/read routes** (`/v1/captures`, etc.): Dual auth via `verifyAuth()` -- session cookie OR API key
+- **Verify routes** (`/v1/verify/*`, `/.well-known/*`): No auth required
+- **Stripe webhook** (`/v1/stripe/webhook`): Signature verification internal to handler
+- **MCP** (`/mcp`): Handled before router, own CORS
+
+This auth routing logic is critical context for any developer touching these routes and is not documented anywhere else.
+
+### 5. Document the verify subdomain restriction
+
+The fetch handler (lines 478-490) restricts `verify.webresourceledger.com` and `verify-staging.webresourceledger.com` to only verification-related paths. This is an important routing constraint that belongs in the reference doc.
+
+### 6. Rate limit details: reference the constants, don't duplicate them
+
+The reference doc should show the rate limit groups and their default values from `rate-limits.js` (capture: 10/60s, verify: 60/60s, admin: 5/60s, auth: 20/60s, account: 30/60s) plus the binding ceiling (100) and IP guard limits. But note these are per-tenant-overridable via `tenantConfig.rateLimit`.
+
+## Proposed Tasks
+
+### Task 1: Extract complete route table
+- Parse `src/index.js` routes array (lines 64-124) plus special-case routes (`/mcp`, CORS preflight)
+- Convert regex patterns to human-readable paths (e.g., `cap_[a-f0-9]{32}` -> `{captureId}`)
+- Cross-reference each route against `openapi.yaml` paths to mark coverage
+- Determine auth type for each route by reading the fetch handler auth logic (lines 526-600+)
+- Determine rate limit group using `getRateLimitGroup()` function (lines 136-146)
+
+### Task 2: Write the route table section
+- Flat markdown table with columns: Method, Path, Auth, Rate Limit Group, Surface, In OpenAPI
+- Group rows by surface area (public API first, then admin, account, auth, billing, notification, UI, infra)
+- Add a note pointing to `openapi.yaml` for request/response schemas
+
+### Task 3: Write the auth model section
+- Document the four auth mechanisms: API key, admin key, session cookie, dual auth
+- Document the fetch handler's auth dispatch logic (which prefixes trigger which auth)
+- Document ToS enforcement gate on account routes
+- Document CSRF checking on session-authenticated mutations
+- Document the verify subdomain path restriction
+
+### Task 4: Write the rate limiting section
+- Table of rate limit groups with default limits from `RATE_LIMITS`
+- Note the binding ceiling (100) and IP guard limits
+- Note per-tenant override mechanism via `tenantConfig.rateLimit`
+- Map which Cloudflare rate limiter bindings correspond to which groups
+
+## Risks and Concerns
+
+1. **Routes missing from OpenAPI spec**: The following routes in `src/index.js` are NOT in `openapi.yaml` and have no public schema documentation:
+   - `/ui` (dashboard)
+   - `/favicon.ico`
+   - `/v1/admin/tenants/{tenantId}/config` (GET, PUT)
+   - `/v1/admin/cache/purge` -- wait, this IS in the spec
+   - `/v1/account/first-key` (GET), `/v1/account/first-key/ack` (POST)
+   - `/v1/account/keys` (GET, POST), `/v1/account/keys/{keyHash}` (DELETE)
+   - `/v1/account/tos` (POST)
+   - `/v1/account/settings` (GET, PATCH)
+   - `/v1/account/notifications/resend-verification` (POST)
+   - `/v1/notifications/verify-email` (GET, POST)
+   - `/v1/billing/checkout` (POST), `/v1/billing/portal` (POST)
+   - `/v1/stripe/webhook` (POST)
+   - `/auth/login`, `/auth/callback`, `/auth/logout`, `/auth/session`
+   - `/mcp`
+   - `/v1/captures/{captureId}/diff/{targetId}` -- wait, this IS in the spec
+
+   These gaps are fine for the reference doc (we document them in the route table) but represent a real spec gap for anyone trying to use the account/billing/auth flows programmatically.
+
+2. **Drift risk**: The route table in the reference doc will drift from `src/index.js` over time. Mitigation: add a comment in the reference doc noting the source file and line range, so developers know where to check for updates. Do NOT try to automate this -- the doc is a snapshot.
+
+3. **Auth logic complexity**: The auth model is implemented across the fetch handler, `verifyAuth()`, `verifySession()`, and individual handlers. The reference doc should document the fetch-handler-level gates but note that some handlers do additional auth checks internally (e.g., Stripe webhook signature verification).
+
+## Additional Agents Needed
+
+None -- the route table extraction and auth model documentation are straightforward reading tasks that don't require additional specialist knowledge. The api-spec-minion's contribution here is the structural recommendation (flat table, no schema duplication, auth model as separate section), not the actual writing of the reference doc.

--- a/docs/history/nefario-reports/2026-03-26-043000-llm-developer-reference/phase2-data-minion.md
+++ b/docs/history/nefario-reports/2026-03-26-043000-llm-developer-reference/phase2-data-minion.md
@@ -1,0 +1,169 @@
+# Domain Plan Contribution: data-minion
+
+## Recommendations
+
+### Schema documentation approach: Option (b) with a twist
+
+**Recommendation: hand-written current-state table summary, derived from migrations but maintained as a standalone section.** Neither (a) nor (c) is the right fit:
+
+- **(a) Generated from migrations** -- fragile. The 16 migrations use ALTER TABLE ADD COLUMN extensively (0005 through 0016). Parsing ALTER TABLE statements from raw SQL to reconstruct current state requires a purpose-built script that must handle CHECK constraints, DEFAULT values, partial indexes, and D1-specific quirks (no CHECK on ALTER TABLE ADD COLUMN). The maintenance burden of the script exceeds the maintenance burden of the document.
+
+- **(c) PRAGMA table_info from local D1** -- accurate but incomplete. PRAGMA table_info returns column names and types but loses CHECK constraints, index definitions, JSON column semantics, and the business logic annotations that make the schema useful to an LLM. It also requires a running D1 instance or wrangler dev, adding a tooling dependency to doc generation.
+
+- **(b) Hand-written summary** -- the right call, with structure. The schema has 10 active tables (share_tokens was dropped in 0013). A hand-written summary can include what PRAGMA cannot: which TEXT columns are JSON, what the JSON shapes contain, which columns have application-layer-only constraints (tier, billing_status, quarantined), and the ID format conventions. This is exactly the kind of context that makes an LLM effective.
+
+**Key structural decision**: organize tables by domain, not alphabetically. Group them as:
+1. Core (tenants, captures, api_keys, signing_keys)
+2. Billing (usage_counters -- with Stripe metering columns)
+3. Auth (github_users, sessions)
+4. Scheduling (schedules)
+5. Webhooks (webhooks)
+6. Notifications (notification_preferences, notification_sent)
+7. Threat intelligence (threat_checks)
+
+For each table, document: columns with types, constraints (including app-layer-only ones), indexes, FK relationships, and ID format conventions.
+
+### KV and R2 patterns: document alongside schema, not separately
+
+**KV and R2 key patterns belong in the same reference document, in their own sections immediately after the D1 schema.** Rationale:
+
+- An LLM operating on WRL needs to understand the full data topology. Separating storage layers into different documents forces the LLM to cross-reference and increases the chance of missing context.
+- The storage layers are tightly coupled: a capture's D1 row references R2 keys in its `artifacts` and `wacz` JSON columns; KV rate limit counters reference the same `tenantId` used as the D1 primary key.
+- The total volume is small enough for a single document -- 10 D1 tables, 4 KV key patterns, 2 R2 key patterns.
+
+## Current State: Storage Layer Analysis
+
+### D1 Tables (10 active, 1 dropped)
+
+| Table | Rows | Purpose | ID Format |
+|-------|------|---------|-----------|
+| tenants | low (hundreds) | Tenant registry, tier, billing, eIDAS config | `[a-z0-9_-]{1,64}` |
+| captures | high (millions) | Capture lifecycle, artifacts refs, threat state | `cap_` + 32 hex (36 chars) |
+| api_keys | low | Hashed API keys with scopes | SHA-256 hex (64 chars) |
+| signing_keys | tiny (single digits) | Archived Ed25519 public keys | First 8 hex of SHA-256 |
+| usage_counters | low | Monthly billing counters per tenant | Composite PK: (tenant_id, period YYYY-MM) |
+| webhooks | low | Outbound webhook registrations | `whk_` + 32 hex (36 chars) |
+| github_users | low | GitHub OAuth identity to tenant mapping | GitHub numeric user ID |
+| sessions | moderate | Server-side cookie sessions (hash-before-store) | SHA-256 hex (64 chars) |
+| schedules | low-moderate | Recurring capture cron definitions | `sch_` + 32 hex (36 chars) |
+| notification_preferences | low | Per-tenant email + notification toggles | PK: tenant_id |
+| notification_sent | moderate | Dedup log for threshold notifications | Composite PK: (tenant_id, period, event_type) |
+| threat_checks | moderate-high | Audit log of every threat check verdict | AUTOINCREMENT integer |
+| ~~share_tokens~~ | **dropped (0013)** | Was: read-only capture access tokens | -- |
+
+### JSON Columns in D1
+
+These TEXT columns store JSON and are parsed at read time:
+
+| Table.Column | JSON Shape |
+|---|---|
+| tenants.config | Rate limit overrides, settings (nullable) |
+| captures.artifacts | `{ screenshot, screenshotBefore?, html, headers }` -- R2 key strings |
+| captures.wacz | `{ key, bundleHash, size, keyId?, timestampStatus?, qualifiedTimestampStatus? }` |
+| captures.render | Render metadata object |
+| captures.capture_settings | Capture configuration used |
+| captures.change_summary | Scheduled capture diff results |
+| api_keys.scopes | JSON array: `["capture", "read"]` |
+| webhooks.events | JSON array: `["capture.complete", "capture.failed"]` |
+
+### Application-Layer Constraints (not enforced by D1 CHECK)
+
+D1/SQLite ALTER TABLE ADD COLUMN does not support CHECK constraints, so these are validated in `db.js`:
+
+| Column | Valid Values | Constant |
+|---|---|---|
+| tenants.tier | `'free'`, `'pro'` | `VALID_TIERS` |
+| tenants.billing_status | `'active'`, `'grace_period'`, `'blocked'` | `VALID_BILLING_STATUSES` |
+| tenants.eidas_qualified | `0`, `1` | -- |
+| captures.quarantined | `0`, `1` | -- |
+
+### KV Key Patterns (4 patterns)
+
+| Key Pattern | Value | TTL | Purpose | Module |
+|---|---|---|---|---|
+| `rl:{tenantId}:{group}:{windowId}` | Integer counter string | period * 2 | Rate limit sliding window | `kv.js` |
+| `oauth_state:{state}` | JSON: `{ codeVerifier, createdAt }` | 600s (10 min) | PKCE OAuth state | `oauth.js` |
+| `first_key:{tenantId}` | Raw API key string | 3600s (1 hr) | One-time key display after onboarding | `oauth.js` |
+| `stripe_evt:{eventId}` | `'1'` | 604800s (7 days) | Stripe webhook idempotency dedup | `stripe-webhook.js` |
+
+### R2 Object Key Patterns (2 patterns)
+
+| Key Pattern | Content Type | Purpose |
+|---|---|---|
+| `captures/{captureId}/screenshot.png` | image/png | Page screenshot |
+| `captures/{captureId}/screenshot-before.png` | image/png | Pre-consent screenshot (optional) |
+| `captures/{captureId}/rendered.html` | text/html; charset=utf-8 | Rendered HTML snapshot |
+| `captures/{captureId}/headers.json` | application/json | HTTP response headers |
+| `captures/{waczHash}.wacz` | application/wacz+zip | WACZ archive (content-addressed by SHA-256) |
+
+Note: per-capture artifacts use `captureId` as prefix; WACZ files are content-addressed by their SHA-256 hash (not captureId), enabling deduplication.
+
+### Bindings Summary (from wrangler.toml)
+
+| Binding | Type | Resource |
+|---|---|---|
+| `DB` | D1 | wrl-metadata |
+| `BUCKET` | R2 | wrl-captures |
+| `KV` | KV Namespace | Rate limits, OAuth state, ephemeral keys |
+| `BROWSER` | Browser Rendering | Headless browser for captures |
+| `CAPTURE_QUEUE` | Queue Producer | wrl-captures |
+| `CAPTURE_DLQ` | Queue Producer | wrl-captures-dlq |
+| `WEBHOOK_QUEUE` | Queue Producer | wrl-webhooks |
+| `WEBHOOK_DLQ` | Queue Producer | wrl-webhooks-dlq |
+| `EMAIL_QUEUE` | Queue Producer | wrl-emails |
+| `EMAIL_DLQ` | Queue Producer | wrl-emails-dlq |
+| `CAPTURE_RATE_LIMITER` | Rate Limit | 100/60s ceiling per tenant |
+| `VERIFY_RATE_LIMITER` | Rate Limit | 60/60s |
+| `GLOBAL_CAPTURE_LIMITER` | Rate Limit | 200/60s across all tenants |
+| `ADMIN_RATE_LIMITER` | Rate Limit | 5/60s |
+| `CAPTURE_IP_GUARD` | Rate Limit | 50/60s per IP |
+| `AUTH_RATE_LIMITER` | Rate Limit | 10/60s |
+
+## Proposed Tasks
+
+### Task 1: Write the D1 schema section of the reference document
+- Produce a hand-written current-state table listing for all 10 active tables
+- Include columns, types, constraints (both D1 CHECK and application-layer), indexes, and FK relationships
+- Group tables by domain (Core, Billing, Auth, Scheduling, Webhooks, Notifications, Threat Intel)
+- Document all JSON column shapes with field-level detail
+- Document ID format conventions (`cap_`, `whk_`, `sch_`, SHA-256 hex patterns)
+- Call out the `quarantined` virtual status mapping (DB stores `status='complete' + quarantined=1`, API returns `status:'quarantined'`)
+
+### Task 2: Write the KV key patterns section
+- Document all 4 KV key patterns with format, value shape, TTL, and owning module
+- Note that KV is used only for ephemeral/atomic operations -- all persistent metadata is in D1
+- Mention the TENANT_ID_RE regex as the tenant ID format constraint shared across KV and D1
+
+### Task 3: Write the R2 object key patterns section
+- Document both key patterns (per-capture prefix and content-addressed WACZ)
+- Note content-type metadata set on R2 objects
+- Note that R2 keys are referenced from D1 JSON columns (captures.artifacts, captures.wacz.key)
+- Call out that WACZ keys use SHA-256 content addressing, not captureId
+
+### Task 4: Write the bindings and env vars section
+- Document all wrangler.toml bindings (D1, R2, KV, Browser, Queues, Rate Limiters)
+- List all secrets (set via `wrangler secret put`) with their purpose
+- List all [vars] with their purpose
+- Distinguish production vs staging resource names
+
+### Task 5: Validate the reference against source code
+- After writing, grep `src/db.js` exported functions to ensure every table operation is represented
+- Verify KV key patterns against `src/kv.js`, `src/oauth.js`, `src/stripe-webhook.js`
+- Verify R2 patterns against `src/capture.js` and `src/index.js`
+- Confirm no storage patterns were missed
+
+## Risks and Concerns
+
+1. **Schema drift**: The hand-written summary will drift from migrations over time. Mitigate by adding a comment at the top of the schema section noting the last migration it reflects (currently 0016_email_verification). Future migration authors should update the reference doc as part of the migration PR.
+
+2. **JSON column shapes are undocumented in migrations**: The shapes of `artifacts`, `wacz`, `render`, `capture_settings`, and `change_summary` are defined only by the code that writes them (`capture.js`, `db.js`). If these shapes change, the reference doc must be updated manually. Consider adding a validation step to CI that checks the reference doc's "last migration" marker against the actual migration count.
+
+3. **Virtual status mapping is a stumbling block**: The `quarantined` status is not a real DB status value -- the DB stores `status='complete'` with `quarantined=1`, and `db.js` maps this to `status:'quarantined'` in the API response. This is a common source of confusion and must be prominently documented.
+
+4. **KV key patterns are scattered across 3 modules**: Unlike D1 (centralized in `db.js`), KV usage is split across `kv.js`, `oauth.js`, and `stripe-webhook.js`. There is no single module that defines all KV key patterns. The reference doc becomes the single source of truth for KV patterns, which is a risk if new KV keys are added without updating the doc.
+
+5. **Content-addressed WACZ vs captureId-prefixed artifacts**: The two different R2 key strategies (captureId prefix for screenshots/HTML vs SHA-256 hash for WACZ) can confuse LLMs into assuming all R2 lookups use the captureId. The doc must make this distinction explicit.
+
+## Additional Agents Needed
+
+None -- the data architecture analysis is complete. The document writer (likely the orchestrating agent) can use this analysis directly. If the reference doc needs to cover API routes in detail, the **api-design-minion** would contribute that section, but that is a separate planning question.

--- a/docs/history/nefario-reports/2026-03-26-043000-llm-developer-reference/phase2-software-docs-minion.md
+++ b/docs/history/nefario-reports/2026-03-26-043000-llm-developer-reference/phase2-software-docs-minion.md
@@ -1,0 +1,74 @@
+## Domain Plan Contribution: software-docs-minion
+
+### Recommendations
+
+**Location: `docs/INTERNALS.md`**
+
+The document should live at `docs/INTERNALS.md` -- a single, flat file in the existing `docs/` directory. Here is the reasoning:
+
+1. **Not `.claude/rules/`**. Rules files are auto-loaded into every Claude Code conversation and must be tiny (the existing five files total 41 lines). A comprehensive internals reference covering D1 schema, API routes, KV namespaces, R2 buckets, env vars, and wrangler config will be 200-400 lines. Auto-loading that into every conversation wastes context on tasks that don't need it (CSS changes, docs edits, CI fixes). Rules files should remain compact pointers and behavioral directives, not reference material.
+
+2. **Not `CLAUDE.md`**. Already 112 lines of project philosophy and process rules. Adding technical reference here would blur the distinction between "how to work on this project" (CLAUDE.md) and "how this project works internally" (the new doc). These are different audiences even when the audience is an LLM.
+
+3. **Not `docs/operations/`**. That directory contains runbooks -- procedural documents for incident response. An internals reference is structural, not procedural.
+
+4. **Not a new subdirectory like `docs/reference/`**. The project has one reference doc to write. Creating a directory for a single file violates YAGNI and the Helix Manifesto's lean-and-mean principle. If more reference docs accumulate later, refactor then.
+
+5. **`docs/INTERNALS.md` specifically** because:
+   - `docs/` is where human-and-LLM-readable project documentation already lives (`mcp.md`, `audit-log-schema.md`, `style-guide.md`, `backlog.md`)
+   - The `INTERNALS` name signals "system guts" clearly to both humans and LLMs
+   - Uppercase filename follows the project's convention for important root-level docs (`OPERATIONS.md`, `CLAUDE.md`) while the `docs/` location keeps it out of the repo root clutter
+   - LLMs can be pointed to it via a one-line addition to `.claude/rules/` (see proposed tasks below)
+
+**Cross-referencing strategy:**
+
+- Add a one-line `.claude/rules/wrl-internals.md` file that tells Claude Code where to find the internals doc. Something like: "For D1 schema, API routes, KV/R2 bindings, and env vars, see `docs/INTERNALS.md`." This gives LLMs the pointer without loading the full reference into every conversation.
+- `OPERATIONS.md` should get a "See also" line pointing to `docs/INTERNALS.md` for binding/schema details. No content duplication.
+- `docs/mcp.md` needs no changes -- it documents the MCP server for external consumers, not internal structure.
+
+**What this document should NOT duplicate:**
+
+- API endpoint behavior and request/response schemas -- that is `openapi.yaml` (5197 lines, authoritative)
+- Operational procedures -- that is `OPERATIONS.md`
+- Audit log event taxonomy -- that is `docs/audit-log-schema.md`
+- Domain IDs, URLs, key cache locations -- those stay in `.claude/rules/` (auto-loaded)
+
+The internals doc should reference these by path rather than repeating their content. Single source of truth, always.
+
+**Document structure recommendation:**
+
+The document should be organized by resource type, not by feature. LLMs and developers reach for this doc when they need to answer "what is binding X?" or "what columns does table Y have?" -- lookup queries, not narrative reading. Flat sections with tables work better than prose for this use case.
+
+Suggested sections:
+1. One-paragraph purpose statement
+2. D1 schema (tables, columns, types, indexes, constraints)
+3. KV namespaces (binding names, key patterns, value shapes, TTLs)
+4. R2 buckets (binding names, object key patterns, what gets stored)
+5. Queue bindings (names, message shapes, consumer behavior)
+6. Environment variables and secrets (name, purpose, where sourced -- not values)
+7. Wrangler config summary (environments, routes, compatibility flags)
+8. API route map (method + path + handler file -- a quick index, NOT duplicating openapi.yaml's detail)
+
+### Proposed Tasks
+
+1. **Create `docs/INTERNALS.md`** -- Extract the structural reference from source code (wrangler.toml, D1 migrations, src/ route handlers, KV/R2 usage patterns). This is the core deliverable. Derive everything from the actual codebase, not from memory or inference.
+
+2. **Create `.claude/rules/wrl-internals.md`** -- A 2-3 line pointer rule telling Claude Code where to find internals. Example: "For D1 schema, KV namespaces, R2 buckets, API routes, env bindings, and wrangler config, read `docs/INTERNALS.md`." This keeps auto-loaded context minimal while ensuring discoverability.
+
+3. **Add cross-reference to `OPERATIONS.md`** -- Insert a one-line "See also" at the top or in the Environments section pointing to `docs/INTERNALS.md` for binding and schema details.
+
+4. **Verify no content duplication** -- After writing, diff the new doc against `OPERATIONS.md`, `docs/audit-log-schema.md`, and `.claude/rules/*.md` to confirm no information is repeated. Where overlap exists, the new doc should reference the authoritative source by path.
+
+### Risks and Concerns
+
+1. **Staleness risk is the primary concern.** D1 schema changes via migrations, wrangler.toml changes via config updates, KV/R2 patterns evolve with features. The document will rot unless there is a maintenance signal. Mitigations: (a) keep the doc tightly scoped to structural facts derivable from source files, so it can be regenerated; (b) note at the top of the doc which source files it was derived from, so reviewers can spot drift.
+
+2. **Over-documentation temptation.** The Helix Manifesto says "lean and mean." The doc should cover structure (what exists and how it's named), not behavior (what happens when you call an endpoint). Behavior is in the code and openapi.yaml. If the implementer starts writing prose about how the capture pipeline works, they've gone too far.
+
+3. **Context window cost.** If the document grows past 400 lines, LLMs loading it consume significant context. The `.claude/rules/` pointer approach mitigates this -- the full doc is only loaded on demand, not auto-injected. But the doc itself should still be as compact as possible: tables over prose, no examples unless they clarify ambiguity.
+
+4. **Duplication with openapi.yaml.** The API route map section must be a thin index (method, path, one-line purpose, handler file), not a second API spec. If someone adds response schemas or parameter details to INTERNALS.md, it will diverge from openapi.yaml immediately.
+
+### Additional Agents Needed
+
+None. The implementation requires reading source code (wrangler.toml, migrations, src/ files) and writing a single Markdown file. A backend-focused implementation minion can handle this without additional specialist input. The software-docs-minion's contribution is the structural decision (where it lives, what it contains, what it doesn't) -- that work is done in this planning document.

--- a/docs/history/nefario-reports/2026-03-26-043000-llm-developer-reference/phase2-ux-strategy-minion.md
+++ b/docs/history/nefario-reports/2026-03-26-043000-llm-developer-reference/phase2-ux-strategy-minion.md
@@ -1,0 +1,76 @@
+## Domain Plan Contribution: ux-strategy-minion
+
+### Recommendations
+
+**The core question: narrative vs. random access?**
+
+Random access. Unambiguously. Here is why.
+
+Both user journeys -- LLM orientation and human lookup -- are random-access tasks. Neither consumer reads this document start-to-finish for comprehension. The LLM needs to rapidly locate specific facts (what is the DB binding name? what routes exist? what secrets are required?) to ground its responses. The human developer needs the same facts for the same reason. Narrative prose would force both consumers to parse paragraphs to extract atomic facts, which is pure extraneous cognitive load.
+
+However, "random access" does not mean "dump everything in one flat list." The document needs two structural properties that tables alone do not provide:
+
+1. **A mental model scaffold at the top** -- a short (10-15 line) section that establishes the system shape: "one Worker, one D1 database, one R2 bucket, one KV namespace, three queue pairs, six rate limiters, headless browser binding." This gives both LLMs and humans the gestalt before they dive into specifics. Without this, readers don't know what categories of information to expect, so they can't efficiently skip to what they need. This is the only "narrative" the document needs, and it should be under 200 words.
+
+2. **Consistent, scannable sections with tables** -- each section (D1, API routes, KV, R2, queues, rate limiters, env vars/secrets, cron triggers) follows an identical structure: one-sentence purpose statement, then a table. No paragraphs of explanation. No prose that restates what the table already shows.
+
+**Information hierarchy: what goes first**
+
+The "10 minutes of codebase archaeology" problem has a specific shape. When an LLM starts a WRL session, the questions come in a predictable priority order:
+
+1. **System shape** (the mental model scaffold) -- what am I looking at?
+2. **Bindings and env vars** -- what names do I use in code? This is the most frequent lookup because every code change touches `env.SOMETHING`.
+3. **D1 schema** -- what tables/columns exist? Second most frequent because most features involve database queries.
+4. **API routes** -- what endpoints exist and what auth do they require? Needed when adding or modifying endpoints.
+5. **Queue architecture** -- how does async processing work? Needed less frequently, only when touching capture pipeline or webhooks.
+6. **Rate limiters** -- what limits exist? Rarely needed except when adding new rate-limited endpoints.
+7. **Staging differences** -- how does staging diverge from production? Only needed during deployment or environment-specific debugging.
+
+This ordering follows the frequency-of-access principle: put the most-looked-up information closest to the top. It also follows progressive disclosure -- you don't need to understand queue architecture to make a database change.
+
+**Specific structural recommendations:**
+
+- **Bindings summary table first** after the system overview. A single table mapping every `env.*` binding to its type (D1, KV, R2, Queue, RateLimit, Browser) and purpose. This is the single highest-value artifact in the document -- it answers the question "what is `env.CAPTURE_QUEUE`?" without requiring the reader to search through wrangler.toml.
+- **Secrets table separate from vars table.** Secrets (set via `wrangler secret put`) and vars (in wrangler.toml `[vars]`) have fundamentally different operational characteristics. Mixing them creates confusion about what is checked in vs. what must be provisioned.
+- **Route table should include auth method.** Each route should show method, path pattern, auth requirement (API key, admin key, session, unauthenticated), and source file. This eliminates the need to read index.js to understand route-level auth.
+- **D1 schema as CREATE TABLE statements, not prose.** LLMs parse SQL faster than English descriptions of tables. Include the current schema as a consolidated DDL block (derived from applying all migrations in order), not as a list of migration files. Migration files tell you history; the reference document should tell you current state.
+- **No staging duplication.** Don't repeat the entire structure for staging. Instead, have one "Staging Differences" section at the bottom that lists only what differs (database IDs, bucket names, queue names, rate limiter namespace IDs, env var overrides). Everything not listed is identical.
+
+**Anti-patterns to avoid:**
+
+- **Don't include "how it works" explanations.** This is a reference document, not an architecture guide. "The capture pipeline works by..." belongs in architecture docs. The reference doc says: "CAPTURE_QUEUE binding, queue name wrl-captures, max_batch_size 1, DLQ: wrl-captures-dlq."
+- **Don't duplicate wrangler.toml verbatim.** The document should be a curated, scannable extraction of the facts in wrangler.toml, not a copy of it. If someone wants the raw config, they read wrangler.toml. The reference doc adds value by organizing, cross-referencing, and annotating.
+- **Don't include historical context.** No "this was added in phase 0016" or "previously we used X." Reference documents describe current state only.
+- **Don't use deeply nested headings.** Two levels maximum (H2 for sections, H3 for subsections). Deep nesting creates navigation friction in both LLM context windows and human scanning.
+
+### Proposed Tasks
+
+1. **Define the document skeleton.** Write the heading structure and one-sentence purpose for each section, following the hierarchy above. Validate that the section order matches access frequency before filling in content. (This is a UX-strategy-informed constraint for whoever writes the actual content.)
+
+2. **Create a consolidated bindings summary table.** Extract from wrangler.toml: binding name, type, underlying resource name, and one-line purpose. This single table is the highest-ROI artifact.
+
+3. **Generate consolidated current-state DDL.** Apply all 16 migrations in order and produce a single CREATE TABLE block representing current schema. Do not list migrations individually.
+
+4. **Build the route table with auth annotations.** Extract from index.js routes array. Columns: Method, Path, Auth (apiKey/adminKey/session/none), Handler file. Group by domain (captures, admin, account, webhooks, schedules, notifications, billing, auth, system).
+
+5. **Write the secrets vs. vars table.** Two separate tables. Secrets table: variable name, how to provision (`wrangler secret put`), purpose. Vars table: variable name, value (or "env-specific"), purpose.
+
+6. **Write the staging differences section.** Only list divergences from production -- different database IDs, bucket names, queue names, etc. Everything unlisted is identical.
+
+7. **Write the system overview paragraph.** Under 200 words. Establishes the mental model: what this Worker is, what bindings it has, what it does. No architecture deep-dive.
+
+8. **Validate the document against the "fresh session" test.** An LLM agent (or a human unfamiliar with the codebase) should be able to answer these questions by scanning the document in under 30 seconds each: (a) What is the D1 binding name? (b) What auth does POST /v1/captures require? (c) What secrets must be provisioned for a new environment? (d) What queue handles webhook delivery? If any of these require more than a quick table scan, the structure needs adjustment.
+
+### Risks and Concerns
+
+1. **Staleness is the primary risk.** Reference documents that fall out of sync with the code are worse than no document -- they create false confidence. The document must be positioned near the source of truth (in-repo, not in an external wiki) and ideally generated or validated by a script that checks wrangler.toml and migration files. Consider adding a comment at the top: "Last validated against wrangler.toml and migrations/ on YYYY-MM-DD."
+
+2. **Scope creep into architecture documentation.** The temptation will be strong to explain *why* things are configured a certain way. Every "why" sentence is a maintenance burden and a staleness vector. The reference doc should link to architecture docs for context, not contain it.
+
+3. **Over-serving the human consumer at the expense of the LLM consumer.** Humans prefer visual formatting (bold, color, spacing). LLMs prefer dense, unambiguous, machine-parseable structure (tables, consistent formatting, no decorative text). Since LLMs are the primary consumer, optimize for parseability. Tables with consistent column structure. No decorative prose. No "Note:" callouts that break table scanning.
+
+4. **Forgetting to include the route-to-auth mapping.** Based on the codebase, auth logic is split across verifyAuth, verifyApiKey, verifyAdminKey, and verifySession, with different routes using different auth methods. If the route table omits auth requirements, LLMs will still need to read index.js to figure out which auth a new endpoint should use -- defeating the purpose.
+
+### Additional Agents Needed
+
+None. The content extraction is straightforward code-reading work suitable for the implementation agent. The information architecture decisions are covered here. No visual design, accessibility, or specialized domain expertise is needed beyond what the existing agent team provides.

--- a/docs/history/nefario-reports/2026-03-26-043000-llm-developer-reference/phase3-synthesis.md
+++ b/docs/history/nefario-reports/2026-03-26-043000-llm-developer-reference/phase3-synthesis.md
@@ -1,0 +1,269 @@
+# Phase 3: Synthesis -- LLM Developer Reference
+
+## Delegation Plan
+
+**Team name**: llm-developer-reference
+**Description**: Create `docs/INTERNALS.md` -- a dense, table-based reference document covering WRL's D1 schema, API routes, KV/R2 patterns, bindings, secrets, queues, and crons -- plus a `.claude/rules/` pointer file for discoverability.
+
+### Decisions
+
+- **Document location: `docs/INTERNALS.md`**
+  Chosen: `docs/INTERNALS.md` with a pointer in `.claude/rules/wrl-internals.md`
+  Over: Placing the full content in `.claude/rules/` (always-loaded), or using `llms.txt` at repo root
+  Why: All five specialists converged on this. Rules files are 4-12 lines each and auto-loaded into every session; a ~250-line reference doc would waste ~2,500 tokens on sessions that never touch schema/routes. The pointer pattern costs ~40 tokens always-loaded and the full doc is loaded on-demand. `llms.txt` is a web-crawler convention, not applicable to internal dev refs.
+
+- **Schema format: hand-written tables, not DDL blocks**
+  Chosen: Hand-written current-state tables grouped by domain, with JSON column shapes and app-layer constraints documented
+  Over: (a) Raw CREATE TABLE DDL (ux-strategy-minion's suggestion), (b) Auto-generated from migrations
+  Why: data-minion made a compelling case that tables can include what DDL cannot: JSON column shapes, app-layer-only constraints (quarantined, tier, billing_status), ID format conventions, and cross-references to R2 keys. ai-modeling-minion corroborated that LLMs parse annotated tables faster than raw SQL. Auto-generation was rejected because ALTER TABLE parsing across 16 migrations is fragile and the maintenance burden of the script exceeds the doc itself.
+
+- **Route table: single flat table with auth, not grouped sub-tables**
+  Chosen: One flat route table with columns: Method, Path, Auth, Rate Limit Group, Surface
+  Over: Separate tables per domain, or a two-table split (public vs internal)
+  Why: api-spec-minion's flat-table approach is the most scannable. Surface column provides the grouping signal without requiring multiple tables. Auth column answers the most common lookup question without reading index.js. OpenAPI coverage column dropped to save tokens -- the doc already points to openapi.yaml.
+
+- **Section ordering: system overview, then bindings, then schema, then routes**
+  Chosen: ux-strategy-minion's frequency-of-access ordering
+  Over: Alphabetical, or schema-first
+  Why: Bindings (`env.SOMETHING`) are the most frequent lookup in code-writing sessions. Schema is second. Routes are third. This ordering matches actual usage patterns.
+
+- **No generation script for MVP**
+  Chosen: Hand-written doc with "Last verified" date and source file pointers
+  Over: A `scripts/generate-internals.sh` automation
+  Why: ai-modeling-minion raised generation as ideal but acknowledged it may be over-engineering for MVP. The schema has 10 tables and changes infrequently (one migration per feature). A generation script that handles ALTER TABLE, CHECK constraints, and JSON column annotations would be more complex than the doc itself. Defer to backlog.
+
+### Task 1: Create document structure and placement
+
+- **Agent**: software-docs-minion
+- **Delegation type**: standard
+- **Model**: sonnet
+- **Mode**: default
+- **Blocked by**: none
+- **Approval gate**: yes
+- **Gate reason**: Document structure and section ordering determine downstream content. Getting the skeleton wrong means reworking all content. This is the only gate in the plan.
+- **Gate rationale**:
+    Chosen: Frequency-of-access section ordering with mental model scaffold, flat route table, domain-grouped schema tables
+    Over: Alphabetical ordering, DDL-based schema, per-domain route sub-tables
+    Why: Optimized for LLM random-access lookup patterns per ux-strategy-minion's analysis
+- **Prompt**: |
+    Create the skeleton for `docs/INTERNALS.md` and the pointer file `.claude/rules/wrl-internals.md` in the WRL repo at `/Users/ben/github/benpeter/web-resource-ledger/.claude/worktrees/snuggly-watching-perlis`.
+
+    ## What to produce
+
+    **File 1: `docs/INTERNALS.md`** -- A skeleton with:
+    - Title and one-line purpose ("LLM and developer reference for WRL internals")
+    - "Last verified" date placeholder
+    - Source files list (which files this doc derives from)
+    - Section headings in this exact order:
+      1. System Overview (~10-15 lines, establishes the mental model: one Worker, one D1, one R2, one KV, three queue pairs, six rate limiters, browser binding)
+      2. Bindings (all `env.*` names mapped to type and purpose)
+      3. Secrets and Variables (two sub-sections: secrets via `wrangler secret put`, vars from `[vars]`)
+      4. D1 Schema (tables grouped by domain: Core, Billing, Auth, Scheduling, Webhooks, Notifications, Threat Intel; include JSON column shapes and app-layer constraints)
+      5. API Routes (flat table: Method, Path, Auth type, Rate Limit Group, Surface classification)
+      6. KV Key Patterns (key format, value, TTL, purpose, module)
+      7. R2 Object Key Patterns (key format, content type, purpose)
+      8. Queues (queue name, binding, batch size, retries, DLQ, handler)
+      9. Cron Triggers (expression, handler, purpose)
+      10. Rate Limiters (binding, limit, purpose)
+      11. Staging Differences (only what differs from production -- resource names, env overrides)
+    - Each section: H2 heading, one-sentence purpose, then a placeholder table with the right columns
+    - Cross-references where appropriate: "For request/response schemas, see `openapi.yaml`", "For operational procedures, see `OPERATIONS.md`", "For audit log events, see `docs/audit-log-schema.md`"
+
+    **File 2: `.claude/rules/wrl-internals.md`** -- A 3-line pointer:
+    ```
+    For WRL internals (D1 schema, API routes, KV/R2 bindings, secrets, queues, crons),
+    read `docs/INTERNALS.md`. Consult it before modifying database queries, adding routes,
+    changing env vars, or touching queue/cron configuration.
+    ```
+
+    ## Constraints
+    - H2 for sections, H3 for subsections. No deeper nesting.
+    - No prose explanations of how things work -- this is a lookup document.
+    - No duplication of content from openapi.yaml, OPERATIONS.md, or audit-log-schema.md.
+    - Tables only (no code blocks for schema). Each table must have the exact columns specified above.
+    - The skeleton should make it obvious what content goes where, so the next agent can fill it in without ambiguity.
+    - Read these existing docs to understand what NOT to duplicate: `OPERATIONS.md`, `docs/audit-log-schema.md`, `docs/mcp.md`.
+
+    ## What NOT to do
+    - Do not fill in the actual data yet (that is a separate task).
+    - Do not create any generation scripts.
+    - Do not modify CLAUDE.md or any existing rules files.
+    - Do not add explanatory prose, tutorials, or "getting started" content.
+
+- **Deliverables**: `docs/INTERNALS.md` skeleton, `.claude/rules/wrl-internals.md` pointer
+- **Success criteria**: Both files exist. The skeleton has all 11 sections with correct headings, column headers, and cross-references. The pointer file is 3-5 lines.
+
+### Task 2: Fill in reference content
+
+- **Agent**: software-docs-minion
+- **Delegation type**: standard
+- **Model**: sonnet
+- **Mode**: default
+- **Blocked by**: Task 1
+- **Approval gate**: no
+- **Prompt**: |
+    Fill in all content for `docs/INTERNALS.md` in the WRL repo at `/Users/ben/github/benpeter/web-resource-ledger/.claude/worktrees/snuggly-watching-perlis`. The skeleton from Task 1 is already in place. Your job is to read the actual source files and populate every table with accurate, current data.
+
+    ## Source files to read (in this order)
+
+    1. **`wrangler.toml`** -- All bindings (D1, R2, KV, Queues, Rate Limiters, Browser), vars, environments, cron triggers, queue consumers, compatibility settings. Read both `[env.production]` and `[env.staging]` sections for staging differences.
+
+    2. **`src/index.js`** -- The `routes` array (near the top, ~60 entries) defines all API routes as `[method, regex, handler]`. The `fetch()` handler implements auth dispatch logic: which route prefixes get which auth checks (admin key, session, API key, dual auth, none). Also check for special-case routes handled before the router (MCP, CORS preflight).
+
+    3. **D1 migrations in `migrations/`** -- Read ALL migration files in order (0001 through 0016) and mentally apply them to build the current schema state. Pay attention to: CREATE TABLE, ALTER TABLE ADD COLUMN, DROP TABLE, CREATE INDEX. The final state has 10 active tables (share_tokens was dropped in migration 0013).
+
+    4. **`src/db.js`** -- Contains application-layer constraints (VALID_TIERS, VALID_BILLING_STATUSES), JSON column parsing logic, and the quarantined status virtual mapping (DB stores status='complete' + quarantined=1, API returns status:'quarantined').
+
+    5. **`src/kv.js`** -- KV key patterns for rate limiting.
+
+    6. **`src/oauth.js`** -- KV key patterns for OAuth state and first-key display.
+
+    7. **`src/stripe-webhook.js`** -- KV key pattern for Stripe event idempotency.
+
+    8. **`src/capture.js`** -- R2 object key patterns for screenshots, HTML, headers.
+
+    9. **`src/rate-limits.js`** -- Rate limit group definitions and default limits.
+
+    ## Content rules for each section
+
+    **System Overview**: Under 200 words. State what this Worker is, enumerate what bindings it has (counts: X tables, Y queues, Z rate limiters), and link to other docs for deeper context. No architecture explanation.
+
+    **Bindings**: One table. Columns: Binding Name, Type, Resource, Purpose. Every binding from wrangler.toml. Include D1, R2, KV, Browser, all Queue producers, all Rate Limiters.
+
+    **Secrets**: Table with columns: Name, Purpose. List every secret set via `wrangler secret put`. Do NOT include values. Source: check wrangler.toml comments and the CLAUDE.local.md secrets section for the full list (CAPTURE_API_KEY, SIGNING_KEY, CORALOGIX_SEND_KEY, IP_HASH_SEED, ADMIN_KEY, GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET, STRIPE_SECRET_KEY, STRIPE_PUBLISHABLE_KEY).
+
+    **Variables**: Table with columns: Name, Value, Purpose. List all entries from wrangler.toml `[vars]` section.
+
+    **D1 Schema**: For each of the 10 active tables, create a sub-section (H3) with a table showing: Column, Type, Constraints, Notes. Group tables by domain:
+    - Core: tenants, captures, api_keys, signing_keys
+    - Billing: usage_counters
+    - Auth: github_users, sessions
+    - Scheduling: schedules
+    - Webhooks: webhooks
+    - Notifications: notification_preferences, notification_sent
+    - Threat Intel: threat_checks
+
+    After the per-table listings, add:
+    - A "JSON Columns" table: Table.Column, Shape (one-line description of the JSON structure)
+    - An "Application-Layer Constraints" table: Column, Valid Values, Notes (for constraints enforced in db.js, not by D1 CHECK)
+    - An "ID Format Conventions" table: Entity, Format, Example
+
+    **API Routes**: One flat table. Columns: Method, Path, Auth, Rate Limit, Surface. Convert regex patterns to readable path templates using `{param}` syntax. Auth values: `api-key`, `admin-key`, `session`, `dual` (session OR api-key), `signature` (Stripe), `none`. Surface values: `public-api`, `admin`, `account`, `auth`, `billing`, `notification`, `ui`, `infra`. Add a note: "For request/response schemas, see `openapi.yaml`." Also document the verify subdomain restriction (verify.webresourceledger.com only serves verification paths).
+
+    **KV Key Patterns**: Table with: Pattern, Value, TTL, Purpose, Module.
+
+    **R2 Object Key Patterns**: Table with: Key Pattern, Content Type, Purpose. Note the distinction between captureId-prefixed artifacts and content-addressed WACZ files.
+
+    **Queues**: Table with: Queue Name, Binding, Max Batch, Max Retries, DLQ, Handler. Cover all three queue pairs (captures, webhooks, emails).
+
+    **Cron Triggers**: Table with: Expression, Handler, Purpose.
+
+    **Rate Limiters**: Table with: Binding, Limit, Purpose. Include the per-tenant override note.
+
+    **Staging Differences**: Only list what differs from production. Typically: database IDs, bucket names, queue names, env var overrides, domain names. Everything not listed is identical.
+
+    ## Token budget
+    Target under 3,000 tokens total. This means:
+    - No prose paragraphs beyond the System Overview
+    - No examples or tutorials
+    - No historical context ("added in phase X")
+    - Compact table cells (abbreviate where clear)
+    - One-sentence purpose intros per section, max
+
+    ## Validation steps (do these after writing)
+    1. Count routes in your table and compare against the length of the `routes` array in `src/index.js`. They should match (plus any special-case routes).
+    2. Verify all 10 active D1 tables are represented. Confirm share_tokens is NOT listed.
+    3. Verify all KV key patterns by grepping for `KV.put` and `KV.get` across src/.
+    4. Verify all R2 patterns by grepping for `BUCKET.put` and `BUCKET.get` across src/.
+    5. Set the "Last verified" date to today's date.
+
+    ## What NOT to do
+    - Do not modify the section structure or ordering from the skeleton.
+    - Do not add new sections.
+    - Do not include request/response schemas (that is openapi.yaml's job).
+    - Do not explain how the capture pipeline works (that is architecture documentation).
+    - Do not include secret values.
+    - Do not create generation scripts.
+
+- **Deliverables**: Completed `docs/INTERNALS.md` with all sections filled in from source code
+- **Success criteria**: All 11 sections populated with accurate data. Route count matches source. All 10 D1 tables documented. All KV and R2 patterns documented. Document is under 3,000 tokens. "Last verified" date is set.
+
+### Task 3: Cross-reference from OPERATIONS.md
+
+- **Agent**: software-docs-minion
+- **Delegation type**: standard
+- **Model**: sonnet
+- **Mode**: default
+- **Blocked by**: Task 1
+- **Approval gate**: no
+- **Prompt**: |
+    Add a one-line cross-reference to `OPERATIONS.md` in the WRL repo at `/Users/ben/github/benpeter/web-resource-ledger/.claude/worktrees/snuggly-watching-perlis` pointing to the new `docs/INTERNALS.md`.
+
+    Read `OPERATIONS.md` first. Find the most natural place for a "See also" line -- likely near the top or in an existing section about environments/bindings. Insert a single line like:
+
+    > For D1 schema, binding names, KV/R2 key patterns, and API route map, see [`docs/INTERNALS.md`](docs/INTERNALS.md).
+
+    Do NOT add content, restructure the document, or duplicate any information from INTERNALS.md. One line only.
+
+- **Deliverables**: Updated `OPERATIONS.md` with cross-reference
+- **Success criteria**: One new line added. No other changes to OPERATIONS.md.
+
+### Cross-Cutting Coverage
+
+- **Testing**: Excluded. This task produces only markdown documentation files. No executable code, no configuration changes, no infrastructure modifications.
+- **Security**: Excluded. The document lists secret names only, never values. No new attack surface, no auth changes, no user input handling.
+- **Usability -- Strategy**: Covered in planning (ux-strategy-minion's contribution shaped section ordering, mental model scaffold, and random-access optimization). No further execution-phase work needed -- the structural decisions are baked into the skeleton.
+- **Usability -- Design**: Excluded. No user-facing UI produced.
+- **Documentation**: This IS the documentation task. software-docs-minion is the executing agent.
+- **Observability**: Excluded. No runtime components produced.
+
+### Architecture Review Agents
+
+- **Mandatory** (5): security-minion, test-minion, ux-strategy-minion, lucy, margo
+- **Discretionary picks**:
+  - None selected. This task produces a single markdown reference document with no UI, no runtime code, no infrastructure, no user-facing output beyond the doc itself.
+- **Not selected**:
+  - ux-design-minion: No UI components or visual layouts produced.
+  - accessibility-minion: No web-facing HTML/UI produced.
+  - sitespeed-minion: No web-facing runtime code produced.
+  - observability-minion: No runtime components produced.
+  - user-docs-minion: The doc is for developers/LLMs, not end users. No user-facing behavior changes.
+
+### Risks and Mitigations
+
+1. **Staleness** (raised by all 5 specialists): The doc will drift from source code over time.
+   Mitigation: "Last verified" date at the top. Source file list so reviewers can spot drift. Defer generation script to backlog. Note in the doc which files to check when updating.
+
+2. **Migration consolidation errors** (ai-modeling-minion, data-minion): Manually applying 16 migrations to reconstruct current schema is error-prone.
+   Mitigation: The executing agent should validate the consolidated schema against a live D1 instance if accessible (`wrangler d1 execute wrl-metadata-staging --command "SELECT sql FROM sqlite_master WHERE type='table'"`), or at minimum cross-reference against `src/db.js` function signatures.
+
+3. **Route count mismatch** (api-spec-minion): Missing routes is a silent error.
+   Mitigation: Validation step in Task 2 -- count routes in doc vs. routes array length in index.js.
+
+4. **Over-documentation / scope creep** (all specialists): Temptation to explain how things work rather than just listing what exists.
+   Mitigation: Explicit constraints in the prompt: no prose beyond System Overview, no "how it works" explanations, no historical context. Token budget of 3K acts as a natural ceiling.
+
+5. **KV pattern completeness** (data-minion): KV usage is scattered across 3 modules with no central registry.
+   Mitigation: Grep-based validation in Task 2 (search for KV.put/KV.get across all src/ files).
+
+### Execution Order
+
+```
+Task 1 (skeleton + pointer) ──> APPROVAL GATE ──> Task 2 (fill content)
+                                                  Task 3 (OPERATIONS.md cross-ref, parallel with Task 2)
+```
+
+Batch 1: Task 1
+Gate: Document structure approval
+Batch 2: Task 2 + Task 3 (parallel)
+
+### Verification Steps
+
+After all tasks complete:
+1. `docs/INTERNALS.md` exists and is under 3,000 tokens (verify with `wc -w`, roughly 1 token per 0.75 words)
+2. `.claude/rules/wrl-internals.md` exists and is 3-5 lines
+3. `OPERATIONS.md` has exactly one new line (the cross-reference)
+4. Route count in INTERNALS.md matches `routes` array length in `src/index.js`
+5. All 10 active D1 tables are documented; `share_tokens` is not
+6. No secret values appear anywhere in the document
+7. No content duplicated from `openapi.yaml`, `OPERATIONS.md`, or `docs/audit-log-schema.md`

--- a/docs/history/nefario-reports/2026-03-26-043000-llm-developer-reference/phase3.5-lucy.md
+++ b/docs/history/nefario-reports/2026-03-26-043000-llm-developer-reference/phase3.5-lucy.md
@@ -1,0 +1,68 @@
+# Lucy Review: LLM Developer Reference Plan
+
+## Verdict: ADVISE
+
+## Original Request (verbatim from prompt.md)
+
+A reference document for WRL internals: D1 schema, API routes, KV/R2 namespaces, env vars, wrangler config. In-scope: D1 schema, API routes, bindings, env vars, worker config. Out-of-scope: public-facing API docs, operational runbooks, architecture narratives.
+
+## Requirement Traceability
+
+| Requirement (from prompt.md) | Plan Element | Status |
+|------------------------------|-------------|--------|
+| D1 tables and columns | Task 2, D1 Schema section | Covered |
+| All API routes with methods | Task 2, API Routes section | Covered |
+| KV/R2 namespace names and purposes | Task 2, KV + R2 sections | Covered |
+| Env vars and secrets (names only) | Task 2, Secrets + Variables sections | Covered |
+| Wrangler.toml bindings | Task 2, Bindings section | Covered |
+| Clear dev-internal vs public-API separation | Task 2, Surface column in route table | Covered |
+| Discoverable by LLMs | Task 1, `.claude/rules/wrl-internals.md` pointer | Covered |
+| Accurate against current codebase | Task 2, validation steps + "Last verified" date | Covered |
+| Not duplicate existing docs | Task prompts explicitly exclude openapi.yaml, OPERATIONS.md, audit-log-schema.md | Covered |
+
+No stated requirements are missing from the plan.
+
+## Scope Assessment
+
+No scope creep detected. The plan produces exactly what was asked for: one reference doc, one pointer file, one cross-reference line. Three tasks total, proportional to the deliverables.
+
+## Findings
+
+### 1. COMPLIANCE: Evolution log not mentioned in plan
+
+**CLAUDE.md directive** (Evolution Log, Rules 1-6): "Every significant development phase must be documented in `docs/evolution/`. This is non-negotiable."
+
+**Plan gap**: The synthesis plan contains no task, step, or mention of creating an evolution log entry for this phase. Per CLAUDE.md Precedence section, "the calling session must add that step."
+
+**Fix**: The orchestrating session (nefario) must ensure an evolution log directory is created (e.g., `docs/evolution/NNNN-llm-developer-reference/`) with `prompt.md`, `decisions.md`, and `outcome.md`, and the index at `docs/evolution/README.md` is updated. This can be handled by the orchestrator after task execution -- it does not require adding a task to this plan, but the orchestrator must not skip it.
+
+**Severity**: Minor. This is a post-execution obligation on the orchestrator, not a plan defect. Flagging to ensure it is not forgotten.
+
+### 2. ADVISE: Backlog update not mentioned
+
+**CLAUDE.md directive** (Evolution Log, Rule 4): "Review `docs/backlog.md` after every phase. Add items that were explicitly deferred or flagged as post-MVP."
+
+**Plan context**: The plan explicitly defers a generation script to backlog (Decision 5: "Defer to backlog"). This deferral should be recorded in `docs/backlog.md` after execution.
+
+**Fix**: Orchestrator should add the generation script deferral to `docs/backlog.md` post-execution.
+
+### 3. ADVISE: Token budget validation method is approximate
+
+The plan says to verify "under 3,000 tokens" using `wc -w` with a "roughly 1 token per 0.75 words" heuristic. This is imprecise for markdown with many table delimiters, pipe characters, and short cells (which tokenize less efficiently than prose). A 3,000-token doc measured this way could actually be 3,500+ tokens.
+
+**Impact**: Low. The 3K target is a guideline, not a hard contract. The real constraint is "fits in context without dominating it," which the pointer-file pattern already handles by making loading on-demand.
+
+**Fix**: No action needed. Noting for awareness -- if the doc comes in at ~2,800 words, it may exceed the token target.
+
+## Convention Compliance
+
+- **YAGNI**: Plan explicitly defers generation scripts. No speculative features.
+- **KISS**: Three tasks, one markdown file, one pointer file, one cross-ref line. Proportional.
+- **No frameworks**: N/A (documentation only).
+- **File naming**: `docs/INTERNALS.md` and `.claude/rules/wrl-internals.md` follow existing patterns (existing rules files use `wrl-` prefix, lowercase with hyphens).
+- **Serverless-first**: N/A (no infrastructure).
+- **Existing docs not duplicated**: Explicitly constrained in task prompts.
+
+## Summary
+
+The plan is well-scoped, directly traceable to the original request, and proportional to the problem. The only compliance gap is the evolution log obligation, which falls on the orchestrator rather than this plan's tasks. No drift, no scope creep, no CLAUDE.md violations in the planned deliverables.

--- a/docs/history/nefario-reports/2026-03-26-043000-llm-developer-reference/phase3.5-margo.md
+++ b/docs/history/nefario-reports/2026-03-26-043000-llm-developer-reference/phase3.5-margo.md
@@ -1,0 +1,19 @@
+# Margo Review: LLM Developer Reference Plan
+
+## Verdict: ADVISE
+
+The plan is well-scoped for what it does. The output is a single reference document -- no runtime code, no infrastructure, no new dependencies. The decisions are sound (hand-written over generated, pointer file over always-loaded, flat tables over nested). Two non-blocking concerns:
+
+### 1. The approval gate on Task 1 (skeleton) is unnecessary overhead
+
+The skeleton is a list of headings and empty tables. If the headings are wrong, they can be fixed in Task 2 at near-zero cost -- it is markdown, not a database schema. The "getting the skeleton wrong means reworking all content" rationale overstates the rework cost. Cutting the gate saves a round-trip and lets Tasks 1+2 run as a single task or at least without a blocking pause.
+
+**Simpler alternative:** Merge Task 1 and Task 2 into one task. The agent reads source files, writes the doc. The skeleton is an implementation detail, not a checkpoint-worthy artifact. This also eliminates the "blocked by" dependency, reducing the plan from 3 tasks to 2 (write doc + add cross-reference).
+
+### 2. Five architecture review agents for a markdown file is disproportionate
+
+security-minion, test-minion, ux-strategy-minion, lucy, and margo are all reviewing a plan that produces two markdown files and a one-line edit. The plan itself correctly notes that testing, security, observability, and design are excluded because there is nothing to test, secure, observe, or design. Yet it still runs five reviewers through a full review cycle. For a documentation-only deliverable, margo alone (checking for scope creep and over-engineering) would suffice, or at most margo + one other.
+
+### Assessment
+
+Neither concern is blocking. The plan will produce the right output. The extra gate and reviewer count add process overhead but do not introduce accidental complexity into the deliverable itself.

--- a/docs/history/nefario-reports/2026-03-26-043000-llm-developer-reference/phase3.5-security-minion.md
+++ b/docs/history/nefario-reports/2026-03-26-043000-llm-developer-reference/phase3.5-security-minion.md
@@ -1,0 +1,25 @@
+## Security Review: LLM Developer Reference (INTERNALS.md)
+
+**Verdict: APPROVE**
+
+### Assessment
+
+This plan produces a static markdown document. The attack surface is near-zero. Specific checks:
+
+**Secret values**: The plan explicitly prohibits including secret values in four separate places (Task 2 prompt lines, "What NOT to do", cross-cutting coverage, and verification step 6). The secrets section documents only the *names* of secrets (`CAPTURE_API_KEY`, `SIGNING_KEY`, etc.). These names are already present in `wrangler.toml` in the repo -- no new exposure.
+
+**[vars] values**: Including `[vars]` values is correct and safe -- these are non-sensitive configuration that ships in the Worker bundle by design (not secrets).
+
+**Enumeration risk**: Documenting the full route table (including admin routes) is appropriate for an internal developer reference. The routes are already in `src/index.js`. The document does not change what exists; it documents what already exists. The `.claude/rules/` placement keeps it out of any public-facing location.
+
+**KV/R2 key patterns**: Documenting key formats is safe. The patterns are schema, not credentials.
+
+**D1 schema enumeration**: Acceptable. This is internal dev reference material, not public documentation. No access controls are weakened.
+
+**Staging differences section**: Correctly scoped -- resource names and env overrides only, no keys or passwords.
+
+### One Note (not blocking)
+
+The Task 2 validation step suggests running `wrangler d1 execute ... --command "SELECT sql FROM sqlite_master WHERE type='table'"` to verify schema. This is fine -- it surfaces only DDL that is already being documented. No concern.
+
+The document should never be committed to a public repo. It references internal route paths and admin surface details. Confirm `docs/INTERNALS.md` is not excluded from `.gitignore` in a way that would prevent tracking, but also confirm the repo itself is private or access-controlled. This is out of scope for the plan itself -- existing repo access controls apply.

--- a/docs/history/nefario-reports/2026-03-26-043000-llm-developer-reference/phase3.5-test-minion.md
+++ b/docs/history/nefario-reports/2026-03-26-043000-llm-developer-reference/phase3.5-test-minion.md
@@ -1,0 +1,13 @@
+## Verdict: APPROVE
+
+This task produces only markdown documentation files. No executable code, no configuration changes, no new runtime behavior. Testing automation does not apply.
+
+The plan already includes the right validation steps for a documentation task:
+
+- Route count in the document vs. `routes` array length in `src/index.js` — this is the only validation that matters and it is explicitly required in Task 2.
+- D1 table count check (10 active, confirm `share_tokens` absent) — correct.
+- Grep-based KV/R2 pattern completeness check (`KV.put`/`KV.get`, `BUCKET.put`/`BUCKET.get`) — correct.
+
+These are embedded in the executing agent's prompt, which is the right place. There is nothing to automate — the "test" is whether the document accurately reflects source files, which requires LLM judgment, not assertions.
+
+No concerns from a test coverage perspective.

--- a/docs/history/nefario-reports/2026-03-26-043000-llm-developer-reference/phase3.5-ux-strategy-minion.md
+++ b/docs/history/nefario-reports/2026-03-26-043000-llm-developer-reference/phase3.5-ux-strategy-minion.md
@@ -1,0 +1,9 @@
+## Verdict: APPROVE
+
+**Journey coherence**: The section ordering is correct. System Overview → Bindings → Schema → Routes → KV/R2 → Queues → Crons → Rate Limiters → Staging Differences moves from orientation to high-frequency lookups to low-frequency configuration. An LLM (or developer) entering a session can read the overview to establish context, then jump directly to the section they need. No backtracking required.
+
+**Cognitive load**: The flat route table with a Surface column is the right call. Sub-tables per domain would require navigating an index first, then a section — two hops instead of one. The pointer pattern (3-line always-loaded rules file + on-demand full doc) correctly applies progressive disclosure to LLM token budgets.
+
+**One minor note for implementation** (not a blocker): The three D1 sub-tables (JSON Columns, Application-Layer Constraints, ID Format Conventions) appear after all 10 per-table listings. A developer checking `captures` will want the JSON column shape for that specific table collocated with it, not separated by nine other tables. The executing agent should consider whether a Notes column in each per-table listing can absorb the most critical cross-references, with the consolidated sub-tables as a secondary reference for exhaustive lookup. This is a content density judgment call — the 3,000-token budget may make colocation impractical. Either way is acceptable; just flag the tradeoff at the approval gate.
+
+**Simplification**: Nothing to cut. Three tasks, clean dependencies, one gate at the right point. Task 3 (one line in OPERATIONS.md) is lightweight enough to justify as a separate parallel task rather than folding it in and risking scope creep on Tasks 1 or 2.

--- a/docs/history/nefario-reports/2026-03-26-043000-llm-developer-reference/prompt.md
+++ b/docs/history/nefario-reports/2026-03-26-043000-llm-developer-reference/prompt.md
@@ -1,0 +1,11 @@
+**Outcome**: A structured reference document exists that gives LLMs (and developers) the context needed to operate on WRL — D1 schema, API routes, KV namespaces, R2 buckets, env vars, and wrangler config — so that AI-assisted development sessions don't start with 10 minutes of codebase archaeology.
+
+**Success criteria**:
+- Document covers: D1 tables and columns, all API routes with methods, KV/R2 namespace names and purposes, environment variables and secrets (names only, not values), wrangler.toml bindings
+- Clear separation between dev-only internals and public API surface
+- Document lives in a location discoverable by LLMs (e.g., `llms.txt`, `CLAUDE.md` reference, or `docs/`)
+- Accurate against current codebase (not stale)
+
+**Scope**:
+- In: D1 schema, API routes, bindings (KV, R2, DO), env vars, worker config
+- Out: Public-facing API documentation (already on docs site), operational runbooks, architecture narratives


### PR DESCRIPTION
## Summary

- Create `docs/INTERNALS.md` — dense, table-based reference document covering WRL's D1 schema (12 tables), API routes (55 total), KV/R2 key patterns, all bindings, secrets (names only), queues, crons, rate limiters, and staging differences
- Add cross-reference from `OPERATIONS.md`
- Add evolution log, nefario report, and backlog update

## Details

The document is optimized for LLM context loading (dense tables, no prose beyond a brief system overview) while remaining useful for human random-access lookups. Section ordering follows frequency-of-access patterns: bindings → secrets → D1 schema → routes → KV → R2 → queues → crons → rate limiters → staging.

A `.claude/rules/wrl-internals.md` pointer file needs manual creation (Claude Code blocks automated writes to `.claude/rules/`).

Resolves #201

## Test plan

- [x] Route count in INTERNALS.md matches `routes` array length in `src/index.js` (52 + 3 special-case)
- [x] All 12 active D1 tables documented; `share_tokens` absent
- [x] All KV patterns verified via grep for `KV.put`/`KV.get`
- [x] All R2 patterns verified via grep for `BUCKET.put`/`BUCKET.get`
- [x] No secret values in document
- [ ] Manual: create `.claude/rules/wrl-internals.md` pointer file

🤖 Generated with [Claude Code](https://claude.com/claude-code)
