### PR TITLE
feat(landing): reorder sections — Use Cases before How It Works

### DIFF
--- a/docs/evolution/0089-landing-legal-section-ordering/decisions.md
+++ b/docs/evolution/0089-landing-legal-section-ordering/decisions.md
@@ -1,0 +1,31 @@
+# Decisions: Landing Page Legal Claims and Section Ordering
+
+## Decision 1: No Trust Bar
+
+**Chosen**: No trust bar or trust strip added. Legal standard references (FRE 901/902, eIDAS) remain only in the Legal Evidence use case card.
+
+**Over**: Trust strip below hero with compact standard badges showing FRE 901(b)(9), FRE 902(14), eIDAS Art. 41(2) with shield icons and plain-English descriptors.
+
+**Advocates**: ux-strategy-minion and ux-design-minion recommended the trust bar for progressive disclosure — signal legal vocabulary early, detail later.
+
+**Why rejected**: product-marketing-minion's analysis was more compelling:
+- Legal citations are meaningful to only 2 of 6 priority audience segments
+- Leading with legal rule numbers risks repositioning WRL as a "legal compliance tool" rather than "web evidence infrastructure"
+- The section reorder (Decision 2) already moves the Legal Evidence card much closer to the top of the page, addressing the "legal readers need vocabulary early" concern without a dedicated element
+- Trust bar pattern works well when credentials are universally relevant (e.g., "SOC 2 Certified"); FRE/eIDAS rule numbers are segment-specific
+
+## Decision 2: Use Cases Above How It Works
+
+**Chosen**: Section order changed to Hero → Use Cases → How It Works → Pricing
+
+**Over**: Original order Hero → How It Works → Use Cases → Pricing
+
+**Why**: All three specialists agreed unanimously. Use Cases answers "why should I care?" (outcomes, jobs-to-be-done). How It Works answers "how does it work?" (mechanism). Leading with outcomes before mechanism follows JTBD principles and serves all audience segments better. The current order forced all visitors through a technical process explanation before showing them what the product is for.
+
+## Decision 3: Legal Evidence Card Content Preserved
+
+**Chosen**: Keep the detailed FRE/eIDAS bullet list in the Legal Evidence use case card exactly as-is.
+
+**Over**: Simplify the card to narrative-only, removing specific standard citations (proposed by ux-design-minion).
+
+**Why**: The bullet list with specific rule references is the card's core value for its target audience. Legal professionals and compliance officers need to see the exact standards supported. Removing them to reduce visual density would weaken the card for the segment it specifically serves. The card is one of four in a grid — density in one card does not overwhelm the section.

--- a/docs/evolution/0089-landing-legal-section-ordering/outcome.md
+++ b/docs/evolution/0089-landing-legal-section-ordering/outcome.md
@@ -1,0 +1,38 @@
+# Outcome: Landing Page Legal Claims and Section Ordering
+
+## What Changed
+
+One file modified: `landing/public/index.html`
+
+1. **Section reorder**: Use Cases section moved above How It Works
+2. **Background class swap**: Use Cases gets `landing-section--white` (was `--muted`), How It Works gets `landing-section--muted` (was `--white`) to maintain visual alternation
+3. **Nav link reorder**: "Use Cases" link now appears before "How It Works" in the header navigation
+
+## What Did Not Change
+
+- Hero section: no modifications
+- Legal Evidence use case card: content preserved exactly as-is (FRE/eIDAS bullet list intact)
+- No trust bar or trust strip added
+- No new sections, elements, or CSS classes
+- Pricing section: unchanged
+- Structured data (schema.org): unchanged
+
+## Lighthouse Results
+
+- Performance: 100 (threshold: 90)
+- Accessibility: 96 (threshold: 95)
+- No heading-order warnings from the section reorder
+
+## Backlog Changes
+
+No backlog items added, removed, or modified. The eIDAS accuracy concern flagged by product-marketing-minion (whether eIDAS Art. 41(2) references overstate current capabilities) is a copy accuracy question that predates this issue and is already tracked.
+
+## Surface Consistency
+
+| Surface | Action |
+|---------|--------|
+| OpenAPI spec | No update needed — no API changes |
+| Docs site | No update needed — no behavior changes |
+| Landing page | Updated (this PR) |
+| MCP server | No update needed — no API changes |
+| Legal pages | No update needed — no new data collection or service integrations |

--- a/docs/evolution/0089-landing-legal-section-ordering/process.md
+++ b/docs/evolution/0089-landing-legal-section-ordering/process.md
@@ -1,0 +1,83 @@
+# Process: Landing Page Legal Claims and Section Ordering
+
+## TL;DR
+
+Three specialists (ux-strategy, ux-design, product-marketing) planned the landing page section reorder. They agreed unanimously on moving Use Cases above How It Works but split 2-1 on adding a trust bar with legal standard references. Product-marketing won the argument: legal citations serve only 2 of 6 audience segments. The implementation was a single HTML file edit with Lighthouse verification. Six Phase 3.5 reviewers all APPROVED. Total: 1 file changed, performance 100, accessibility 96.
+
+## Phase 1: Meta-Plan
+
+Nefario identified three planning specialists:
+- **ux-strategy-minion**: Information hierarchy, cognitive load for dual audiences (developers vs. legal decision-makers)
+- **ux-design-minion**: Visual patterns for compliance references (trust badges, strips, shields)
+- **product-marketing-minion**: Positioning impact across audience segments
+
+Notable exclusions: frontend-minion (vanilla HTML/CSS, no framework code), seo-minion (scope explicitly excludes SEO metadata), accessibility-minion (deferred to Phase 3.5 review).
+
+One external skill discovered (ops-runbook) — not relevant.
+
+## Phase 2: Specialist Planning
+
+All three agents read the landing page HTML and provided recommendations in parallel.
+
+### Where They Agreed
+
+All three recommended moving Use Cases above How It Works. Their reasoning converged from different angles:
+- **ux-strategy**: "How It Works delays the emotional payoff of concrete use cases"
+- **ux-design**: "Outcomes section first gives users a reason to care about the mechanism"
+- **product-marketing**: "Visitors need to see themselves in the product before they care about the technical approach"
+
+### Where They Disagreed
+
+The trust bar question split the team:
+
+**For trust bar (2 agents)**:
+- ux-strategy-minion proposed a lightweight trust bar below the hero: "Ed25519 | RFC 3161 | FRE 901/902 | eIDAS" — progressive disclosure, signal first, detail in the Use Cases card later. Argued legal/compliance decision-makers need to see "vocabulary they recognize" within 5 seconds.
+- ux-design-minion proposed a compact trust strip with three horizontal items, each with a shield icon, standard reference, and one-line plain-English descriptor.
+
+**Against trust bar (1 agent)**:
+- product-marketing-minion argued legal standard references are segment-specific proof points, not universal value signals. "Only 2 of 6 priority segments respond positively to FRE citations. For journalism, AI agents, OSINT, and compliance segments, legal rule numbers signal 'this is not for me.'" Proposed at most a subtle credibility line below the hero CTAs.
+
+## Phase 3: Synthesis
+
+Nefario sided with product-marketing-minion on the trust bar question. The deciding factors:
+
+1. **Audience math**: FRE/eIDAS citations resonate with 2 of 6 segments. A trust bar with rule numbers creates cognitive overhead for the majority.
+2. **The reorder solves the timing problem**: Moving Use Cases above How It Works means the Legal Evidence card (with its FRE/eIDAS references) becomes the first content section after the hero. Legal readers find their vocabulary quickly — no dedicated trust element needed.
+3. **Category risk**: product-marketing's argument about narrowing WRL's perceived positioning from "web evidence infrastructure" to "legal compliance tool" was compelling. The trust bar pattern works for universally-recognized credentials (SOC 2, ISO 27001); FRE rule numbers are not universally recognized.
+
+The synthesis also rejected ux-design-minion's proposal to simplify the Legal Evidence card to narrative-only. The detailed bullet list with specific standards is the card's core value for legal professionals.
+
+Final plan: 2 tasks (section reorder + Lighthouse), 0 approval gates.
+
+## Phase 3.5: Architecture Review
+
+Six reviewers (5 mandatory + accessibility-minion discretionary) all returned APPROVE:
+- **security-minion**: "No security implications. No new inputs, endpoints, auth changes."
+- **test-minion**: "Verification steps adequate. Lighthouse covers accessibility regressions."
+- **ux-strategy-minion**: "Section reorder is correct. Trust bar rejection holds up."
+- **lucy**: "Plan aligns with issue #207. Scope boundaries respected."
+- **margo**: "Zero complexity budget spend. No scope creep."
+- **accessibility-minion**: "Both sections are sibling h2 elements — swapping DOM order creates no heading hierarchy violations."
+
+No revision rounds needed.
+
+## Phase 4: Execution
+
+The section reorder was implemented directly (no subagent needed for a well-defined HTML edit):
+1. Swapped nav link order in header
+2. Moved Use Cases section above How It Works
+3. Swapped background classes (white ↔ muted) to maintain visual alternation
+
+Lighthouse verification: Performance 100, Accessibility 96.
+
+## What Was Deliberately Left Alone
+
+- **Hero copy**: No changes. The hero tagline ("Capture any web page and get a signed, timestamped evidence bundle...") already implies legal/evidentiary value without explicit rule references.
+- **Legal Evidence card content**: FRE/eIDAS bullet list preserved exactly as-is despite ux-design-minion's simplification proposal.
+- **Use case card ordering within the grid**: product-marketing-minion noted that if the primary growth segment is developers (AI Agent Grounding), that card might be better positioned first. This is a separate business strategy decision, explicitly out of scope.
+
+## Where to Read More
+
+- Specialist contributions: `docs/history/nefario-reports/2026-03-26-040037-landing-legal-section-ordering/`
+- Synthesis and conflict resolution: `phase3-synthesis.md` in the companion directory
+- Reviewer verdicts: `phase3.5-*.md` files in the companion directory

--- a/docs/evolution/0089-landing-legal-section-ordering/prompt.md
+++ b/docs/evolution/0089-landing-legal-section-ordering/prompt.md
@@ -1,0 +1,11 @@
+**Outcome**: The landing page presents legal/compliance claims and the "how this works" section in the most effective order, ensuring legal claims are prominent enough to build trust without overwhelming the initial impression.
+
+**Success criteria**:
+- Decision documented on whether legal claims belong in hero banner or below
+- Decision documented on whether "how this works" should move below other sections
+- Changes implemented if warranted
+- Landing page still passes Lighthouse performance and accessibility checks
+
+**Scope**:
+- In: Hero banner content, legal/compliance claims placement, "how this works" section position relative to other sections
+- Out: Copy rewrites, new sections, mobile-specific layout changes, SEO metadata

--- a/docs/evolution/README.md
+++ b/docs/evolution/README.md
@@ -97,3 +97,4 @@ software development.
 | [0086-mermaid-architecture-diagrams](0086-mermaid-architecture-diagrams/) | Add Mermaid architecture diagrams to docs site: user interaction flows + capture pipeline & integrity chain (Issue #168) |
 | [0087-llm-developer-reference](0087-llm-developer-reference/) | LLM-oriented developer reference for WRL internals: D1 schema, API routes, bindings, secrets, queues, crons (Issue #201) |
 | [0088-autoconsent-ci](0088-autoconsent-ci/) | Automated autoconsent update pipeline: GitHub Action for weekly vendor updates with test battery (Issue #152) |
+| [0089-landing-legal-section-ordering](0089-landing-legal-section-ordering/) | Landing page section reorder: Use Cases above How It Works, trust bar rejected, legal claims stay in use case card (Issue #207) |

--- a/docs/history/nefario-reports/2026-03-26-040037-landing-legal-section-ordering.md
+++ b/docs/history/nefario-reports/2026-03-26-040037-landing-legal-section-ordering.md
@@ -1,0 +1,89 @@
+---
+task: "Review landing page legal claims placement and section ordering"
+source-issue: 207
+date: 2026-03-26
+status: complete
+agents: [ux-strategy-minion, ux-design-minion, product-marketing-minion, security-minion, test-minion, accessibility-minion, lucy, margo]
+task-count: 2
+gate-count: 0
+mode: execution
+---
+
+## Summary
+
+Reordered the WRL landing page sections: Use Cases now appears before How It Works, leading with outcomes before mechanism. Rejected adding a trust bar with legal standard references — the section reorder already moves legal proof points (FRE 901/902, eIDAS) closer to the top of the page without narrowing perceived audience. Lighthouse verification passed: performance 100, accessibility 96.
+
+## Original Prompt
+
+The landing page presents legal/compliance claims and the "how this works" section in the most effective order, ensuring legal claims are prominent enough to build trust without overwhelming the initial impression.
+
+Success criteria:
+- Decision documented on whether legal claims belong in hero banner or below
+- Decision documented on whether "how this works" should move below other sections
+- Changes implemented if warranted
+- Landing page still passes Lighthouse performance and accessibility checks
+
+## Key Design Decisions
+
+1. **No trust bar** — Legal citations (FRE 901/902, eIDAS) are meaningful to only 2 of 6 priority segments. Adding them to the hero or a trust strip risks repositioning WRL as a "legal compliance tool" rather than "web evidence infrastructure." The section reorder addresses the timing concern without a dedicated element.
+
+2. **Use Cases above How It Works** — Unanimous specialist agreement. Outcomes ("why should I care?") before mechanism ("how does it work?") follows JTBD principles and serves all audience segments better.
+
+3. **Legal Evidence card content preserved** — The detailed FRE/eIDAS bullet list stays as-is. It serves its target audience (legal professionals) effectively. Removing specificity to reduce visual density would weaken the card for its intended readers.
+
+## Execution
+
+### Task 1: Reorder sections and update nav
+- **Agent**: frontend-minion (sonnet)
+- **Outcome**: Section order changed to Hero → Use Cases (white) → How It Works (muted) → Pricing (white). Nav links reordered to match.
+- **Files**: `landing/public/index.html` (modified)
+
+### Task 2: Lighthouse verification
+- **Outcome**: Performance 100, Accessibility 96. Both above thresholds (90, 95).
+
+## Verification
+
+Verification: Lighthouse passed (performance 100, accessibility 96). Code review: not applicable — single HTML section reorder, 6 reviewers pre-approved plan. Tests: not applicable — no code logic changes.
+
+## Agent Contributions
+
+### Planning (Phase 2)
+
+| Agent | Recommendation | Key Insight |
+|-------|---------------|-------------|
+| ux-strategy-minion | Trust bar + section reorder | Progressive disclosure: signal legal vocabulary early, detail later |
+| ux-design-minion | Trust strip with shield icons | Compact horizontal badges for compliance references |
+| product-marketing-minion | Section reorder only, no trust bar | Legal jargon narrows perceived audience for 4 of 6 segments |
+
+### Review (Phase 3.5)
+
+All 6 reviewers APPROVED: security-minion, test-minion, ux-strategy-minion, lucy, margo, accessibility-minion.
+
+## Decisions
+
+### Trust bar rejected
+- **Chosen**: No trust bar. Legal references stay in Use Cases card only.
+- **Over**: Trust strip below hero with compact standard badges (ux-strategy-minion, ux-design-minion)
+- **Why**: Legal citations meaningful to only 2/6 segments. Section reorder moves legal content closer to top without narrowing audience.
+
+### Legal Evidence card preserved
+- **Chosen**: Keep detailed FRE/eIDAS bullet list.
+- **Over**: Simplify to narrative only (ux-design-minion)
+- **Why**: Specific rule references are the card's core value for legal professionals.
+
+## Working Files
+
+Companion directory: `docs/history/nefario-reports/2026-03-26-040037-landing-legal-section-ordering/`
+
+Files: prompt.md, phase1-metaplan.md, phase2-ux-strategy-minion.md, phase2-ux-design-minion.md, phase2-product-marketing-minion.md, phase3-synthesis.md, phase3.5-*.md (6 reviewer verdicts), plus all -prompt.md files.
+
+## Session Resources
+
+<details>
+<summary>Skills Invoked</summary>
+
+- `/nefario` — orchestration workflow
+
+</details>
+
+Resolves #207

--- a/docs/history/nefario-reports/2026-03-26-040037-landing-legal-section-ordering/phase1-metaplan-prompt.md
+++ b/docs/history/nefario-reports/2026-03-26-040037-landing-legal-section-ordering/phase1-metaplan-prompt.md
@@ -1,0 +1,47 @@
+MODE: META-PLAN
+
+You are creating a meta-plan — a plan for who should help plan.
+
+## Task
+<github-issue>
+**Outcome**: The landing page presents legal/compliance claims and the "how this works" section in the most effective order, ensuring legal claims are prominent enough to build trust without overwhelming the initial impression.
+
+**Success criteria**:
+- Decision documented on whether legal claims belong in hero banner or below
+- Decision documented on whether "how this works" should move below other sections
+- Changes implemented if warranted
+- Landing page still passes Lighthouse performance and accessibility checks
+
+**Scope**:
+- In: Hero banner content, legal/compliance claims placement, "how this works" section position relative to other sections
+- Out: Copy rewrites, new sections, mobile-specific layout changes, SEO metadata
+</github-issue>
+
+## Working Directory
+/Users/ben/github/benpeter/web-resource-ledger/.claude/worktrees/silly-kindling-jellyfish
+
+## Current Landing Page Structure
+The landing page (landing/public/index.html) currently has this section order:
+1. Hero: "Web evidence you can prove." + tagline about signed/timestamped evidence
+2. How It Works (3 steps: Capture, Sign, Verify)
+3. Use Cases (Legal Evidence with FRE/eIDAS claims, Compliance, AI Agent, Journalism)
+4. Pricing
+
+Legal/compliance claims (FRE 901(b)(9), FRE 902(14), eIDAS Art. 41(2)) are currently in the Use Cases section under the "Legal Evidence" card.
+
+## External Skill Discovery
+Before analyzing the task, scan for project-local skills. If skills are discovered, include an "External Skill Integration" section in your meta-plan.
+
+## Instructions
+1. Read relevant files to understand the codebase context
+2. Discover external skills:
+   a. Scan .claude/skills/ and .skills/ in the working directory for SKILL.md files
+   b. Read frontmatter (name, description) for each discovered skill
+   c. For skills whose description matches the task domain, classify as ORCHESTRATION or LEAF
+   d. Check the project's CLAUDE.md for explicit skill preferences
+   e. Include discovered skills in your meta-plan output
+3. Analyze the task against your delegation table
+4. Identify which specialists should be CONSULTED FOR PLANNING (not execution — planning). These are agents whose domain expertise is needed to create a good plan.
+5. For each specialist, write a specific planning question that draws on their unique expertise.
+6. Return the meta-plan in the structured format.
+7. Write your complete meta-plan to /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-0wHqHc/landing-legal-claims-section-ordering/phase1-metaplan.md

--- a/docs/history/nefario-reports/2026-03-26-040037-landing-legal-section-ordering/phase1-metaplan.md
+++ b/docs/history/nefario-reports/2026-03-26-040037-landing-legal-section-ordering/phase1-metaplan.md
@@ -1,0 +1,65 @@
+# Meta-Plan: Landing Page Legal Claims and Section Ordering
+
+## Task Summary
+
+Evaluate and optimize the placement of legal/compliance claims (FRE 901(b)(9), FRE 902(14), eIDAS Art. 41(2)) and the "How It Works" section on the WRL landing page. Currently, legal claims are buried in a Use Cases card, and "How It Works" sits directly below the hero. The question is whether reordering these sections would improve trust-building and conversion.
+
+## Planning Consultations
+
+### Consultation 1: Content Hierarchy and Trust Signaling Strategy
+- **Agent**: ux-strategy-minion
+- **Planning question**: For a product whose primary value proposition is legal/evidentiary trust, what is the optimal information hierarchy? Specifically: (a) Should legal standard references (FRE 901/902, eIDAS) appear as trust signals in or near the hero, or does front-loading legalese create cognitive overload that undermines the "simple and approachable" first impression? (b) Should "How It Works" (a process explanation) sit between the hero and the value propositions (use cases), or does it delay the emotional payoff of seeing concrete use cases? Consider the two primary audience segments: technical integrators (developers, DevOps) and decision-makers (legal counsel, compliance officers).
+- **Context to provide**: Current index.html section order (Hero > How It Works > Use Cases > Pricing), the legal claims content currently in the Legal Evidence use case card, hero tagline text.
+- **Why this agent**: UX strategy owns information architecture, cognitive load assessment, and user journey coherence. This is fundamentally a question about what information to surface when and to whom.
+
+### Consultation 2: Trust Badge and Visual Hierarchy Patterns
+- **Agent**: ux-design-minion
+- **Planning question**: If we decide to surface legal claims higher on the page, what are effective visual patterns for presenting compliance/legal references without making them feel like a wall of legal text? Consider: trust badges/shields, compact reference strips, expandable details, or inline callouts in the hero or a dedicated trust section. What patterns work for B2B SaaS landing pages where compliance credentials are a key differentiator?
+- **Context to provide**: Current landing page HTML structure, CSS design system (design-system.css and landing.css), the specific claims (FRE 901(b)(9), FRE 902(14), eIDAS Art. 41(2)).
+- **Why this agent**: UX design owns visual hierarchy, component design, and interaction patterns. If claims move up, the visual treatment matters as much as the position.
+
+### Consultation 3: Product Positioning Impact
+- **Agent**: product-marketing-minion
+- **Planning question**: WRL targets both US (FRE) and EU (eIDAS) legal frameworks. From a positioning perspective: (a) Do legal standard references strengthen or weaken the hero's first impression for each audience segment? (b) Is there a risk that leading with legal jargon narrows the perceived audience (scares off the "journalism" and "AI agent" segments)? (c) Should the landing page lead with the technical mechanism (How It Works) or the outcomes (Use Cases) to maximize perceived value across all four use case segments?
+- **Context to provide**: The four use case segments (Legal Evidence, Compliance Archiving, AI Agent Grounding, Journalism), current hero copy, current section order.
+- **Why this agent**: Product marketing owns positioning, messaging hierarchy, and audience segmentation. This task is fundamentally about which message hits first for which audience.
+
+## Cross-Cutting Checklist
+
+- **Testing**: No -- this task is HTML/CSS section reordering. No executable logic changes. Visual verification via Lighthouse is sufficient (and explicitly in success criteria).
+- **Security**: No -- no new attack surface, no auth changes, no user input handling. Pure content reordering.
+- **Usability -- Strategy**: ALWAYS include -- see Consultation 1 above. This is the core question.
+- **Usability -- Design**: Include -- see Consultation 2 above. If claims move, visual treatment is critical.
+- **Documentation**: No for planning. If changes are made, the evolution log captures decisions. No user-facing docs or API surface changes.
+- **Observability**: No -- no runtime components, no services, no APIs affected.
+
+## Notable Exclusions
+
+- **accessibility-minion**: The success criteria already require Lighthouse accessibility checks. Section reordering does not introduce new a11y patterns -- existing semantic HTML (sections, headings, landmarks) remains intact. Will be included in Phase 3.5 architecture review if the plan involves new UI components.
+- **frontend-minion**: No framework code, no build tooling, no state management. This is vanilla HTML/CSS editing. If the execution plan involves new CSS components (e.g., trust badges), frontend-minion may be added at synthesis.
+- **seo-minion**: Scope explicitly excludes SEO metadata. Section reordering within the same page does not affect crawlability or structured data. The existing schema.org markup already lists FRE support in featureList.
+
+## Anticipated Approval Gates
+
+1. **Section ordering decision** (MUST gate): The decision on where legal claims go and whether "How It Works" moves is hard to reverse once implemented (it shapes the entire page flow) and all implementation tasks depend on it. This is the key decision point -- ux-strategy, ux-design, and product-marketing should converge on a recommendation before any HTML is touched.
+
+## Rationale
+
+This task sits at the intersection of three domains: information architecture (ux-strategy), visual design (ux-design), and messaging hierarchy (product-marketing). The technical implementation is straightforward HTML/CSS reordering, but the *decision* of what to move where requires domain expertise from all three perspectives. Each agent brings a different lens: ux-strategy on cognitive load and user journeys, ux-design on visual treatment options, and product-marketing on audience segmentation and positioning.
+
+## Scope
+
+- **In scope**: Hero banner content augmentation (trust signals), legal/compliance claims placement, "How It Works" section position relative to Use Cases, decision documentation.
+- **Out of scope**: Copy rewrites (wording changes beyond moving existing text), new sections, mobile-specific layout changes, SEO metadata, pricing section changes.
+
+## External Skill Integration
+
+### Discovered Skills
+
+| Skill | Location | Classification | Domain | Recommendation |
+|-------|----------|---------------|--------|----------------|
+| ops-runbook | .claude/skills/ops-runbook/ | LEAF | Infrastructure operations | Not relevant -- skip |
+
+### Precedence Decisions
+
+No external skills overlap with the task domain. No precedence decisions needed.

--- a/docs/history/nefario-reports/2026-03-26-040037-landing-legal-section-ordering/phase2-product-marketing-minion-prompt.md
+++ b/docs/history/nefario-reports/2026-03-26-040037-landing-legal-section-ordering/phase2-product-marketing-minion-prompt.md
@@ -1,0 +1,38 @@
+You are contributing to the PLANNING phase of a multi-agent project.
+You are NOT executing yet — you are providing your domain expertise to help build a comprehensive plan.
+
+## Project Task
+The landing page for Web Resource Ledger needs its legal/compliance claims and section ordering reviewed. The key decisions:
+1. Should legal standard references (FRE 901(b)(9), FRE 902(14), eIDAS Art. 41(2)) move to be more prominent?
+2. Should the "How It Works" section move below Use Cases?
+
+## Your Planning Question
+WRL targets both US (FRE) and EU (eIDAS) legal frameworks. From a positioning perspective: (a) Do legal standard references strengthen or weaken the hero's first impression for each audience segment? (b) Is there a risk that leading with legal jargon narrows the perceived audience (scares off journalism and AI agent segments)? (c) Should the landing page lead with the technical mechanism (How It Works) or the outcomes (Use Cases) to maximize perceived value across all four segments?
+
+## Context
+Four audience segments: Legal Evidence, Compliance Archiving, AI Agent Grounding, Journalism
+Current hero: "Web evidence you can prove." + "Capture any web page and get a signed, timestamped evidence bundle that anyone can independently verify -- no account, no trust in us required."
+Current section order: Hero > How It Works > Use Cases > Pricing
+Landing page: /Users/ben/github/benpeter/web-resource-ledger/.claude/worktrees/silly-kindling-jellyfish/landing/public/index.html
+
+## Instructions
+1. Read the landing page HTML to understand the current state
+2. Apply your domain expertise to the planning question
+3. Identify risks, dependencies, and requirements from your perspective
+4. Return your contribution in this format:
+
+## Domain Plan Contribution: product-marketing-minion
+
+### Recommendations
+<your expert recommendations for positioning and messaging hierarchy>
+
+### Proposed Tasks
+<specific tasks that should be in the execution plan>
+
+### Risks and Concerns
+<things that could go wrong from your domain perspective>
+
+### Additional Agents Needed
+<any specialists not yet involved who should be, and why>
+
+5. Write your complete contribution to /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-0wHqHc/landing-legal-claims-section-ordering/phase2-product-marketing-minion.md

--- a/docs/history/nefario-reports/2026-03-26-040037-landing-legal-section-ordering/phase2-product-marketing-minion.md
+++ b/docs/history/nefario-reports/2026-03-26-040037-landing-legal-section-ordering/phase2-product-marketing-minion.md
@@ -1,0 +1,77 @@
+## Domain Plan Contribution: product-marketing-minion
+
+### Recommendations
+
+#### (a) Legal standard references in the hero: Do not promote them
+
+Legal standard references (FRE 901(b)(9), FRE 902(14), eIDAS Art. 41(2)) should **not** move into the hero or become more prominent at the page level. Here is why, segment by segment:
+
+**For the Legal/E-discovery audience:** These references are powerful proof points, but they are *supporting evidence*, not the core message. The job-to-be-done for a lawyer is "prove what was on a webpage at a specific time in a way that survives a challenge." The FRE references validate that WRL can do this job -- they do not *define* the job. A lawyer scanning the page needs to see "evidence that survives challenges" before they need to see which specific rules it satisfies. The current placement inside the Legal Evidence use case card is correct positioning: the references appear exactly when the legal reader is evaluating whether WRL meets their specific requirements. Moving them higher would front-load specifics before establishing relevance.
+
+**For non-legal audiences (Journalism, AI Agents, Compliance):** FRE rule numbers are opaque jargon. A journalist sees "FRE 901(b)(9)" and thinks "this is not for me." An AI agent developer sees it and assumes the product is a legal niche tool. The GTM plan explicitly identifies six priority segments, only two of which (Legal/E-discovery and Digital Forensics) would respond positively to FRE references. Leading with legal citations narrows perceived audience at the exact moment when the page needs to cast the widest net.
+
+**Recommendation:** Keep legal standard references in the Legal Evidence use case card. Do not surface them in the hero, subhead, or any section header. The hero's job is to communicate the universal value proposition ("prove what was online, when") and let each segment self-select into their use case card for segment-specific proof points.
+
+One exception worth considering: a subtle credibility signal like "Designed for FRE and eIDAS evidence standards" as a small trust badge or fine-print line beneath the hero CTAs could work. It signals legal seriousness to lawyers without requiring non-lawyers to parse rule numbers. But this is a secondary optimization, not a priority change.
+
+#### (b) Risk of leading with legal jargon: Real and measurable
+
+Yes, there is a concrete risk. The GTM plan's Language Gap table already documents it: the landing page's vocabulary does not match what OSINT, compliance, or brand protection segments search for. Adding more legal jargon at the top of the page would widen this gap further.
+
+The specific risk model:
+
+1. **Narrowing effect on perceived audience.** When a product's first impression includes specialized legal citations, visitors who do not identify as "legal users" bounce. The journalism and AI agent segments are particularly vulnerable because their job-to-be-done ("preserve what I saw" / "ground agent claims in evidence") maps to the same product capabilities but uses entirely different language.
+
+2. **SEO signal confusion.** The meta description already mentions "FRE 901/902 evidence authentication support" in the structured data. Promoting legal citations in visible page copy would further weight the page toward legal search intent, potentially at the expense of terms like "forensic web capture," "OSINT capture tool," or "AI agent web evidence" that the GTM plan identifies as underserved.
+
+3. **Category perception risk.** WRL is executing a new-category play ("web evidence infrastructure"). The category is defined by the *outcome* (proof anyone can verify), not by the *compliance framework* it satisfies. Leading with FRE/eIDAS references repositions WRL as a "legal compliance tool" -- a smaller, more competitive category where PageFreezer, Page Vault, and Hanzo are established incumbents with enterprise sales teams.
+
+**Recommendation:** The legal standards should be discoverable, not dominant. The current use case card placement plus a future FAQ section (already in the GTM plan) is the right approach. FAQ entries like "Does WRL meet FRE 901(b)(9) requirements?" let legal searchers find what they need via SEO without imposing that language on the page's primary narrative.
+
+#### (c) Section ordering: Lead with Use Cases, not How It Works
+
+**Move Use Cases above How It Works.** Here is the positioning rationale:
+
+The current order (Hero > How It Works > Use Cases) follows a *product-out* narrative: "Here is what we built, here is how it works, here is who it is for." The problem is that visitors do not care how it works until they believe it solves their problem. The messaging hierarchy should be:
+
+1. **Core message** (Hero): "Web evidence you can prove." -- establishes the value.
+2. **"Is this for me?"** (Use Cases): Let each segment see themselves in the product. This is the moment of self-selection where a visitor decides to invest more attention.
+3. **"How does it actually work?"** (How It Works): Now that the visitor believes the product addresses their job-to-be-done, the mechanism becomes interesting and credibility-building.
+
+This follows the Jobs-to-be-Done principle: lead with the progress the customer is trying to make, then explain the mechanism that enables it.
+
+**Evidence from the competitive landscape:** PageFreezer, Hanzo, and Page Vault all lead their landing pages with use cases / outcomes before explaining their technical approach. The visitors WRL is competing for are trained to scan for "does this solve my problem" before "how does it work." The "How It Works" section is excellent content -- the three-step Capture/Sign/Verify narrative is clear and compelling -- but it is *credibility content*, not *discovery content*.
+
+**For developer-heavy segments (AI Agents, technical users):** Even developers evaluate "what does this do for me" before "how does it do it." The How It Works section will still appear on the page and in the nav. Developers who want to understand the mechanism first will click "How It Works" in the nav. But the default scroll-through experience should prioritize self-identification over mechanism.
+
+**Proposed section order:** Hero > Use Cases > How It Works > Pricing
+
+**Nav should update accordingly:** Use Cases | How It Works | Pricing | Docs
+
+### Proposed Tasks
+
+1. **Reorder sections: Use Cases above How It Works** -- Move the `#use-cases` section to appear directly after the hero, before `#how-it-works`. Update nav link order to match. Low risk, high impact on conversion for non-technical segments.
+
+2. **Update nav order** -- Change nav from "How It Works | Use Cases | Pricing | Docs" to "Use Cases | How It Works | Pricing | Docs" to match the new section order.
+
+3. **Keep legal references in current position** -- No change to FRE/eIDAS references. They stay in the Legal Evidence use case card where they serve as proof points for the right audience at the right moment.
+
+4. **Consider adding a subtle legal credibility signal below hero CTAs** (optional, lower priority) -- A single line like "Designed for FRE and eIDAS evidence standards" in smaller text below the "No credit card required" hint. This gives legal-segment visitors an early signal without dominating the hero. Should be evaluated after the section reorder ships.
+
+5. **Do not change the hero copy** -- "Web evidence you can prove" and the tagline work well across all segments. The core message is outcome-oriented and segment-neutral. No change needed.
+
+### Risks and Concerns
+
+1. **Section reorder could affect anchor link traffic.** If any external links point to `#how-it-works` or `#use-cases`, the anchors still work regardless of order -- no breakage risk. But monitor analytics for any change in scroll depth or bounce rate after the reorder.
+
+2. **Legal credibility signal (if added) must not overstate.** The FRCP research document is clear: "FRCP compliant" is a marketing term, not a legal standard. Any credibility signal must be defensible. "Designed for FRE and eIDAS evidence standards" is factual -- WRL was designed with these in mind. "FRE compliant" or "Legally admissible" would be overclaims per the Claims Readiness Ladder. The claims document explicitly lists "Court-admissible" as NOT YET CLAIMABLE.
+
+3. **Missing segments on the page.** The GTM plan identifies OSINT/Investigations and Brand Protection as priority segments that are not represented in the current use case cards. The section reorder makes Use Cases more prominent, which amplifies this gap. Adding OSINT and Brand Protection cards should be a fast follow (the GTM plan already flags this as needed). However, this is a separate task from the ordering question.
+
+4. **eIDAS reference accuracy.** The landing page references "eIDAS Art. 41(2)" in the Legal Evidence card. The Claims Readiness Ladder says eIDAS qualified timestamps are "DEFERRED (2027+)" with implementing acts still pending. The current card text says "optional qualified timestamps" which is accurate for the RFC 3161 upgrade path, but the specific article citation implies a level of eIDAS integration that may not yet be shipped. Verify that the eIDAS opt-in feature is actually live before keeping this reference prominent. If it is live (even as an opt-in), the reference is defensible. If not, it should be softened to "eIDAS-ready" or moved to a roadmap context.
+
+### Additional Agents Needed
+
+- **UX strategy review** -- The section reorder is a positioning decision, but there may be UX considerations (scroll depth, visual rhythm of alternating white/muted sections, CTA placement relative to the fold) that a UX specialist should evaluate. The current white/muted alternation pattern breaks if Use Cases (muted) follows the hero directly without a white section between them.
+
+- **SEO review** -- The meta description and structured data reference FRE 901/902. Keeping legal terms in metadata while removing them from visible above-the-fold copy is a deliberate SEO strategy (target legal search intent in metadata, keep page copy segment-neutral). An SEO-aware agent should verify this is optimal and check whether the heading hierarchy change (Use Cases h2 now appearing before How It Works h2) has any crawl/ranking implications.

--- a/docs/history/nefario-reports/2026-03-26-040037-landing-legal-section-ordering/phase2-ux-design-minion-prompt.md
+++ b/docs/history/nefario-reports/2026-03-26-040037-landing-legal-section-ordering/phase2-ux-design-minion-prompt.md
@@ -1,0 +1,38 @@
+You are contributing to the PLANNING phase of a multi-agent project.
+You are NOT executing yet — you are providing your domain expertise to help build a comprehensive plan.
+
+## Project Task
+The landing page for Web Resource Ledger needs its legal/compliance claims and section ordering reviewed. The key decisions:
+1. Should legal standard references (FRE 901(b)(9), FRE 902(14), eIDAS Art. 41(2)) move from their current position in the Use Cases section to higher on the page?
+2. What visual patterns should be used if claims are surfaced higher?
+
+## Your Planning Question
+If we decide to surface legal claims higher on the page, what are effective visual patterns for presenting compliance/legal references without making them feel like a wall of legal text? Consider: trust badges/shields, compact reference strips, expandable details, or inline callouts in the hero or a dedicated trust section. What patterns work for B2B SaaS landing pages where compliance credentials are a key differentiator?
+
+## Context
+Current landing page: /Users/ben/github/benpeter/web-resource-ledger/.claude/worktrees/silly-kindling-jellyfish/landing/public/index.html
+CSS files: landing/public/css/design-system.css and landing/public/css/landing.css
+The specific claims: FRE 901(b)(9), FRE 902(14), eIDAS Art. 41(2)
+The page uses vanilla CSS with custom properties (no framework).
+
+## Instructions
+1. Read the landing page HTML and CSS to understand the current state
+2. Apply your domain expertise to the planning question
+3. Identify risks, dependencies, and requirements from your perspective
+4. Return your contribution in this format:
+
+## Domain Plan Contribution: ux-design-minion
+
+### Recommendations
+<your expert recommendations for visual treatment of legal claims>
+
+### Proposed Tasks
+<specific tasks that should be in the execution plan>
+
+### Risks and Concerns
+<things that could go wrong from your domain perspective>
+
+### Additional Agents Needed
+<any specialists not yet involved who should be, and why>
+
+5. Write your complete contribution to /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-0wHqHc/landing-legal-claims-section-ordering/phase2-ux-design-minion.md

--- a/docs/history/nefario-reports/2026-03-26-040037-landing-legal-section-ordering/phase2-ux-design-minion.md
+++ b/docs/history/nefario-reports/2026-03-26-040037-landing-legal-section-ordering/phase2-ux-design-minion.md
@@ -1,0 +1,86 @@
+## Domain Plan Contribution: ux-design-minion
+
+### Recommendations
+
+#### Current State Assessment
+
+The landing page currently buries its strongest differentiator. The legal standard references (FRE 901(b)(9), FRE 902(14), eIDAS Art. 41(2)) are nested inside a single "Legal Evidence" use-case card within a four-column grid. They appear as a bulleted list at small text size (`--text-sm`), visually equivalent to the other three use cases. For the target audience -- legal, compliance, and enterprise buyers -- these credentials are not a feature detail; they are the reason to trust the product. They should be surfaced much earlier.
+
+#### Recommended Pattern: Compact Trust Strip Below the Hero
+
+The most effective pattern for B2B SaaS compliance credentials is a **trust strip** -- a narrow, horizontally-oriented band that sits directly below the hero section and above "How It Works." This pattern works because:
+
+1. **It occupies a natural visual pause.** After the hero's call-to-action, the eye scans downward. A trust strip catches this scan without requiring scroll commitment.
+2. **It does not read as legal text.** Unlike a paragraph or bulleted list, a horizontal strip with short labels reads as a credential bar -- similar to "As seen in" logos or certification badges. The format signals authority, not terms-and-conditions.
+3. **It respects the page rhythm.** The current flow is: Hero (dark bg) -> How It Works (white bg) -> Use Cases (muted bg). A trust strip can sit as a thin transition element between hero and How It Works, using the muted background to differentiate it from both adjacent sections without adding a heavy new section.
+
+#### Specific Visual Design
+
+**Layout: Horizontal label row, centered, single line on desktop, wrapping gracefully on mobile.**
+
+Each standard gets a compact "chip" presentation:
+
+```
+[shield-icon] FRE 901(b)(9)     [shield-icon] FRE 902(14)     [shield-icon] eIDAS Art. 41(2)
+   Evidence authentication          Self-authenticating              EU-qualified timestamps
+```
+
+Design details:
+
+- **Container**: Full-width band with `--color-surface-muted` background, vertical padding of `--space-4` to `--space-6` (much thinner than a full landing section). No `scroll-margin-top` or section ID needed -- this is not a navigation target.
+- **Layout**: Flexbox row, `justify-content: center`, `gap: var(--space-8)` between items. Each item is a flex column: bold standard reference on top (monospace or medium-weight sans), short plain-English descriptor below in `--text-sm` / `--color-text-muted`.
+- **Optional shield icon**: A small inline SVG shield (16x16 or 20x20) to the left of each standard name. This is the "trust badge" pattern distilled to its minimal form. It adds visual credibility without being kitschy. Use `--color-accent` (#3d7c9a) for the shield fill -- it already exists in the design system and reads as authoritative/institutional.
+- **No borders, no cards**: Each item should NOT be in its own card or bordered box. That creates visual heaviness. The items float as text in the strip. The background color change from hero to strip to white section provides sufficient visual grouping.
+- **Leading text** (optional): A small centered label above the three items: "Standards alignment" or "Evidence standards" in `--text-xs`, uppercase, `--color-text-muted`, `letter-spacing: 0.06em` -- matching the existing `.site-footer__heading` treatment. This gives context without a full heading.
+
+**Mobile (below 768px)**: Stack the three items vertically, left-aligned, with `gap: var(--space-4)`. The strip becomes a short vertical list. Each item remains compact (icon + name + descriptor on two lines).
+
+**Desktop (1024px+)**: Single row, centered. The three items should fit comfortably within the 1120px container.
+
+#### What Stays in the Use Cases Section
+
+The Legal Evidence use-case card should remain but can be simplified. Instead of repeating the three standards with full explanations, it becomes a narrative card: "Screenshots get challenged. WRL captures produce signed, timestamped evidence bundles designed for courtroom authentication." with a link to the legal evidence docs page. The standards themselves are already introduced in the trust strip; the use-case card tells the story of why they matter.
+
+This avoids the "wall of legal text" risk in both locations: the trust strip is too compact to feel like legal text, and the use-case card is now narrative rather than a list of statute numbers.
+
+#### Alternative Patterns Considered (Not Recommended)
+
+1. **Trust badges/shields as graphical icons**: Large shield graphics with standard names inside. Risks looking like generic "Norton Secured" badges that users have learned to ignore. Also requires custom SVG artwork that the current landing page does not have.
+
+2. **Expandable details/accordion**: Hiding standards behind `<details>` elements reduces their visibility to exactly zero for scanners. The whole point of surfacing them is that they should be visible without interaction.
+
+3. **Hero inline callout**: Putting standards references directly in the hero section (e.g., below the tagline). Too dense -- the hero's job is emotional/aspirational ("Web evidence you can prove"), not technical/credential. Mixing these dilutes both messages.
+
+4. **Dedicated "Compliance" section**: A full landing section with heading, description, and cards for each standard. This over-invests page real estate in what should be a quick credibility signal. Save the deep explanation for the docs page (which already exists at `/legal-evidence/`).
+
+5. **Banner/ribbon above the hero**: An alert-style banner pinned above the header. Reads as a promotion or warning, not a credential. Wrong semantic signal.
+
+### Proposed Tasks
+
+1. **Create trust strip HTML** -- Add a new `<section>` between the hero and "How It Works" with class `trust-strip`. Contains three items, each with an optional shield SVG, the standard reference, and a one-line descriptor. Aria: use `aria-label="Evidence standards"` on the section. The standard references are informational text, not interactive -- no special ARIA roles needed.
+
+2. **Create trust strip CSS** -- New styles in `landing.css` under a new section comment block. Flexbox row layout, responsive breakpoint at 768px for stacking. Use existing design tokens exclusively. Estimated: ~40 lines of CSS.
+
+3. **Create shield SVG icon** -- A simple, small (20x20 viewBox) shield outline in `--color-accent`. Inline in HTML (not an external file) for simplicity and to avoid an extra HTTP request. Keep it minimal: shield shape, no inner detail.
+
+4. **Simplify Legal Evidence use-case card** -- Remove the `<ul class="use-case-details">` list of three standards. Replace with a concise narrative paragraph. Keep the docs link.
+
+5. **Verify contrast** -- The trust strip text on `--color-surface-muted` (#f3f2f0) background: `--color-text` (#1e2a36) gives strong contrast. `--color-text-muted` (#6e6a66) on #f3f2f0 should be checked -- this combination is used extensively elsewhere on the page so presumably passes, but should be confirmed for the specific text sizes used in the strip.
+
+6. **Test responsive behavior** -- Verify the strip works at 320px, 768px, and 1024px+ breakpoints. Ensure touch targets are not relevant here (no interactive elements in the strip).
+
+### Risks and Concerns
+
+1. **Legal accuracy of simplified claims.** Moving standard references to a prominent position increases their visibility and therefore the scrutiny they will receive. The one-line descriptors must be technically accurate. "Evidence authentication" for FRE 901(b)(9) and "Self-authenticating" for FRE 902(14) are reasonable shorthand, but a legal reviewer (not a design decision) should confirm these do not overstate what WRL provides. The current use-case card uses careful language ("designed to support authentication under") -- the trust strip descriptors should maintain similar precision even in compressed form.
+
+2. **Implied certification risk.** Shield icons paired with legal standard numbers could be interpreted as "certified by" or "compliant with" these standards. WRL supports evidence authentication under these standards; it is not certified by any court or regulatory body. The visual treatment should avoid anything that reads as a certification mark. Using a generic shield icon (not a seal, not a checkmark-in-shield) and the word "alignment" rather than "compliance" or "certified" mitigates this.
+
+3. **Contrast verification for muted text.** The `--color-text-muted` (#6e6a66) on `--color-surface-muted` (#f3f2f0) combination appears throughout the page already, but at `--text-sm` size in the trust strip, it should be verified against APCA Lc targets. Quick mental math: #6e6a66 is mid-gray (~L 0.47 in OKLCH), #f3f2f0 is near-white (~L 0.96). The delta of ~0.49 in L should reach Lc 60+ but should be confirmed with an actual APCA calculator rather than estimated.
+
+4. **Section ordering change affects scroll anchors.** The nav links target `#how-it-works` and `#use-cases`. Adding the trust strip between hero and How It Works does not break these anchors, but it does push How It Works slightly further down the page. The `scroll-margin-top` on `.landing-section` should still work correctly since it is relative to the header height, not absolute position.
+
+### Additional Agents Needed
+
+- **Content/copy review**: The one-line descriptors for each standard need to be precise. Someone with legal domain knowledge should validate that the compressed phrasing does not overstate WRL's capabilities. This is a content accuracy concern, not a design concern.
+- **Frontend minion**: To implement the HTML/CSS changes. The trust strip is straightforward vanilla CSS -- no framework or JS needed. Should be implementable within the existing design system tokens.
+- **Accessibility minion**: Post-implementation, should verify the trust strip's contrast ratios at actual rendered sizes and confirm the section's landmark/heading structure does not disrupt the page's accessibility tree (since the strip intentionally omits an h2 heading, it should use `aria-label` on the section element instead).

--- a/docs/history/nefario-reports/2026-03-26-040037-landing-legal-section-ordering/phase2-ux-strategy-minion-prompt.md
+++ b/docs/history/nefario-reports/2026-03-26-040037-landing-legal-section-ordering/phase2-ux-strategy-minion-prompt.md
@@ -1,0 +1,41 @@
+You are contributing to the PLANNING phase of a multi-agent project.
+You are NOT executing yet — you are providing your domain expertise to help build a comprehensive plan.
+
+## Project Task
+The landing page for Web Resource Ledger needs its legal/compliance claims and section ordering reviewed. The key decisions:
+1. Should legal standard references (FRE 901(b)(9), FRE 902(14), eIDAS Art. 41(2)) move from their current position in the Use Cases section to the hero banner or a trust section near the top?
+2. Should "How It Works" move below Use Cases (or stay where it is)?
+
+## Your Planning Question
+For a product whose primary value proposition is legal/evidentiary trust, what is the optimal information hierarchy? Specifically: (a) Should legal standard references appear as trust signals in or near the hero, or does front-loading legalese create cognitive overload? (b) Should "How It Works" sit between hero and use cases, or does it delay the emotional payoff of concrete use cases? Consider two primary audience segments: technical integrators (developers, DevOps) and decision-makers (legal counsel, compliance officers).
+
+## Context
+Current section order: Hero > How It Works > Use Cases > Pricing
+- Hero: "Web evidence you can prove." + tagline about signed/timestamped evidence bundles
+- How It Works: 3-step process (Capture, Sign, Verify)
+- Use Cases: 4 cards (Legal Evidence with FRE/eIDAS claims, Compliance Archiving, AI Agent Grounding, Journalism)
+- Pricing: Usage-based + Enterprise
+
+The landing page is at: /Users/ben/github/benpeter/web-resource-ledger/.claude/worktrees/silly-kindling-jellyfish/landing/public/index.html
+
+## Instructions
+1. Read the landing page HTML to understand the current state
+2. Apply your domain expertise to the planning question
+3. Identify risks, dependencies, and requirements from your perspective
+4. Return your contribution in this format:
+
+## Domain Plan Contribution: ux-strategy-minion
+
+### Recommendations
+<your expert recommendations for section ordering and legal claims placement>
+
+### Proposed Tasks
+<specific tasks that should be in the execution plan>
+
+### Risks and Concerns
+<things that could go wrong from your domain perspective>
+
+### Additional Agents Needed
+<any specialists not yet involved who should be, and why>
+
+5. Write your complete contribution to /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-0wHqHc/landing-legal-claims-section-ordering/phase2-ux-strategy-minion.md

--- a/docs/history/nefario-reports/2026-03-26-040037-landing-legal-section-ordering/phase2-ux-strategy-minion.md
+++ b/docs/history/nefario-reports/2026-03-26-040037-landing-legal-section-ordering/phase2-ux-strategy-minion.md
@@ -1,0 +1,72 @@
+## Domain Plan Contribution: ux-strategy-minion
+
+### Recommendations
+
+#### (a) Legal standard references: trust signals near hero vs. current placement
+
+**Recommendation: Do NOT move the legal references into or immediately adjacent to the hero. Instead, add a lightweight trust bar between hero and How It Works, and keep the detailed legal references in Use Cases.**
+
+Rationale by audience segment:
+
+**Decision-makers (legal counsel, compliance officers)** -- These users scan for credibility markers early. They need to know within 5 seconds that this product speaks their language. But they do not need the full FRE/eIDAS citations in the hero. What they need is a trust signal -- a compressed indicator that this product is built for evidentiary standards. The full citations are the proof; the trust signal is the promise.
+
+**Technical integrators (developers, DevOps)** -- Front-loading legal citations creates cognitive overload for this audience. They satisfice on "is this technically sound?" and will bounce if the first screen reads like a legal brief. They need the hero to say "cryptographic proof" (which it does well), not "FRE 901(b)(9)."
+
+**The solution is a trust bar** -- a single horizontal strip of 3-4 compact badges or phrases placed between the hero and How It Works. Think: `Ed25519 Signatures | RFC 3161 Timestamps | FRE 901/902 Compatible | eIDAS Qualified`. No explanations, no bullet points -- just the names. This serves dual duty:
+
+- Legal/compliance decision-makers see the vocabulary they were scanning for and know they are in the right place. Their emotional response: "these people understand my world." This keeps them scrolling.
+- Technical integrators register the standards as credibility markers without having to parse legal context. Their reaction: "serious cryptography, not snake oil."
+
+The detailed citations (FRE 901(b)(9), FRE 902(14), eIDAS Art. 41(2)) stay in the Legal Evidence use case card where they currently live. That card is doing excellent work -- it explains *what each standard means for the user*. Moving those explanations to the hero would strip them of the context that makes them useful (the contrast with "screenshots get challenged").
+
+This follows progressive disclosure: trust signal early (recognition), detailed explanation later (recall). The trust bar is a Kano "must-be" for the legal audience -- its absence means they have to scroll past How It Works to find evidence the product is legally relevant. Its presence costs zero cognitive load for the technical audience (they skip it as "badges").
+
+#### (b) Section ordering: How It Works placement
+
+**Recommendation: Move Use Cases above How It Works. New order: Hero > Trust Bar > Use Cases > How It Works > Pricing.**
+
+Rationale:
+
+The current order (Hero > How It Works > Use Cases) follows a logical/pedagogical structure: here's what it is, here's how it works, here's who it's for. But landing pages are not textbooks. Users satisfice -- they need to find their reason to care before they invest attention in mechanism.
+
+**Use Cases answer "why should I care?" How It Works answers "how does it work?"** The JTBD framework makes this clear:
+
+- A compliance officer's job: "When I face an audit, I want timestamped evidence of our web content, so I can prove compliance on specific dates."
+- A litigation attorney's job: "When opposing counsel challenges a screenshot, I want evidence that meets FRE authentication standards, so it is admissible."
+- A developer's job: "When I need to capture web state programmatically, I want a reliable API, so I can integrate it into my workflow."
+
+All three jobs are articulated in Use Cases. None are articulated in How It Works. The three-step process (Capture, Sign, Verify) is mechanism -- it answers "how" after the user already cares about "why."
+
+**For decision-makers**: They are buying outcomes, not processes. "Signed, timestamped evidence bundles designed to support authentication under federal and EU evidence standards" is the sentence that gets them to schedule a demo. That sentence is currently below the fold, behind a section they may not read carefully. Moving Use Cases up means the first content they engage with after the hero speaks directly to their job.
+
+**For technical integrators**: They care about mechanism, but only after they know the product solves a real problem. A developer scanning this page will see the use case cards as "this product does something meaningful" and then read How It Works as "and here's how they pull it off technically." This is a stronger persuasion sequence.
+
+**Heuristic support**: Nielsen's "match between system and the real world" -- users think in terms of problems they have, not processes they don't yet understand. Krug's satisficing principle -- users will grab the first thing that resonates with their need and skip the rest. Use Cases are the resonance point.
+
+**One caveat**: The How It Works section is well-written and concise (3 steps, clean). It does not need to be removed or hidden. It just needs to follow the motivation, not precede it. The ordered list format (1-2-3) will feel even more satisfying after the user already understands why they want this product.
+
+### Proposed Tasks
+
+1. **Add trust bar between hero and first content section** -- A horizontal strip of 3-4 compact standard/technology references (Ed25519, RFC 3161, FRE 901/902, eIDAS). No explanations, just names. Visually understated -- muted text, small type, horizontal layout. This is a recognition aid, not a content section.
+
+2. **Reorder sections: Use Cases before How It Works** -- Move the Use Cases section above How It Works. Update the nav anchor order to match (Use Cases, How It Works, Pricing, Docs). The nav link text and section content remain unchanged.
+
+3. **Update nav link order** -- The header nav currently reads "How It Works | Use Cases | Pricing | Docs". After reordering sections, update to "Use Cases | How It Works | Pricing | Docs" so the nav matches the page flow.
+
+4. **Keep legal citations in the Legal Evidence card unchanged** -- The current FRE/eIDAS detail in the Legal Evidence use case card is well-structured and should not be duplicated, abbreviated, or moved. The trust bar and the card serve different cognitive functions (recognition vs. comprehension).
+
+### Risks and Concerns
+
+1. **Trust bar could feel like empty badging** -- If the trust bar has too many items or uses logos/shields, it risks looking like the "as seen on" strips that users have learned to distrust. Keep it text-only, 3-4 items max, with no visual embellishment beyond typography. The restraint itself communicates confidence.
+
+2. **Section reorder may break existing link shares** -- If anyone has shared links to `#how-it-works` or `#use-cases`, the anchors will still work (they are ID-based, not position-dependent). No risk here, but worth noting that bookmarks and anchor links are stable.
+
+3. **Decision-maker vs. integrator tension on Use Cases card order** -- The four use case cards are currently ordered: Legal Evidence, Compliance, AI Agent, Journalism. For the legal/compliance audience, Legal Evidence first is correct. But if the primary growth segment is developers (AI Agent Grounding), consider whether that card should be first. This is a business strategy question, not a UX question -- the information hierarchy should reflect which audience the business is prioritizing. Current order (legal first) is correct if the primary value proposition is evidentiary trust.
+
+4. **Cognitive load of Use Cases section** -- The Legal Evidence card is significantly denser than the other three (it has a bullet list with bold references). After moving Use Cases up, this card becomes one of the first things users read. The density is justified by the audience it serves, but if analytics show high bounce rates from this section, consider whether the card needs a "summary line + expandable detail" treatment. Do not pre-optimize -- measure first.
+
+### Additional Agents Needed
+
+- **ux-design-minion** -- To design the trust bar's visual treatment (typography scale, spacing, color, layout at different breakpoints). The trust bar must feel like a natural part of the page flow, not a bolted-on element.
+- **frontend-minion** -- To implement the section reorder and trust bar HTML/CSS. Straightforward work but the trust bar needs responsive behavior (likely wrapping on mobile).
+- **copywriting-minion** (if available) -- The trust bar items need exact phrasing. "FRE 901/902 Compatible" vs. "Federal Rules of Evidence" vs. "US & EU Evidence Standards" -- the word choice matters for both audiences. The current page copy is strong; this is a small but consequential detail.

--- a/docs/history/nefario-reports/2026-03-26-040037-landing-legal-section-ordering/phase3-synthesis-prompt.md
+++ b/docs/history/nefario-reports/2026-03-26-040037-landing-legal-section-ordering/phase3-synthesis-prompt.md
@@ -1,0 +1,40 @@
+MODE: SYNTHESIS
+
+You are synthesizing specialist planning contributions into a final execution plan.
+
+## Original Task
+The landing page presents legal/compliance claims and the "how this works" section in the most effective order, ensuring legal claims are prominent enough to build trust without overwhelming the initial impression.
+
+Success criteria:
+- Decision documented on whether legal claims belong in hero banner or below
+- Decision documented on whether "how this works" should move below other sections
+- Changes implemented if warranted
+- Landing page still passes Lighthouse performance and accessibility checks
+
+Scope:
+- In: Hero banner content, legal/compliance claims placement, "how this works" section position relative to other sections
+- Out: Copy rewrites, new sections, mobile-specific layout changes, SEO metadata
+
+## Specialist Contributions
+
+Read the following scratch files for full specialist contributions:
+- /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-0wHqHc/landing-legal-claims-section-ordering/phase2-ux-strategy-minion.md
+- /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-0wHqHc/landing-legal-claims-section-ordering/phase2-ux-design-minion.md
+- /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-0wHqHc/landing-legal-claims-section-ordering/phase2-product-marketing-minion.md
+
+## Key consensus across specialists:
+- ALL THREE agree: Move Use Cases section above How It Works. Rationale: outcomes (why should I care?) before mechanism (how does it work?). Follows JTBD principles.
+- ux-strategy + ux-design RECOMMEND: Add a trust bar/strip below hero with compact legal standard references (FRE 901/902, eIDAS). Progressive disclosure -- signal first, detail later.
+- product-marketing OPPOSES trust bar: Says legal standard refs are proof points for a specific segment, not the universal value prop. Only 2 of 6 priority segments respond positively to FRE citations. At most a subtle credibility line.
+- ALL agree: Keep detailed legal citations in the Legal Evidence use case card.
+
+## External Skills Context
+No external skills detected relevant to this task.
+
+## Instructions
+1. Review all specialist contributions
+2. Resolve the conflict on trust bar vs. no trust bar
+3. Incorporate risks and concerns into the plan
+4. Create the final execution plan in structured format
+5. Ensure every task has a complete, self-contained prompt
+6. Write your complete delegation plan to /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-0wHqHc/landing-legal-claims-section-ordering/phase3-synthesis.md

--- a/docs/history/nefario-reports/2026-03-26-040037-landing-legal-section-ordering/phase3-synthesis.md
+++ b/docs/history/nefario-reports/2026-03-26-040037-landing-legal-section-ordering/phase3-synthesis.md
@@ -1,0 +1,200 @@
+## Delegation Plan
+
+**Team name**: landing-section-ordering
+**Description**: Reorder landing page sections (Use Cases before How It Works) and resolve trust bar question. Implement changes and verify with Lighthouse.
+
+### Conflict Resolution: Trust Bar
+
+The key disagreement between specialists:
+
+- **ux-strategy-minion + ux-design-minion**: Add a trust strip below hero with compact legal standard references (FRE 901/902, eIDAS, Ed25519, RFC 3161). Progressive disclosure -- signal first, detail later.
+- **product-marketing-minion**: Opposes. Legal standard refs are proof points for only 2 of 6 priority segments. Leading with legal jargon narrows perceived audience. At most a subtle credibility line.
+
+**Resolution: No trust bar. Side with product-marketing-minion.**
+
+Why: The product-marketing argument is stronger on the evidence. The GTM plan identifies 6 priority segments, and FRE/eIDAS citations are meaningful to only 2 (Legal/E-discovery, Digital Forensics). The trust bar pattern works well when the credentials are universally relevant (like "SOC 2 Certified" for a B2B SaaS). Here, the credentials are segment-specific -- they are powerful proof points for the right audience but opaque jargon for everyone else. The current placement inside the Legal Evidence use case card is correct: it delivers the proof points exactly when the legal reader is evaluating fit, without imposing legal vocabulary on the page's primary narrative.
+
+The ux-strategy argument about "legal audience needing to see vocabulary within 5 seconds" is valid, but the section reorder addresses this more effectively: moving Use Cases above How It Works means the Legal Evidence card (with its FRE/eIDAS references) becomes the first content section after the hero. Legal readers will find their vocabulary quickly without a trust bar.
+
+Additionally, the ux-design-minion's proposal to simplify the Legal Evidence card (removing the standards list, replacing with narrative) would strip out the very detail that makes the card effective for its target audience. Rejected.
+
+### Task 1: Reorder sections and update nav
+- **Agent**: frontend-minion
+- **Delegation type**: standard
+- **Model**: sonnet
+- **Mode**: bypassPermissions
+- **Blocked by**: none
+- **Approval gate**: no
+- **Prompt**: |
+    You are modifying the WRL landing page to reorder sections and update navigation.
+
+    ## What to do
+
+    Make two changes to `/Users/ben/github/benpeter/web-resource-ledger/.claude/worktrees/silly-kindling-jellyfish/landing/public/index.html`:
+
+    **1. Move the Use Cases section above How It Works.**
+
+    Current order in the HTML:
+    ```
+    Hero → How It Works (#how-it-works, landing-section--white) → Use Cases (#use-cases, landing-section--muted) → Pricing
+    ```
+
+    New order:
+    ```
+    Hero → Use Cases → How It Works → Pricing
+    ```
+
+    Cut the entire `<!-- Use Cases -->` section (lines 149-188, from `<!-- Use Cases -->` comment through the closing `</section>`) and paste it before the `<!-- How It Works -->` section.
+
+    **Important: Swap the background classes when reordering.** The page alternates white/muted backgrounds. After the move:
+    - Use Cases (now first after hero) gets `landing-section--white` (was `--muted`)
+    - How It Works (now second) gets `landing-section--muted` (was `--white`)
+
+    This maintains the visual alternation: Hero (dark) → Use Cases (white) → How It Works (muted) → Pricing (white).
+
+    **2. Update the nav link order to match.**
+
+    In the `<nav aria-label="Main">` element, change the link order from:
+    ```html
+    <a href="#how-it-works">How It Works</a>
+    <a href="#use-cases">Use Cases</a>
+    ```
+    to:
+    ```html
+    <a href="#use-cases">Use Cases</a>
+    <a href="#how-it-works">How It Works</a>
+    ```
+
+    The Pricing, Docs, and Sign in links stay in their current positions.
+
+    ## What NOT to do
+
+    - Do NOT change any copy or content within sections
+    - Do NOT add new sections, elements, or classes
+    - Do NOT modify the CSS file
+    - Do NOT add a trust bar or trust strip
+    - Do NOT change the Legal Evidence use case card content
+    - Do NOT modify the hero section
+    - Do NOT change any IDs, aria attributes, or structured data
+
+    ## Why
+
+    All three specialists agreed: Use Cases answers "why should I care?" while How It Works answers "how does it work?" Leading with outcomes before mechanism follows Jobs-to-be-Done principles and improves the page for all audience segments. The section reorder also means legal/compliance readers encounter the Legal Evidence card (with its FRE/eIDAS references) earlier in the scroll, addressing the trust signal concern without needing a separate trust bar.
+
+    ## Deliverables
+
+    Modified file: `landing/public/index.html`
+
+    ## Success criteria
+
+    - Use Cases section appears before How It Works in the HTML source
+    - Background classes alternate correctly (white → muted → white)
+    - Nav links appear in order: Use Cases, How It Works, Pricing, Docs, Sign in
+    - All anchor IDs (#use-cases, #how-it-works) are preserved unchanged
+    - No other content changes
+- **Deliverables**: Modified `landing/public/index.html` with reordered sections and nav
+- **Success criteria**: Use Cases before How It Works, alternating backgrounds maintained, nav order matches section order
+
+### Task 2: Lighthouse verification
+- **Agent**: frontend-minion
+- **Delegation type**: standard
+- **Model**: sonnet
+- **Mode**: default
+- **Blocked by**: Task 1
+- **Approval gate**: no
+- **Prompt**: |
+    Run Lighthouse performance and accessibility audits on the modified landing page to verify the section reorder did not introduce regressions.
+
+    ## What to do
+
+    1. Serve the landing page locally. The landing page is static HTML in `/Users/ben/github/benpeter/web-resource-ledger/.claude/worktrees/silly-kindling-jellyfish/landing/public/`. Use any simple static file server (e.g., `npx serve landing/public` or Python's http.server).
+
+    2. Run Lighthouse CLI against the local server:
+    ```bash
+    npx lighthouse http://localhost:<port>/ --output=json --output=html --output-path=/tmp/wrl-landing-lighthouse --only-categories=performance,accessibility
+    ```
+
+    3. Check the results:
+       - Accessibility score should be 95+
+       - Performance score should be 90+
+       - No new accessibility violations related to heading order, landmark structure, or navigation
+
+    4. If scores are below thresholds, investigate and report which specific audits failed.
+
+    ## What NOT to do
+
+    - Do NOT modify any files based on Lighthouse results -- just report findings
+    - Do NOT run SEO or best-practices categories (out of scope)
+
+    ## Deliverables
+
+    Report the Lighthouse accessibility and performance scores. Flag any regressions.
+
+    ## Success criteria
+
+    - Accessibility score >= 95
+    - Performance score >= 90
+    - No heading-order warnings from the section reorder
+- **Deliverables**: Lighthouse score report confirming no regressions
+- **Success criteria**: Accessibility >= 95, Performance >= 90, no heading-order warnings
+
+### Cross-Cutting Coverage
+
+- **Testing**: No code logic changes -- this is a static HTML section reorder. Lighthouse verification (Task 2) covers accessibility and performance testing. No unit/integration tests needed.
+- **Security**: No security surface changes. No new inputs, endpoints, auth flows, or dependencies. Excluded.
+- **Usability -- Strategy**: Covered by ux-strategy-minion's planning contribution. The section reorder implements their primary recommendation. Trust bar was evaluated and rejected with documented rationale.
+- **Usability -- Design**: Covered by ux-design-minion's planning contribution. The background class swap maintains visual rhythm. No new UI components being added (trust bar rejected).
+- **Documentation**: No architectural or API changes. The evolution log (required by CLAUDE.md) will be handled by the calling session's post-execution phases. No dedicated documentation task needed within this plan.
+- **Observability**: No runtime components affected. Excluded.
+
+### Architecture Review Agents
+
+- **Mandatory** (5): security-minion, test-minion, ux-strategy-minion, lucy, margo
+- **Discretionary picks**:
+  - accessibility-minion: The section reorder changes heading order in the DOM. Worth a quick check that the accessibility tree remains coherent, especially since the heading hierarchy (h2 for Use Cases, h2 for How It Works) stays flat but the landmark/section order changes.
+    Review focus: Heading order in DOM after section swap, landmark structure, nav link order matching content order.
+- **Not selected**:
+  - ux-design-minion: No new visual elements being added. The background class swap is mechanical. Design review not needed for a section reorder.
+  - sitespeed-minion: No new assets, scripts, or layout changes that would affect Core Web Vitals. Lighthouse in Task 2 covers performance.
+  - observability-minion: No runtime components.
+  - user-docs-minion: No user-facing documentation changes needed for a section reorder.
+
+### Decisions
+
+- **Trust bar: rejected**
+  Chosen: No trust bar. Legal standard references remain only in the Legal Evidence use case card.
+  Over: Trust strip below hero with compact standard badges (advocated by ux-strategy-minion and ux-design-minion).
+  Why: Legal citations are meaningful to only 2 of 6 priority segments. The section reorder already moves legal proof points closer to the top of the page. Adding a trust bar with FRE rule numbers risks narrowing perceived audience for the 4 non-legal segments, and the product-marketing analysis of category perception risk (positioning WRL as a "legal compliance tool" rather than "web evidence infrastructure") is compelling.
+
+- **Legal Evidence card content: preserved as-is**
+  Chosen: Keep the detailed FRE/eIDAS bullet list in the Legal Evidence use case card.
+  Over: Simplify the card to narrative-only, removing standard citations (advocated by ux-design-minion).
+  Why: The bullet list with specific rule references is the card's primary value for its target audience. Removing them to avoid "density" would weaken the card for the legal segment that it specifically serves. The card is one of four in a grid -- density in one card does not overwhelm the section.
+
+### Risks and Mitigations
+
+1. **Background alternation after reorder** -- Swapping sections without swapping background classes would create two consecutive same-colored sections (muted → muted or white → white). Mitigated by explicitly including background class swap in the task prompt.
+
+2. **Legal credibility signal timing** -- By rejecting the trust bar, legal/compliance visitors must scroll past the hero to find legal vocabulary. Mitigated by the section reorder itself: the Legal Evidence card is now the first content card after the hero, significantly reducing scroll distance to legal proof points.
+
+3. **Use case card order within grid** -- product-marketing-minion noted that if the primary growth segment is developers (AI Agent Grounding), that card should perhaps be first rather than Legal Evidence. This is a separate business strategy decision, explicitly out of scope for this task.
+
+4. **eIDAS accuracy concern** -- product-marketing-minion flagged that eIDAS Art. 41(2) references may overstate current capabilities if qualified timestamps are not yet shipping. This is a copy accuracy question, out of scope for this section-ordering task, but flagged for follow-up.
+
+### Execution Order
+
+```
+Batch 1 (sequential):
+  Task 1: Reorder sections and update nav
+  Task 2: Lighthouse verification (blocked by Task 1)
+```
+
+Single approval gate: none. Both changes are easily reversible (additive HTML reorder) with zero downstream dependents.
+
+### Verification Steps
+
+1. Visual inspection: Open index.html in a browser. Confirm Use Cases appears after hero, How It Works appears after Use Cases.
+2. Scroll test: Confirm smooth scroll from nav links lands on correct sections.
+3. Background alternation: Confirm visual pattern is hero (dark) → use cases (white) → how it works (muted) → pricing (white).
+4. Anchor stability: Confirm `#use-cases` and `#how-it-works` anchors still work correctly.
+5. Lighthouse: Accessibility >= 95, Performance >= 90 (Task 2).

--- a/docs/history/nefario-reports/2026-03-26-040037-landing-legal-section-ordering/phase3.5-accessibility-minion.md
+++ b/docs/history/nefario-reports/2026-03-26-040037-landing-legal-section-ordering/phase3.5-accessibility-minion.md
@@ -1,0 +1,17 @@
+## Verdict: APPROVE
+
+### Review Summary
+
+The section reorder is a clean structural swap with no accessibility regressions.
+
+**Heading hierarchy** -- Both sections use `<h2>` headings (`#how-it-works-heading`, `#use-cases-heading`). They are siblings in the heading tree. Swapping their DOM order does not create any heading level gaps or violations. The `<h3>` headings nested inside each section travel with their parent, so the h1 → h2 → h3 hierarchy is fully preserved regardless of order.
+
+**Landmark structure** -- Both sections are `<section>` elements with `aria-labelledby` pointing to their respective `<h2>`. The landmark names are unique and meaningful in both the before and after state. No landmark integrity issues.
+
+**Nav link order** -- The plan explicitly swaps the nav links to match the new section order. After the change, the nav reads: Use Cases → How It Works → Pricing → Docs → Sign in, which matches the DOM order of the page sections. This is correct per WCAG 2.4.3 (Focus Order) and aligns with user expectations for in-page anchor navigation.
+
+**Skip link** -- The `<a class="sr-only skip-link" href="#content">` targets `<main id="content">`, which is unaffected.
+
+**Background class swap** -- CSS class changes only. No semantic or structural impact on the accessibility tree.
+
+**WCAG concerns** -- None. This change does not touch IDs, aria attributes, roles, or interactive elements. The Lighthouse accessibility verification in Task 2 (target >= 95) provides an appropriate automated safety net.

--- a/docs/history/nefario-reports/2026-03-26-040037-landing-legal-section-ordering/phase3.5-lucy.md
+++ b/docs/history/nefario-reports/2026-03-26-040037-landing-legal-section-ordering/phase3.5-lucy.md
@@ -1,0 +1,36 @@
+# Lucy Review: landing-section-ordering
+
+## Verdict: APPROVE
+
+## Requirements Traceability
+
+| Requirement (from prompt.md) | Plan Element | Status |
+|---|---|---|
+| Decision on whether legal claims belong in hero banner or below | Trust bar rejected; legal claims stay in Legal Evidence card (Decisions section) | Covered |
+| Decision on whether "how this works" should move below other sections | Use Cases moved above How It Works (Task 1) | Covered |
+| Changes implemented if warranted | Task 1 implements the reorder | Covered |
+| Lighthouse performance and accessibility checks | Task 2 runs Lighthouse with thresholds | Covered |
+| Scope-out: copy rewrites | Task 1 prompt explicitly forbids content changes | Respected |
+| Scope-out: new sections | Task 1 prompt explicitly forbids new elements; trust bar rejected | Respected |
+| Scope-out: mobile-specific layout changes | No mobile work in plan | Respected |
+| Scope-out: SEO metadata | Task 2 explicitly excludes SEO category | Respected |
+
+No orphaned tasks. No unaddressed requirements.
+
+## Scope Assessment
+
+The plan contains exactly 2 tasks for a section reorder and verification. Proportional to the problem. No scope creep detected.
+
+The trust bar discussion was necessary to resolve the "legal claims placement" requirement from the prompt. The decision to reject it is well-documented with segment-specific reasoning rather than hand-waving. The plan correctly identifies this as a scope question (where to place existing content) rather than a content creation question.
+
+## CLAUDE.md Compliance
+
+- **Evolution log**: Plan notes documentation will be handled by the calling session's post-execution phases. This is acceptable -- CLAUDE.md assigns that responsibility to the session, not the delegation plan.
+- **Engineering philosophy (YAGNI/KISS)**: Rejecting the trust bar aligns with YAGNI. The section reorder is the minimal change that addresses the stated concern.
+- **Vanilla solutions preference**: No new dependencies or frameworks introduced.
+- **Backlog update**: Not mentioned in the plan, but the prompt's scope is narrow enough (reorder existing sections) that no new backlog items are expected. The eIDAS accuracy flag in Risk 4 is appropriately noted for follow-up without expanding scope.
+
+## Minor Observations (no action required)
+
+- Task 1 references specific line numbers (149-188) which may drift if the file has been edited since the plan was written. The task prompt also describes the sections by comment markers and content, which is sufficient for the agent to locate them regardless.
+- Risk 3 (use case card order within grid) is correctly scoped out. Good discipline.

--- a/docs/history/nefario-reports/2026-03-26-040037-landing-legal-section-ordering/phase3.5-margo.md
+++ b/docs/history/nefario-reports/2026-03-26-040037-landing-legal-section-ordering/phase3.5-margo.md
@@ -1,0 +1,29 @@
+## Margo — Complexity Review
+
+**Verdict: APPROVE**
+
+This plan is proportional to the task. Two HTML edits (section swap + nav link swap) handled by one task, followed by a mechanical Lighthouse check. No new dependencies, no new abstractions, no new code.
+
+### Observations
+
+1. **Task count is appropriate.** The request is "reorder two sections." The plan has two tasks: make the edit, verify with Lighthouse. That is the minimum responsible scope.
+
+2. **No accidental complexity introduced.** No new CSS classes, no new JS, no new build steps, no framework additions. The background class swap is the only non-obvious detail and it is correctly specified.
+
+3. **Trust bar rejection is sound from a complexity standpoint.** Adding a new UI component (trust strip with badges) for a section-ordering task would be scope creep. The plan correctly defers it.
+
+4. **The "What NOT to do" guardrails are well-scoped.** They prevent the executing agent from gold-plating.
+
+5. **Lighthouse task is lightweight but justified.** For a DOM reorder that changes heading/landmark sequence, a quick accessibility check is the minimum due diligence, not over-engineering.
+
+### Complexity Budget
+
+| Item | Cost | Column |
+|------|------|--------|
+| (no new technology) | 0 | — |
+| (no new services) | 0 | — |
+| (no new abstractions) | 0 | — |
+| (no new dependencies) | 0 | — |
+| **Total** | **0** | — |
+
+No flags. Ship it.

--- a/docs/history/nefario-reports/2026-03-26-040037-landing-legal-section-ordering/phase3.5-security-minion.md
+++ b/docs/history/nefario-reports/2026-03-26-040037-landing-legal-section-ordering/phase3.5-security-minion.md
@@ -1,0 +1,11 @@
+## Security Review: landing-legal-claims-section-ordering
+
+**Verdict: APPROVE**
+
+This plan makes two changes to a static HTML file: reordering two `<section>` blocks and swapping two nav `<a>` elements. There are no new attack surfaces, no auth or input handling changes, no new dependencies, no script additions, and no server-side components touched.
+
+The Lighthouse verification task runs against localhost only and is read-only (no file modifications). No security concerns.
+
+One minor note flagged in the plan itself (eIDAS Art. 41(2) accuracy) is a legal accuracy concern, not a security vulnerability. Out of scope here and correctly deferred.
+
+No action required from security perspective.

--- a/docs/history/nefario-reports/2026-03-26-040037-landing-legal-section-ordering/phase3.5-test-minion.md
+++ b/docs/history/nefario-reports/2026-03-26-040037-landing-legal-section-ordering/phase3.5-test-minion.md
@@ -1,0 +1,15 @@
+## Test Minion Review
+
+**Verdict: APPROVE**
+
+This is a static HTML section reorder with no code logic, no new dependencies, and no runtime components. The verification strategy is proportionate:
+
+- Task 1 success criteria are structural and diffable (section order in HTML source, background classes, nav link order, anchor IDs preserved). These are mechanical checks that frontend-minion can verify directly on the file.
+- Task 2 Lighthouse audit covers the two dimensions that a DOM reorder could realistically affect: accessibility (heading order, landmark structure, nav coherence) and performance (no regressions).
+- The threshold targets (accessibility >= 95, performance >= 90) are concrete and observable.
+
+No unit or integration tests are warranted here. Adding automated tests for HTML section ordering would be testing the editor, not the product.
+
+One minor note: the plan relies on visual inspection for the background alternation check (Verification Step 3), which is manual. This is fine given the change is CSS class names — the structural check (Task 1 success criteria) verifies the class names are correct, and Lighthouse's layout audit would surface any visual contrast issues. The manual step is belt-and-suspenders.
+
+The eIDAS accuracy concern flagged as a risk is correctly deferred — it is a copy accuracy question, not in scope here, and does not affect whether this plan's verification is adequate.

--- a/docs/history/nefario-reports/2026-03-26-040037-landing-legal-section-ordering/phase3.5-ux-strategy-minion.md
+++ b/docs/history/nefario-reports/2026-03-26-040037-landing-legal-section-ordering/phase3.5-ux-strategy-minion.md
@@ -1,0 +1,21 @@
+## UX Strategy Review
+
+**Verdict: APPROVE**
+
+### Assessment
+
+The plan executes a single, high-value UX improvement with minimal scope and tight constraints. From a user journey and cognitive load perspective, this is sound.
+
+**Section reorder is the right call.** "Use Cases" answers the visitor's first question: "Is this for me?" "How It Works" answers their second: "How does it work?" The current order inverts this natural evaluation sequence. Moving Use Cases first follows JTBD logic -- users are scanning for evidence that the product fits their job before they invest in understanding the mechanism.
+
+**Trust bar rejection is well-reasoned.** The synthesis correctly identifies the category risk: FRE/eIDAS vocabulary in a hero-level trust strip signals "legal compliance tool" to all six audience segments, not just the two for whom it's meaningful. The section reorder achieves the same goal -- legal vocabulary surfaces early in the scroll for legal readers -- without the audience-narrowing side effect. This is a good application of progressive disclosure: specialized proof points appear at the point where the right reader is already evaluating fit.
+
+**Legal Evidence card preservation is correct.** The density in that card is its functional value for the legal segment. Removing specificity to reduce visual density would be trading the card's effectiveness for aesthetic tidiness. The right audience expects and values the specificity.
+
+### One flag (non-blocking)
+
+The plan notes (Risk 4) that the eIDAS Art. 41(2) reference may overstate current capabilities if qualified timestamps aren't yet shipping. This is copy accuracy, out of scope here, but it's a real trust risk: a legal reader who verifies the claim and finds it unsupported will lose confidence in the entire product. Flag for follow-up before the next public promotion of this page.
+
+### Summary
+
+This is a tight, coherent change. It reduces the cognitive distance between what a visitor needs to know and where they find it. No simplification opportunities are being missed; the plan correctly rejects additive complexity (trust bar) in favor of structural improvement (section order). Execute as planned.

--- a/docs/history/nefario-reports/2026-03-26-040037-landing-legal-section-ordering/prompt.md
+++ b/docs/history/nefario-reports/2026-03-26-040037-landing-legal-section-ordering/prompt.md
@@ -1,0 +1,11 @@
+**Outcome**: The landing page presents legal/compliance claims and the "how this works" section in the most effective order, ensuring legal claims are prominent enough to build trust without overwhelming the initial impression.
+
+**Success criteria**:
+- Decision documented on whether legal claims belong in hero banner or below
+- Decision documented on whether "how this works" should move below other sections
+- Changes implemented if warranted
+- Landing page still passes Lighthouse performance and accessibility checks
+
+**Scope**:
+- In: Hero banner content, legal/compliance claims placement, "how this works" section position relative to other sections
+- Out: Copy rewrites, new sections, mobile-specific layout changes, SEO metadata

--- a/landing/public/index.html
+++ b/landing/public/index.html
@@ -88,8 +88,8 @@
         <span class="site-header__wordmark">Web Resource Ledger</span>
       </a>
       <nav aria-label="Main">
-        <a href="#how-it-works">How It Works</a>
         <a href="#use-cases">Use Cases</a>
+        <a href="#how-it-works">How It Works</a>
         <a href="#pricing">Pricing</a>
         <a href="https://docs.webresourceledger.com">Docs</a>
         <a href="https://api.webresourceledger.com/auth/login" class="btn btn--primary btn--sm">Sign in</a>
@@ -114,40 +114,8 @@
       </div>
     </section>
 
-    <!-- How It Works -->
-    <section id="how-it-works" class="landing-section landing-section--white" aria-labelledby="how-it-works-heading">
-      <div class="container">
-        <div class="section-header">
-          <h2 id="how-it-works-heading">How It Works</h2>
-        </div>
-        <ol class="steps">
-          <li class="step">
-            <div class="step__number" aria-hidden="true">1</div>
-            <div class="step__body">
-              <h3>Capture</h3>
-              <p>Submit a URL. WRL renders the page in a headless browser, captures a screenshot, the rendered HTML, and HTTP headers -- recording what the page looked like at that moment.</p>
-            </div>
-          </li>
-          <li class="step">
-            <div class="step__number" aria-hidden="true">2</div>
-            <div class="step__body">
-              <h3>Sign</h3>
-              <p>Every artifact is hashed, bundled into a WACZ archive, and signed with Ed25519. An independent RFC 3161 timestamp from a third-party authority anchors the capture to a specific point in time.</p>
-            </div>
-          </li>
-          <li class="step">
-            <div class="step__number" aria-hidden="true">3</div>
-            <div class="step__body">
-              <h3>Verify</h3>
-              <p>Share the verification link with anyone. They can confirm the content has not been altered and the timestamp is authentic -- no account needed, no trust in you required.</p>
-            </div>
-          </li>
-        </ol>
-      </div>
-    </section>
-
     <!-- Use Cases -->
-    <section id="use-cases" class="landing-section landing-section--muted" aria-labelledby="use-cases-heading">
+    <section id="use-cases" class="landing-section landing-section--white" aria-labelledby="use-cases-heading">
       <div class="container">
         <div class="section-header">
           <h2 id="use-cases-heading">Built for teams who need proof, not promises.</h2>
@@ -184,6 +152,38 @@
           </article>
 
         </div>
+      </div>
+    </section>
+
+    <!-- How It Works -->
+    <section id="how-it-works" class="landing-section landing-section--muted" aria-labelledby="how-it-works-heading">
+      <div class="container">
+        <div class="section-header">
+          <h2 id="how-it-works-heading">How It Works</h2>
+        </div>
+        <ol class="steps">
+          <li class="step">
+            <div class="step__number" aria-hidden="true">1</div>
+            <div class="step__body">
+              <h3>Capture</h3>
+              <p>Submit a URL. WRL renders the page in a headless browser, captures a screenshot, the rendered HTML, and HTTP headers -- recording what the page looked like at that moment.</p>
+            </div>
+          </li>
+          <li class="step">
+            <div class="step__number" aria-hidden="true">2</div>
+            <div class="step__body">
+              <h3>Sign</h3>
+              <p>Every artifact is hashed, bundled into a WACZ archive, and signed with Ed25519. An independent RFC 3161 timestamp from a third-party authority anchors the capture to a specific point in time.</p>
+            </div>
+          </li>
+          <li class="step">
+            <div class="step__number" aria-hidden="true">3</div>
+            <div class="step__body">
+              <h3>Verify</h3>
+              <p>Share the verification link with anyone. They can confirm the content has not been altered and the timestamp is authentic -- no account needed, no trust in you required.</p>
+            </div>
+          </li>
+        </ol>
       </div>
     </section>
 


### PR DESCRIPTION
## Summary

Reordered the WRL landing page sections: Use Cases now appears before How It Works, leading with outcomes before mechanism. Rejected adding a trust bar with legal standard references — the section reorder already moves legal proof points (FRE 901/902, eIDAS) closer to the top of the page without narrowing perceived audience. Lighthouse verification passed: performance 100, accessibility 96.

## Key Decisions

1. **No trust bar** — Legal citations meaningful to only 2 of 6 audience segments. Adding them near the hero risks repositioning WRL as a "legal compliance tool" rather than "web evidence infrastructure."
2. **Use Cases above How It Works** — Unanimous specialist agreement. Outcomes before mechanism follows JTBD principles.
3. **Legal Evidence card preserved** — Detailed FRE/eIDAS bullet list stays as-is for its target audience.

## Changes

- `landing/public/index.html`: Section reorder (Use Cases ↔ How It Works), background class swap, nav link reorder

## Verification

- Lighthouse Performance: 100 (threshold: 90)
- Lighthouse Accessibility: 96 (threshold: 95)
- 6 architecture reviewers: all APPROVE

## Test plan

- [x] Lighthouse performance >= 90
- [x] Lighthouse accessibility >= 95
- [ ] Visual check: sections alternate white/muted/white correctly
- [ ] Nav anchor links scroll to correct sections

Resolves #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)
