### PR TITLE
feat(landing,docs): feature list and competitor comparison table (#144)

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -142,6 +142,12 @@ Deferred items with explicit activation triggers. Revisit when condition is met.
 | [consider] SMS/push notification channels | When email alone proves insufficient for urgent alerts | Phase 0072, out-of-scope |
 | [consider] Provision RESEND_API_KEY secrets (staging + production) | Before production deployment; manual ops step via wrangler secret put | Phase 0072, iac-minion |
 
+### Docs Site
+
+| Item | Condition | Source |
+|------|-----------|--------|
+| [consider] Docs site SEO infrastructure (canonical tags, OG tags, BreadcrumbList) | When organic search traffic to docs is a priority | Phase 0090, seo-minion |
+
 ### MCP (R15 expanded -- extensions)
 
 | Item | Condition | Source |
@@ -232,7 +238,7 @@ Deferred items with explicit activation triggers. Revisit when condition is met.
 | [consider] GTM metrics: Cloudflare Web Analytics + Search Console (#148) | Phase 0066 shipped (ecosystem push); activate when measuring GTM impact | GTM research |
 | [consider] SEO optimization for landing page (#136) | Phase 0066 shipped; activate when organic search traffic is a priority | GTM research |
 | [consider] Generative Engine Optimization / GEO (#137) | Phase 0066 shipped; activate when AI search visibility is a priority | GTM research |
-| ~~[consider] Feature list and competitor comparison (#144)~~ | ~~When landing page content refresh (Phase 0074)~~ -- DONE (Phase 0074): Legal Evidence card with FRE 901/902 + eIDAS references on landing page, verification comparison table on docs site (Issue #142) | GTM research |
+| ~~[consider] Feature list and competitor comparison (#144)~~ | ~~When landing page content refresh~~ -- DONE (Phase 0090): Feature list section (10 capabilities) on landing page, summary comparison table (4 competitors), full comparison page on docs site (9 competitors × 7 columns) (Issue #144) | GTM research |
 
 ---
 

--- a/docs/evolution/0090-feature-list-competitor-comparison/decisions.md
+++ b/docs/evolution/0090-feature-list-competitor-comparison/decisions.md
@@ -1,0 +1,70 @@
+# Decisions: Feature List and Competitor Comparison (#144)
+
+## 1. Feature list uses lightweight list, not cards
+
+The landing page Use Cases section already uses the `.card` component heavily.
+Using cards again for features would create "card fatigue" and no visual
+contrast between sections. The lightweight grid (heading + description, no
+borders) lets the content breathe.
+
+Over: Card-based grid with `.card` class and badge icons (frontend-minion).
+
+## 2. Landing comparison: 4 competitors x 4 feature columns
+
+The landing page gets a summary table, not the full matrix. Four competitors
+(Wayback Machine, PageFreezer, Webrecorder, Manual + Notary) were chosen to
+maximize recognition, enterprise credibility, technical respect, and common
+practice. Four feature columns (Crypto Signing, Independent Timestamps, Public
+Verification, Open Format) highlight WRL's core differentiators.
+
+Over: Full 9-competitor table on landing (rejected: too dense per UX review).
+
+## 3. Docs comparison page is .njk, not .md
+
+The mobile-responsive card-stack pattern requires `data-label` attributes on
+`<td>` elements. Markdown tables cannot produce custom HTML attributes.
+Precedent: `api-reference.njk` already uses Nunjucks for structured HTML content.
+
+Over: Markdown file (software-docs-minion).
+
+## 4. Single /compare/ page on docs (no separate features page)
+
+The comparison table already implies feature coverage. A separate features page
+would duplicate information and create maintenance burden with no clear user
+benefit. The landing page feature list links directly to the comparison page.
+
+Over: Separate /features/ + /compare/ pages.
+
+## 5. "Features" in landing nav, "Compare" excluded
+
+Adding "Features" to the header nav gives it 5 content links + Sign in, which
+is at the scannable limit. Adding "Compare" would push to 6 content links and
+comparison is a secondary evaluation step, not a primary navigation target.
+
+## 6. Docs SEO infrastructure deferred
+
+Template-level SEO changes (canonical tags, OG tags, BreadcrumbList) affect
+all 15+ docs pages and deserve their own review cycle. Added to backlog.
+
+Over: Including template-level fixes in this task (seo-minion).
+
+## 7. Competitor data: public sources only, with methodology disclosure
+
+Every cell in the comparison table is a factual assertion verifiable by
+competitors and the web archiving community. The methodology section discloses
+the "last verified" date (March 2026), uses "Not documented" instead of "No"
+when uncertain, and links to GitHub issues for corrections.
+
+## 8. Background alternation fix
+
+Inserting two new sections required changing How It Works from `--muted` to
+`--white` to maintain the alternating background pattern across all 5 content
+sections: white, muted, white, muted, white.
+
+## 9. aria-hidden removed from thead (post-review fix)
+
+Initially added `aria-hidden="true"` to `<thead>` per accessibility-minion's
+Phase 3.5 recommendation. Code review identified this was incorrect: the
+`.sr-only` CSS positioning already handles visual hiding for mobile, and
+the attribute unnecessarily removed column headers from screen readers on
+desktop viewports. Removed in the code review fix commit.

--- a/docs/evolution/0090-feature-list-competitor-comparison/outcome.md
+++ b/docs/evolution/0090-feature-list-competitor-comparison/outcome.md
@@ -1,0 +1,68 @@
+# Outcome: Feature List and Competitor Comparison (#144)
+
+## What Was Built
+
+### Landing Page (`landing/public/index.html`)
+
+**Feature list section ("What You Get")**: 10 features in two groups:
+- Evidence Integrity (5): Full-fidelity capture, Ed25519 signing, RFC 3161 timestamps, eIDAS qualified timestamps, WACZ standard format
+- Developer Experience (5): REST API + MCP server, scheduled captures, webhooks, CLI verification tool, public verification
+
+Each feature is heading + description in a responsive grid (1→2→5 columns).
+Links to docs comparison page via "See how WRL compares" CTA.
+
+**Summary comparison table ("How WRL Compares")**: 4 competitors (Wayback Machine, PageFreezer, Webrecorder, Manual + Notarization) × 4 feature columns (Crypto Signing, Independent Timestamps, Public Verification, Open Format). Badge system (pass/fail/skip) for visual scanning. Links to full comparison on docs site.
+
+**Navigation**: Added "Features" link between "Use Cases" and "How It Works" (5 content links + Sign in = 6 total, at scannable limit).
+
+**Structured data**: Expanded SoftwareApplication JSON-LD from 8 to 15 feature items, added `applicationSubCategory` and `offers` schema.
+
+**Background alternation fix**: Changed How It Works from `--muted` to `--white` to maintain white/muted/white/muted/white pattern across 5 content sections.
+
+### Docs Site (`site/content/compare.njk`)
+
+New Nunjucks page at `/compare/` with the full 9-competitor × 7-column comparison table:
+- Competitors: Wayback Machine, PageFreezer, Hanzo, Page Vault, MirrorWeb, Stillio, Archive-It, Webrecorder, Manual Screenshots + Notarization
+- Columns: Cryptographic Signing, Independent Timestamps, Public Verification, API Access, Standard Format, eIDAS Qualified, Open Source
+- Per-competitor notes (H3 sections) with nuanced technical context
+- Methodology section with "March 2026" verification date and GitHub issue link for corrections
+- Cross-link back to landing page summary
+
+Added "Compare" to docs site navigation (after Architecture, before Security & Compliance).
+
+### CSS
+
+**Landing** (`landing/public/css/landing.css`): `.features-grid` responsive grid, `.comparison-table` with mobile card-stack pattern via `data-label` + `::before`, badge styles.
+
+**Docs** (`site/css/docs.css`): `.comparison-table-wrapper` with breakout margin for wide table, same mobile card-stack pattern adapted for docs context. Sync comments note intentional differences between landing and docs implementations.
+
+## Files Changed (5 modified, 1 created)
+
+- `landing/public/index.html` — feature list section, summary comparison table, nav link, JSON-LD expansion, background fix (+320/-6)
+- `landing/public/css/landing.css` — feature grid, comparison table, mobile card-stack (+97)
+- `site/content/compare.njk` — NEW: full comparison page (217 lines)
+- `site/css/docs.css` — comparison table styles with mobile card-stack (+93)
+- `site/_data/site.js` — added Compare nav entry (+1)
+
+## Surface Consistency
+
+| Surface | Action |
+|---------|--------|
+| **OpenAPI spec** | No update needed — no API changes |
+| **Docs site** | Updated: new `/compare/` page, nav entry added |
+| **Landing page** | Updated: feature list section, summary comparison table |
+| **MCP server** | No update needed — no API changes |
+| **Legal pages** | No update needed — no new data collection or services |
+
+## Backlog Changes
+
+- Updated #144 entry in Parking Lot / Product Features: marked as DONE (Phase 0090)
+- Added [consider] item: Docs site SEO infrastructure (canonical tags, OG tags, BreadcrumbList) — deferred from this phase per decision #6
+
+## Deviations from Plan
+
+1. **aria-hidden on thead**: Initially added per accessibility-minion recommendation in Phase 3.5. Code review caught this was incorrect (`.sr-only` CSS already handles mobile hiding; attribute removed column headers from screen readers on desktop). Fixed in a follow-up commit.
+
+2. **Sync comment wording**: Original comments said "equivalent pattern" between landing and docs CSS. Margo's code review correctly noted this was misleading since the patterns intentionally differ. Updated to "contexts differ intentionally, do not merge."
+
+3. **Feature count**: Expanded from 8 features (initial plan) to 10 after Lucy's Phase 3.5 review caught that CLI verification tool and webhooks were explicitly required by #144 success criteria but missing from the synthesis.

--- a/docs/evolution/0090-feature-list-competitor-comparison/process.md
+++ b/docs/evolution/0090-feature-list-competitor-comparison/process.md
@@ -1,0 +1,140 @@
+# Process: Feature List and Competitor Comparison (#144)
+
+## TL;DR
+
+Five specialists planned, seven reviewers vetted, two execution agents built.
+The result: a 10-feature capability section and 4-competitor summary table on
+the landing page, plus a full 9-competitor × 7-column comparison page on the
+docs site. Two post-execution fixes (aria-hidden removal, sync comment
+accuracy). Three commits, one PR. The interesting tension was between marketing
+density and UX simplicity — the table that product-marketing wanted (9
+competitors on landing) was twice what UX would allow.
+
+## Phase 1: Meta-Plan
+
+Nefario identified five specialists: frontend-minion (implementation),
+product-marketing-minion (messaging and positioning), seo-minion (structured
+data and discoverability), software-docs-minion (docs page structure), and
+ux-strategy-minion (information hierarchy and mobile UX). No external skills
+discovered.
+
+## Phase 2: Specialist Planning
+
+Five agents ran in parallel. Key contributions and tensions:
+
+**product-marketing-minion** pushed for maximum competitive coverage — all 9
+competitors on the landing page, 6 comparison columns, and a "Why WRL Wins"
+narrative framing. Proposed badge-based visual system (pass/fail/skip) which
+survived intact to the final implementation.
+
+**ux-strategy-minion** argued the opposite direction: 3-4 competitors max on
+landing, 3-4 columns, no scroll. Their core argument was cognitive load — a
+9×7 table on a marketing page is a spreadsheet, not a comparison. They
+proposed the lightweight feature list (no cards, no borders) which was adopted.
+
+**frontend-minion** landed in between: 5-column responsive grid for features,
+mobile card-stack pattern using `data-label` + CSS `::before` pseudo-elements.
+Their card-stack proposal was the technical breakthrough that made the
+comparison table mobile-viable without JavaScript.
+
+**software-docs-minion** made the critical format call: the docs comparison
+page must be `.njk` (Nunjucks), not Markdown, because `data-label` attributes
+on `<td>` elements are impossible in Markdown tables. Precedent: `api-reference.njk`.
+
+**seo-minion** proposed extensive docs site template changes (canonical URLs,
+OG tags, BreadcrumbList structured data). This was the largest scope risk.
+
+## Phase 3: Synthesis
+
+Nefario resolved the marketing-vs-UX density conflict by splitting: 4
+competitors × 4 columns on landing (UX wins), full 9 × 7 on docs
+(marketing wins). The 4 landing competitors were chosen to maximize category
+coverage: Wayback Machine (institutional recognition), PageFreezer (enterprise
+credibility), Webrecorder (technical respect), Manual + Notarization (common
+practice).
+
+The seo-minion's template-level changes were deferred to backlog — they affect
+15+ docs pages and deserve their own review cycle.
+
+Two execution tasks:
+1. Landing page: feature list, summary table, nav link, JSON-LD, CSS
+2. Docs site: full comparison page, docs CSS, nav entry
+
+## Phase 3.5: Architecture Review
+
+Seven reviewers, all APPROVE (some with ADVISE notes):
+
+**lucy** caught two gaps against #144 success criteria: CLI verification tool
+and webhooks were missing from the feature list. Both were explicitly required
+by the issue. This expanded the feature count from 8 to 10. Lucy also caught
+the background alternation problem — inserting Features (muted) before How It
+Works (muted) would break the white/muted alternation pattern.
+
+**margo** caught that Tasks 1 and 2 both writing to `index.html` would cause
+merge conflicts. The JSON-LD update was moved from Task 2 into Task 1.
+
+**accessibility-minion** recommended `aria-hidden="true"` on `<thead>` for the
+mobile card-stack pattern, arguing that visually-hidden headers shouldn't be
+announced. This was adopted in execution but reversed in code review (see
+Phase 5).
+
+**seo-minion** reiterated docs template SEO gaps. Deferred per synthesis
+decision.
+
+**test-minion** confirmed no automated tests needed for HTML/CSS-only changes.
+
+**security-minion** and **ux-strategy-minion** approved without issues.
+
+## Phase 4: Execution
+
+Two tasks ran sequentially (Task 2 depended on Task 1's CSS patterns):
+
+**Task 1** (frontend-minion): Landing page implementation. 4 files modified.
+The feature grid uses CSS Grid with `auto-fill` columns for natural responsive
+behavior. The summary comparison table uses the same badge system
+(pass/fail/skip) as the full docs table but with fewer columns. JSON-LD
+expanded from 8 to 15 feature items.
+
+**Task 2** (frontend-minion): Docs site implementation. Created `compare.njk`
+with 217 lines of structured HTML. Each competitor row includes `data-label`
+on every `<td>` for the mobile card-stack. Per-competitor H3 notes sections
+provide nuanced context (e.g., acknowledging Webrecorder created the WACZ-Auth
+spec that WRL implements). Methodology section discloses verification date and
+invites corrections.
+
+## Phase 5: Code Review
+
+Two reviewers (lucy, margo):
+
+**lucy** identified the `aria-hidden="true"` on `<thead>` was incorrect. The
+reasoning: `.sr-only` CSS already positions the header off-screen on mobile
+(visually hidden but announced by screen readers). Adding `aria-hidden` removed
+the headers from screen readers on *desktop* too, where they're visible and
+needed. The accessibility-minion's Phase 3.5 recommendation was well-intentioned
+but wrong — the `.sr-only` class is specifically designed to keep content
+accessible to assistive technology while hiding it visually.
+
+**margo** caught that the CSS sync comments ("equivalent pattern in...") were
+misleading. The landing and docs implementations share the same *approach*
+(card-stack via data-label) but differ in specifics (breakpoints, margins,
+min-width). Updated to "contexts differ intentionally, do not merge."
+
+Both fixes applied in a follow-up commit. Both reviewers approved after fixes.
+
+## Autonomous Gate Decisions
+
+All gates decided by Lucy agents (autonomous mode, no human operator):
+
+- **Team approval (P1)**: Approved as proposed
+- **Execution plan approval (P3)**: Approved with 3 ADVISE notes incorporated
+- **Reviewer approval (P3.5)**: Approved with gru, lucy, margo included
+- **Code review fixes (P5)**: Auto-fixed (aria-hidden removal, sync comments)
+
+## Where to Read More
+
+- Specialist contributions: `docs/history/nefario-reports/2026-03-26-044407-feature-list-competitor-comparison/phase2-*.md`
+- Synthesis: `docs/history/nefario-reports/2026-03-26-044407-feature-list-competitor-comparison/phase3-synthesis.md`
+- Review verdicts: `docs/history/nefario-reports/2026-03-26-044407-feature-list-competitor-comparison/phase3.5-*.md`
+- Code review: `docs/history/nefario-reports/2026-03-26-044407-feature-list-competitor-comparison/phase5-*.md`
+- Decisions: `docs/evolution/0090-feature-list-competitor-comparison/decisions.md`
+- Outcome: `docs/evolution/0090-feature-list-competitor-comparison/outcome.md`

--- a/docs/evolution/0090-feature-list-competitor-comparison/prompt.md
+++ b/docs/evolution/0090-feature-list-competitor-comparison/prompt.md
@@ -1,0 +1,20 @@
+Feature list and competitor comparison table (#144)
+
+**Outcome**: Prospective users can see at a glance how WRL compares to alternative web capture and archival approaches, making the value proposition concrete. A dedicated feature list and competition comparison table on the public site converts "what is this?" visitors into "I need this" users by showing WRL's cryptographic integrity advantage over every competitor. The feature list also highlights technical/developer capabilities (API, MCP server, Ed25519 signatures, WACZ format) so developer-minded visitors see that WRL is programmable and interoperable.
+
+**Success criteria**:
+- Landing site has a feature list section showing WRL's core capabilities (capture, signing, timestamps, verification, WACZ, MCP, scheduled captures)
+- Feature list includes a technical/developer benefits subsection covering: REST API, MCP server, Ed25519 signatures, WACZ standard format, CLI verification tool, webhooks — with links to relevant docs pages
+- Comparison table covers at least: Wayback Machine, PageFreezer, Hanzo, Page Vault, MirrorWeb, Stillio, Archive-It, Webrecorder, manual screenshots + notarization
+- Table columns include: integrity approach, cryptographic signing, independent timestamps, public verification, API access, standard format (WACZ), eIDAS support
+- Each competitor row is factually accurate (no strawmanning - cite what they actually provide)
+- Table renders well on mobile (responsive)
+- Hosted on both landing page (summary version) and docs site (full version with detailed notes)
+
+**Scope**:
+- In: Feature list section on landing page (including developer/technical benefits), full comparison table on docs site, summary comparison on landing page, links between the two
+- Out: Blog posts about competitors, SEO landing pages per competitor, pricing comparison
+
+**Constraints**:
+- Pure HTML + CSS, no JS framework (consistent with existing landing page and docs site)
+- Must match existing design system (design-system.css)

--- a/docs/evolution/README.md
+++ b/docs/evolution/README.md
@@ -98,3 +98,4 @@ software development.
 | [0087-llm-developer-reference](0087-llm-developer-reference/) | LLM-oriented developer reference for WRL internals: D1 schema, API routes, bindings, secrets, queues, crons (Issue #201) |
 | [0088-autoconsent-ci](0088-autoconsent-ci/) | Automated autoconsent update pipeline: GitHub Action for weekly vendor updates with test battery (Issue #152) |
 | [0089-landing-legal-section-ordering](0089-landing-legal-section-ordering/) | Landing page section reorder: Use Cases above How It Works, trust bar rejected, legal claims stay in use case card (Issue #207) |
+| [0090-feature-list-competitor-comparison](0090-feature-list-competitor-comparison/) | Feature list and competitor comparison table on landing page and docs site (Issue #144) |

--- a/docs/history/nefario-reports/2026-03-26-044407-feature-list-competitor-comparison.md
+++ b/docs/history/nefario-reports/2026-03-26-044407-feature-list-competitor-comparison.md
@@ -1,0 +1,75 @@
+---
+title: "Feature List and Competitor Comparison Table"
+source-issue: 144
+timestamp: 2026-03-26T04:44:07
+branch: worktree-cuddly-sparking-badger
+slug: feature-list-competitor-comparison
+status: complete
+---
+
+# Nefario Execution Report: Feature List and Competitor Comparison (#144)
+
+## Original Prompt
+
+Add a feature list section and competitor comparison table to the landing page
+and docs site. The feature list covers WRL's core capabilities with a
+developer/technical benefits subsection. The comparison table covers 9+
+competitors across integrity, signing, timestamps, verification, API, format,
+and eIDAS columns. Summary version on landing page, full version on docs site.
+
+## Team
+
+### Phase 2 Specialists (5)
+- **frontend-minion**: Landing page HTML/CSS implementation, responsive grid, mobile card-stack
+- **product-marketing-minion**: Feature messaging, competitor positioning, badge system
+- **seo-minion**: Structured data expansion, cross-linking strategy, docs SEO audit
+- **software-docs-minion**: Docs comparison page structure, Nunjucks template, methodology section
+- **ux-strategy-minion**: Information hierarchy, mobile UX, card fatigue avoidance
+
+### Phase 3.5 Reviewers (7)
+- **lucy**: Success criteria validation, missing features catch (CLI verify + webhooks)
+- **margo**: Complexity review, parallel write conflict detection, sync comment accuracy
+- **accessibility-minion**: Screen reader table semantics, aria-hidden recommendation (later reversed)
+- **security-minion**: No sensitive data exposure in comparison content
+- **seo-minion**: Docs template SEO gaps (deferred to backlog)
+- **test-minion**: No code tests needed for HTML/CSS-only changes
+- **ux-strategy-minion**: Mobile card-stack validation, badge contrast review
+
+### Phase 5 Code Reviewers (2)
+- **lucy**: Caught incorrect aria-hidden on thead, approved after fix
+- **margo**: Caught misleading sync comments, approved after fix
+
+## Execution Summary
+
+2 tasks executed sequentially (Task 2 depended on Task 1's CSS):
+
+1. **Task 1** (frontend-minion): Landing page — feature list section, summary comparison table, nav link, JSON-LD expansion, CSS for both sections including mobile card-stack. 4 files modified.
+
+2. **Task 2** (frontend-minion): Docs site — full comparison page (compare.njk), docs CSS with card-stack pattern, nav entry. 3 files modified/created.
+
+## Key Decisions
+
+1. Lightweight list over cards for features (avoid card fatigue)
+2. 4 competitors × 4 columns on landing (density limit); 9 × 7 on docs
+3. Nunjucks (.njk) for docs page (data-label attributes impossible in Markdown)
+4. Single /compare/ page (no separate /features/)
+5. "Features" in nav, "Compare" excluded (5 links = scannable limit)
+6. Docs SEO infrastructure deferred to backlog
+7. Public sources only, methodology disclosure, "Not documented" over "No"
+
+## Post-Execution Fixes
+
+- Removed `aria-hidden="true"` from `<thead>` (incorrectly added per a11y review; `.sr-only` CSS already handles mobile hiding)
+- Updated CSS sync comments from "equivalent pattern" to "contexts differ intentionally, do not merge"
+
+## Artifacts
+
+- 5 files modified, 1 file created
+- 2 commits on branch `worktree-cuddly-sparking-badger`
+- Evolution log: `docs/evolution/0090-feature-list-competitor-comparison/`
+- Companion directory: `docs/history/nefario-reports/2026-03-26-044407-feature-list-competitor-comparison/`
+
+## Backlog Changes
+
+- Marked #144 as DONE (Phase 0090) in Product Features parking lot
+- Added: [consider] Docs site SEO infrastructure (canonical tags, OG tags, BreadcrumbList)

--- a/docs/history/nefario-reports/2026-03-26-044407-feature-list-competitor-comparison/phase1-metaplan-prompt.md
+++ b/docs/history/nefario-reports/2026-03-26-044407-feature-list-competitor-comparison/phase1-metaplan-prompt.md
@@ -1,0 +1,47 @@
+MODE: META-PLAN
+
+You are creating a meta-plan — a plan for who should help plan.
+
+## Task
+
+Feature list and competitor comparison table for WRL landing page and docs site.
+
+Outcome: Prospective users can see at a glance how WRL compares to alternative web capture and archival approaches. A dedicated feature list and competition comparison table on the public site converts "what is this?" visitors into "I need this" users by showing WRL's cryptographic integrity advantage over every competitor. The feature list also highlights technical/developer capabilities (API, MCP server, Ed25519 signatures, WACZ format) so developer-minded visitors see that WRL is programmable and interoperable.
+
+Success criteria:
+- Landing site has a feature list section showing WRL's core capabilities
+- Feature list includes technical/developer benefits subsection with links to docs
+- Comparison table covers at least 9 competitors
+- Table columns: integrity approach, cryptographic signing, independent timestamps, public verification, API access, standard format (WACZ), eIDAS support
+- Each competitor row is factually accurate (no strawmanning)
+- Responsive table on mobile
+- Landing page (summary) and docs site (full version with detailed notes)
+
+Constraints:
+- Pure HTML + CSS, no JS framework
+- Must match existing design system (design-system.css)
+
+## Working Directory
+
+/Users/ben/github/benpeter/web-resource-ledger/.claude/worktrees/cuddly-sparking-badger
+
+## Existing Structure
+
+Landing page: landing/public/index.html (sections: Hero, Use Cases, How It Works, Pricing)
+Landing CSS: landing/public/css/landing.css + design-system.css
+Docs site: site/content/ (Eleventy-based, .md and .njk files)
+Current docs pages: api-reference, architecture, authentication, batch, index, legal-evidence, limits, mcp, schedules, security/, verification, webhooks
+
+## External Skill Discovery
+
+Check .claude/skills/ and .skills/ for SKILL.md files. Only ops-runbook was found in .claude/skills/ — not relevant to this task.
+
+## Instructions
+
+1. Read relevant files to understand the codebase context
+2. External skills: ops-runbook discovered, not relevant (classified as LEAF, not applicable)
+3. Analyze the task against your delegation table
+4. Identify which specialists should be CONSULTED FOR PLANNING (not execution — planning)
+5. For each specialist, write a specific planning question
+6. Return the meta-plan in structured format
+7. Write your complete meta-plan to /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-0ldPyr/feature-list-competitor-comparison/phase1-metaplan.md

--- a/docs/history/nefario-reports/2026-03-26-044407-feature-list-competitor-comparison/phase1-metaplan.md
+++ b/docs/history/nefario-reports/2026-03-26-044407-feature-list-competitor-comparison/phase1-metaplan.md
@@ -1,0 +1,104 @@
+# Meta-Plan: Feature List and Competitor Comparison Table
+
+## Planning Consultations
+
+### Consultation 1: Competitor Research and Factual Accuracy
+
+- **Agent**: product-marketing-minion
+- **Planning question**: For the comparison table covering Wayback Machine, PageFreezer, Hanzo, Page Vault, MirrorWeb, Stillio, Archive-It, Webrecorder, and manual screenshots + notarization -- what is each competitor's actual approach to: integrity/tamper-evidence, cryptographic signing, independent timestamps, public verification, API access, standard format support (WACZ), and eIDAS compliance? What are WRL's genuine differentiators vs. areas where competitors match or exceed WRL? How should we frame the comparison to be factually honest while highlighting WRL's strengths?
+- **Context to provide**: WRL's capabilities (Ed25519 signing, RFC 3161 timestamps, WACZ bundles, public verification URLs, eIDAS-qualified timestamps, REST API, MCP server). The success criteria requiring no strawmanning.
+- **Why this agent**: product-marketing-minion specializes in competitive differentiation and feature messaging. The comparison table's credibility depends on accurate competitor characterization -- getting this wrong undermines trust. This agent can research each competitor and propose the column structure that best highlights genuine differentiation.
+
+### Consultation 2: Feature List Content and Developer Messaging
+
+- **Agent**: product-marketing-minion
+- **Planning question**: How should the feature list be structured to serve both non-technical ("what does this do for me?") and developer ("what can I build with this?") audiences? What feature categories and copy approach will convert "what is this?" visitors into "I need this" users? Specifically: should the developer subsection use a different visual treatment than the main feature list, and what level of technical detail belongs on the landing page vs. the docs site?
+- **Context to provide**: Current landing page structure (Hero, Use Cases, How It Works, Pricing), target audience mix (legal professionals, compliance officers, developers, AI agent builders).
+- **Why this agent**: Same agent, second question. Feature messaging strategy -- what to emphasize, what order, what vocabulary -- is core product-marketing work.
+
+**Note**: Consultations 1 and 2 are both for product-marketing-minion. They can be combined into a single consultation prompt if the skill runner prefers.
+
+### Consultation 3: Information Architecture and Placement
+
+- **Agent**: ux-strategy-minion
+- **Planning question**: Where should the feature list and comparison table be placed in the landing page flow relative to existing sections (Hero > Use Cases > How It Works > Pricing)? The task specifies a summary version on the landing page and a full version on the docs site -- what content should live on each, and how should users flow between them? What is the cognitive load risk of adding two new content-heavy sections to a currently concise landing page?
+- **Context to provide**: Current landing page HTML structure (4 sections, clean flow), docs site navigation (15 entries already). The landing page is currently ~310 lines of HTML with a tight narrative arc.
+- **Why this agent**: ux-strategy-minion evaluates journey coherence and cognitive load. Adding two substantial sections (feature list + comparison table) to a concise landing page risks overwhelming visitors. This agent can recommend the right content split between landing and docs.
+
+### Consultation 4: Responsive Table Design
+
+- **Agent**: frontend-minion
+- **Planning question**: The comparison table has 7+ columns and 9+ competitor rows. What CSS-only patterns (no JS frameworks) work for making a data-dense comparison table responsive on mobile while remaining scannable? Should the landing page summary use a different layout pattern (e.g., cards, stacked rows) than the full docs-site table? What existing design-system.css components (`.table`, `.card`, `.badge`) can be reused vs. what new CSS is needed?
+- **Context to provide**: design-system.css (has `.table` and `.badge` components), landing.css (responsive breakpoints at 640px, 768px, 1024px), docs.css. Constraint: pure HTML + CSS only.
+- **Why this agent**: frontend-minion knows responsive CSS patterns for data-dense tables. A 7x10 comparison table that breaks on mobile defeats the purpose. This is the hardest implementation challenge in the task.
+
+### Consultation 5: Landing Page SEO Impact
+
+- **Agent**: seo-minion
+- **Planning question**: The landing page already has SoftwareApplication structured data with a `featureList` array. How should the new feature list section and comparison table be reflected in structured data? Should the comparison table get its own schema.org markup (e.g., `ItemList` with `ListItem` for competitors)? Are there SEO considerations for the landing-page-summary vs. docs-site-full split (canonical URLs, duplicate content)?
+- **Context to provide**: Existing structured data in index.html (Organization + SoftwareApplication schemas), docs site at docs.webresourceledger.com (separate subdomain).
+- **Why this agent**: seo-minion ensures the new content is discoverable and properly structured for search engines. The dual-site split (landing summary + docs full) needs careful handling to avoid duplicate content issues.
+
+## Cross-Cutting Checklist
+
+- **Testing**: Exclude from planning. This task produces static HTML/CSS content only -- no code logic, no API changes, no infrastructure. Visual verification is sufficient per CLAUDE.md ("For UI-only changes, visual verification is sufficient").
+- **Security**: Exclude from planning. No user input handling, no auth changes, no new attack surface. Pure static content addition.
+- **Usability -- Strategy**: ALWAYS include -- covered by Consultation 3 (ux-strategy-minion). Planning question addresses page flow, cognitive load, and content split between landing and docs.
+- **Usability -- Design**: Include in execution but not planning. ux-design-minion should review the final visual treatment of the feature list and comparison table (visual hierarchy, spacing, color usage for badges). No planning question needed -- the design review happens against concrete HTML/CSS.
+- **Documentation**: ALWAYS include -- the docs site IS the deliverable. software-docs-minion should advise during planning on where the full comparison page fits in the docs site navigation and whether it warrants its own section or lives under an existing page. Planning question: "Given the current docs nav (15 items across Getting Started, Auth, Verification, Legal Evidence, etc.), where should a detailed features/comparison page live? Should it be a top-level nav item or nested? What title?"
+- **Observability**: Exclude from planning. No runtime components, no APIs, no background processes.
+
+### Consultation 6: Docs Site Navigation Placement
+
+- **Agent**: software-docs-minion
+- **Planning question**: The docs site nav has 15 entries. Where should the full comparison/features page live? Should it be a single page combining features + comparison, or two separate pages? What title and position in the nav? Should it link back to the landing page summary, and vice versa?
+- **Context to provide**: Current nav structure from site/_data/site.js, existing page topics.
+- **Why this agent**: software-docs-minion owns documentation architecture. The docs nav is already long -- adding content needs to be intentional about placement.
+
+## Notable Exclusions
+
+- **accessibility-minion**: The comparison table is the main a11y risk (complex table semantics, mobile overflow). However, frontend-minion can handle WCAG table markup as part of implementation. Accessibility review is better suited for Phase 3.5 architecture review against the concrete plan rather than planning consultation.
+- **data-minion**: No database or data modeling involved -- competitor data is static content, not stored or queried.
+- **ai-modeling-minion**: No prompt engineering or agent architecture changes. The MCP server is mentioned as a feature but not being modified.
+
+## Anticipated Approval Gates
+
+1. **Content strategy gate** (MUST): Where to place feature list and comparison table on landing page, what content goes on landing vs. docs, comparison table column structure. This is hard to reverse (restructuring HTML sections after implementation is significant rework) and has high blast radius (every subsequent task depends on these decisions).
+
+2. **Competitor characterization gate** (MUST): The factual accuracy of each competitor row before it goes into HTML. Getting competitor claims wrong is reputationally damaging and hard to reverse once published. This is the highest-risk deliverable in the plan.
+
+No other gates anticipated. CSS implementation and docs-site integration are straightforward and reversible.
+
+## Rationale
+
+This task is primarily a **content + design** challenge, not a technical one. The hardest parts are:
+
+1. **Factual accuracy** of competitor comparisons (product-marketing-minion)
+2. **Information architecture** -- where to put two dense new sections without breaking the landing page's narrative flow (ux-strategy-minion)
+3. **Responsive design** for a data-dense comparison table on mobile (frontend-minion)
+4. **SEO** -- structured data and duplicate content handling across two sites (seo-minion)
+5. **Docs navigation** -- fitting a new page into an already-long nav (software-docs-minion)
+
+The implementation itself is straightforward HTML/CSS using existing design-system components. The planning phase is about getting the content and placement decisions right before writing markup.
+
+## Scope
+
+**In scope**:
+- Feature list section for landing page (core capabilities + developer subsection)
+- Comparison table for landing page (summary version)
+- Full comparison page for docs site (detailed version with notes)
+- CSS for responsive table rendering on mobile
+- Updates to landing page nav and docs site nav
+- Structured data updates for SEO
+- Links between landing summary and docs full version
+
+**Out of scope**:
+- Changes to existing landing page sections (Hero, Use Cases, How It Works, Pricing)
+- Changes to the WRL product itself (API, MCP server, etc.)
+- New JavaScript functionality
+- Changes to design-system.css (extend via landing.css / docs.css only)
+- Blog post or marketing copy beyond the landing/docs pages
+
+## External Skill Integration
+
+No external skills detected in project. The ops-runbook skill in `.claude/skills/` is not relevant to this content/design task.

--- a/docs/history/nefario-reports/2026-03-26-044407-feature-list-competitor-comparison/phase2-frontend-minion.md
+++ b/docs/history/nefario-reports/2026-03-26-044407-feature-list-competitor-comparison/phase2-frontend-minion.md
@@ -1,0 +1,230 @@
+# Domain Plan Contribution: frontend-minion
+
+## Recommendations
+
+### 1. Responsive Pattern for 8-Column Comparison Table
+
+An 8-column data table cannot be meaningfully displayed as a traditional table at 320px. The only CSS-only patterns that work:
+
+**Recommended: Card-stack pattern at mobile (< 768px)**
+
+Each row becomes a stacked card. Use `display: block` on `table`, `thead`, `tr`, `td`. Hide the `thead` visually with `.sr-only` (keep it in the DOM for screen readers). Each `td` gets a `data-label` attribute and a `::before` pseudo-element that renders the column header inline:
+
+```css
+@media (max-width: 767px) {
+  .comparison-table thead { /* visually hide, keep for a11y */
+    position: absolute; width: 1px; height: 1px;
+    overflow: hidden; clip: rect(0,0,0,0);
+  }
+  .comparison-table tr {
+    display: block;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+    padding: var(--space-4);
+    margin-bottom: var(--space-4);
+    background: var(--color-surface);
+  }
+  .comparison-table td {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: var(--space-2) 0;
+    border-bottom: 1px solid var(--color-border-subtle);
+  }
+  .comparison-table td::before {
+    content: attr(data-label);
+    font-weight: var(--weight-medium);
+    font-size: var(--text-xs);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--color-text-muted);
+    flex-shrink: 0;
+    margin-right: var(--space-3);
+  }
+  .comparison-table td:last-child { border-bottom: none; }
+}
+```
+
+This pattern is entirely CSS (the `data-label` attributes are in the HTML, which is static). The competitor/tool name becomes the card heading. Each feature becomes a label-value row inside the card.
+
+**Why not horizontal scroll?** `overflow-x: auto` on a wrapper works technically but is a terrible UX for a comparison table -- users cannot see two rows side by side to compare. It also fails the "can a user actually use this" test that the Helix manifesto demands.
+
+**Why not column hiding?** Hiding columns means the user never sees critical differentiation data on mobile. The whole point of a comparison table is to show everything.
+
+**Desktop (>= 768px):** Standard `<table>` with the existing `.table` class styling. The 8 columns at 1120px container width gives ~140px per column, which is tight but workable because most cells will contain badges (pass/fail/skip) not long text.
+
+### 2. Landing Page Summary vs Full Docs Table
+
+**Landing page: Condensed comparison (3-4 key columns only)**
+
+Do NOT put the full 8-column table on the landing page. Instead, show a curated summary that highlights WRL's strongest differentiators. Proposed approach:
+
+- **Layout**: A styled `<table>` with 4-5 columns max: Tool name, Cryptographic Signing, Independent Timestamps, Public Verification, Standard Format. These are the columns where WRL wins clearly.
+- **Rows**: 4-5 competitors max (the most well-known). A "See full comparison" link points to the docs page.
+- **Mobile**: Even at 5 columns, the card-stack pattern applies below 768px.
+- **CTA**: Below the table, a line like "Full comparison of 9 tools across 7 criteria" linking to docs.
+
+This follows the landing page's existing pattern: the pricing section summarizes two tiers without showing every detail, linking to docs for full information.
+
+**Docs site: Full comparison table**
+
+The docs page gets the complete 8-column, 9+ row table. It lives in the docs site's prose content area (`max-width: 42rem` in `.docs-content`). At that width, even desktop needs `overflow-x: auto` on a wrapper -- 42rem (672px) cannot hold 8 columns comfortably.
+
+**Recommendation for docs:** Override `.docs-content` max-width for the comparison page only, or use a breakout container pattern:
+
+```css
+.comparison-table-wrapper {
+  max-width: calc(100vw - 240px - 2rem); /* sidebar + padding */
+  overflow-x: auto;
+  margin: 0 calc(-1 * var(--space-6));
+  padding: 0 var(--space-6);
+}
+```
+
+This lets the table break out of the 42rem prose column while staying within the viewport. On mobile (sidebar collapsed), it becomes `max-width: calc(100vw - 2rem)`.
+
+### 3. Design System Components to Reuse
+
+**Direct reuse (no changes needed):**
+
+| Component | Where | Usage |
+|-----------|-------|-------|
+| `.badge--pass` | Both | "Yes" / supported features |
+| `.badge--fail` | Both | "No" / unsupported features |
+| `.badge--skip` | Both | "Partial" / limited support |
+| `.table` + `th`/`td` | Both | Base table styling |
+| `.card` | Landing | Wrapping feature list items |
+| `.sr-only` | Both | Visually hidden table headers on mobile |
+
+**Reuse with extension (landing.css additions):**
+
+| Component | Extension needed |
+|-----------|-----------------|
+| `.landing-section` | New `landing-section--comparison` not needed; use existing `--white` or `--muted` |
+| `.section-header` | Reuse as-is for the comparison section heading |
+| `.container` | Reuse as-is |
+
+**Reuse with extension (docs.css additions):**
+
+| Component | Extension needed |
+|-----------|-----------------|
+| `.docs-prose table` | The docs prose already styles tables (th/td). Add comparison-specific overrides for the wider layout. |
+
+### 4. Feature List Layout
+
+The landing page feature list should use a grid of feature items. Two approaches that match the existing design:
+
+**Recommended: Icon + text grid (reuse `.card` + new `.feature-item`)**
+
+```html
+<div class="features-grid">
+  <div class="card feature-item">
+    <span class="badge badge--pass" aria-hidden="true">...</span>
+    <h3>Ed25519 Digital Signatures</h3>
+    <p>Every capture is signed...</p>
+  </div>
+  ...
+</div>
+```
+
+```css
+.features-grid {
+  display: grid;
+  gap: var(--space-6);
+}
+
+.feature-item {
+  padding: var(--space-6);
+}
+
+.feature-item h3 {
+  margin: var(--space-3) 0 var(--space-2);
+  font-size: var(--text-lg);
+  font-weight: var(--weight-bold);
+}
+
+.feature-item p {
+  margin: 0;
+  color: var(--color-text-muted);
+  line-height: var(--leading-relaxed);
+}
+
+@media (min-width: 768px) {
+  .features-grid { grid-template-columns: repeat(2, 1fr); }
+}
+@media (min-width: 1024px) {
+  .features-grid { grid-template-columns: repeat(3, 1fr); }
+}
+```
+
+This mirrors the existing `.use-cases-grid` pattern (1-col mobile, 2-col tablet, 3-col desktop) but the use-cases grid does 4-col at desktop. For features, 3-col is better because feature descriptions tend to be shorter than use-case descriptions.
+
+**Badge as icon substitute:** Rather than adding SVG icons (which would require new assets and design decisions -- out of scope for frontend-minion), use the existing `.badge` component as a visual anchor. A green `.badge--pass` with a checkmark character or short label like "Core" / "Standard" / "eIDAS" works within the existing system.
+
+### 5. Accessibility
+
+**Table semantics (critical):**
+
+- Use a real `<table>` element, not `div` grids. Screen readers announce row/column relationships automatically with native table markup.
+- `<caption>` element for the table's accessible name (can be visually hidden with `.sr-only` if the section header serves that purpose).
+- `scope="col"` on all `<th>` elements in the header row.
+- `scope="row"` on the first `<td>` (or `<th>`) in each body row (the competitor name).
+- `aria-label` on badge elements to convey meaning beyond color: `<span class="badge badge--pass" aria-label="Yes">` or use visible text inside the badge.
+
+**Mobile card-stack pattern:**
+
+- The `thead` is visually hidden but remains in the DOM for screen readers. This means screen readers still get full table semantics even when the visual layout is cards.
+- The `data-label` pseudo-elements are decorative from a screen reader perspective (they are in CSS `content`, which some screen readers read and some don't). The actual column association comes from the preserved table markup.
+
+**Color independence:**
+
+- Badges already have text content (not just color). The `--pass`, `--fail`, `--skip` variants use distinct background + text + border -- but the text inside the badge must also differ (e.g., "Yes", "No", "Partial") so the information is not conveyed by color alone.
+
+**Focus management:**
+
+- No special focus management needed for a static comparison table.
+- If the landing page summary links to the docs comparison, the docs page anchor should receive focus via `scroll-margin-top` (already set on `.landing-section`).
+
+**Reduced motion:**
+
+- No animations in the comparison table. The existing `prefers-reduced-motion` rule in design-system.css covers any future additions.
+
+### 6. Landing Page Section Placement
+
+Based on the current page structure (Hero > Use Cases > How It Works > Pricing), the new sections should slot in as:
+
+- **Feature list**: After "Use Cases", before "How It Works". It answers "what does WRL include?" after the user has seen "who is it for?"
+- **Comparison summary**: After "How It Works", before "Pricing". Once the user understands the mechanism, show them how it stacks up against alternatives before they see pricing.
+
+Both sections get their own `id` attributes and nav links in the site header.
+
+## Proposed Tasks
+
+1. **Landing page: Feature list section** -- Add a new `landing-section` with a features grid using `.card` components. 6-8 feature items with badge, heading, description. Responsive 1/2/3 column grid. Reuse `.card`, `.badge`, `.section-header`. New CSS: `.features-grid`, `.feature-item` in `landing.css`.
+
+2. **Landing page: Comparison summary section** -- Add a condensed comparison table (5 columns, 4-5 rows) as a new `landing-section`. Reuse `.table`, `.badge--pass/fail/skip`. New CSS: mobile card-stack pattern for the comparison table in `landing.css`. Add "See full comparison" link to docs.
+
+3. **Landing page: Navigation update** -- Add nav links for the new sections in the site header. Update the `<nav>` in the header and potentially the footer.
+
+4. **Docs site: Full comparison page** -- Create a new content page (e.g., `site/content/comparison.md` or `.njk`) with the full 8-column, 9+ row table. Add the breakout wrapper CSS for the wider table. New CSS additions in `docs.css`. Add to sidebar navigation.
+
+5. **Docs site: Comparison table responsive CSS** -- Add the card-stack mobile pattern to `docs.css`. This is the most complex CSS task. The `data-label` attributes must be in the HTML template (Nunjucks or Markdown won't generate them automatically -- this will need to be a `.njk` file, not `.md`).
+
+6. **Design system: No changes** -- All needed components already exist. No modifications to `design-system.css`.
+
+## Risks and Concerns
+
+1. **`data-label` in Markdown**: The docs site uses Markdown for content. Markdown tables cannot have `data-label` attributes on `<td>` elements. The comparison page in the docs site **must** be a Nunjucks template (`.njk`), not Markdown. This is consistent with `api-reference.njk` which already uses Nunjucks for structured content.
+
+2. **Docs prose column width**: The docs content area is `max-width: 42rem` (672px). An 8-column table at 672px gives ~84px per column. Even with short badge content, column headers (e.g., "Independent Timestamps") will wrap. The breakout wrapper is necessary, not optional. If the breakout approach feels too invasive, an alternative is to make the full comparison page use a different layout template without the 42rem constraint.
+
+3. **Badge text content**: Current badges in the codebase are empty or have short text. For the comparison table, each badge needs explicit visible text ("Yes", "No", "Partial", "N/A") to be accessible. Do not rely on color alone.
+
+4. **Content decisions are not frontend decisions**: The actual competitor list, which features to highlight, and what the summary vs full table contains are content/strategy decisions. Frontend-minion provides the layout and CSS patterns; the content needs to come from whoever owns the competitive analysis.
+
+5. **Screen reader testing**: The card-stack mobile pattern with visually-hidden `thead` is well-established but should be tested with VoiceOver on iOS Safari. Some mobile screen readers handle `display: block` on table elements differently. If issues arise, fallback to `overflow-x: auto` horizontal scroll with an `aria-label` noting the table scrolls.
+
+## Additional Agents Needed
+
+- **Content/strategy agent**: To define which competitors appear in the table, what features to include, and how to describe each. Frontend can build the containers but needs the actual data.
+- **ux-design-minion**: The feature list needs visual anchors (icons or badges). If SVG icons are desired instead of text badges, design needs to provide them. Also, the landing page section ordering (where features and comparison fit in the page flow) is a UX decision that should be validated.

--- a/docs/history/nefario-reports/2026-03-26-044407-feature-list-competitor-comparison/phase2-product-marketing-minion.md
+++ b/docs/history/nefario-reports/2026-03-26-044407-feature-list-competitor-comparison/phase2-product-marketing-minion.md
@@ -1,0 +1,291 @@
+## Domain Plan Contribution: product-marketing-minion
+
+### Recommendations
+
+#### 1. Competitor Research: Factual Assessment
+
+Below is what I can verify from public sources. Where I could not confirm a capability, I say so explicitly. This data should drive both the comparison table and the feature list framing.
+
+##### Wayback Machine (Internet Archive)
+
+- **Integrity/signing**: None. No cryptographic signatures on captures. Integrity is based on institutional reputation.
+- **Independent timestamps**: None in the RFC 3161 sense. Captures have metadata timestamps from the crawl, but no independent third-party temporal proof.
+- **Public verification**: Anyone can access archived pages. No cryptographic verification -- "verification" is "trust that archive.org didn't alter it."
+- **API access**: Yes. Save Page Now API (submit URLs), Availability API, CDX API (query captures), Memento API. Rate-limited (15 requests/minute since 2019).
+- **Standard format**: WARC (ISO 28500). Not WACZ.
+- **eIDAS support**: None.
+- **Where they're strong**: Massive scale, free, institutional credibility accepted by some courts (US Patent Office accepts their timestamps as prior art evidence). Cultural authority. 850+ billion pages archived.
+- **Honest WRL differentiation**: WRL provides cryptographic proof vs. institutional trust. However, Wayback Machine has massive brand recognition and acceptance as a reference that WRL lacks. For casual "I want to see what a page looked like," Wayback Machine wins on accessibility and cost. WRL wins when you need evidence that can be independently verified without trusting any institution.
+
+##### PageFreezer
+
+- **Integrity/signing**: SHA-256 hashing on archived records. Digital signatures (their docs say "PKCS#1 v1.5" in some materials). Each archived page gets a SHA-256 digital signature.
+- **Independent timestamps**: Stratum-1 atomic clock synchronized timestamps. Described as "ESIGN Act compliant." Not RFC 3161 -- this is their own timestamping infrastructure, not an independent third-party TSA. (One source mentioned "RFC 3136 compliant" which appears to be a documentation error or a different standard.)
+- **Public verification**: Not documented. Verification appears to be internal to their platform. No public verification endpoint for third parties.
+- **API access**: Yes. REST API available to partners. Supports single URL and bulk capture (up to 100,000 URLs). Outputs signed searchable PDFs. Requires partner registration for API access.
+- **Standard format**: PDF exports. CSV exports. eDiscovery-compatible formats. No WACZ support confirmed. The WebPreserver sub-product may support WACZ/WARC but this is not confirmed for the main archiving platform.
+- **eIDAS support**: Not documented.
+- **Where they're strong**: Enterprise-grade compliance (FedRAMP authorized, SOC 2). Social media archiving (Teams, Workplace, etc.) -- WRL doesn't do this. Bulk capture at scale. Established legal market presence.
+- **Honest WRL differentiation**: WRL uses Ed25519 + RFC 3161 (independent third-party timestamps) vs. PageFreezer's SHA-256 + proprietary timestamps. WRL produces WACZ (open standard) vs. PageFreezer's PDF (proprietary output). WRL's verification is public; PageFreezer's appears platform-locked. However, PageFreezer has FedRAMP and broader enterprise compliance certifications WRL lacks.
+
+##### Hanzo
+
+- **Integrity/signing**: Proprietary integrity mechanisms. Chain of custody documentation. WARC format storage on WORM (immutable) storage. ISO 28500 compliant. No public documentation of cryptographic signing.
+- **Independent timestamps**: Not documented publicly.
+- **Public verification**: Not available. Verification is internal to their platform.
+- **API access**: No API available (confirmed by multiple sources including GetApp and Capterra reviews).
+- **Standard format**: WARC (ISO 28500). No WACZ.
+- **eIDAS support**: Not documented.
+- **Where they're strong**: Dynamic content capture (SPAs, interactive elements, personalized pages). SOC 2 Type 2 certified. Strong in eDiscovery workflows with legal hold and targeted collection. Enterprise customer base.
+- **Honest WRL differentiation**: WRL has an API, open verification, cryptographic signing, and standard timestamps. Hanzo has superior dynamic content capture capabilities and deeper eDiscovery integration. WRL is developer-accessible; Hanzo is enterprise-sales-only.
+
+##### Page Vault
+
+- **Integrity/signing**: SHA-256 hashing, digital signatures, timestamps. Metadata includes precise timestamp, source URL, capturing account. Designed for FRE 901(b)(9) and 902(13)/902(14) admissibility.
+- **Independent timestamps**: Timestamps are part of their capture process. Not confirmed as RFC 3161 independent timestamps -- appears to be internally generated.
+- **Public verification**: Not a self-service verification endpoint. They provide expert witness testimony and affidavit services to authenticate captures in court.
+- **API access**: No API available. The product is a browser extension and managed capture service, not a developer-accessible platform.
+- **Standard format**: Proprietary format. PDF exports. No WACZ or WARC.
+- **eIDAS support**: Not documented. US legal market focus (FRE-oriented).
+- **Where they're strong**: Purpose-built for US litigation. Expert witness/affidavit service is a significant differentiator for court admissibility. Strong legal market brand. Social media capture with auto-scroll/auto-expand.
+- **Honest WRL differentiation**: WRL provides machine-verifiable cryptographic proof; Page Vault provides human-verifiable expert testimony. Both target evidence use cases but from opposite ends: WRL is API-first and developer-accessible; Page Vault is point-and-click for legal professionals. Page Vault's expert witness service is something WRL cannot currently match.
+
+##### MirrorWeb
+
+- **Integrity/signing**: SHA-1 digital signatures on archived records (per their documentation). Tamper-evident WORM storage. SOC 2 certified.
+- **Independent timestamps**: Timestamped records, but not confirmed as RFC 3161. Timestamps appear to be part of their archiving process.
+- **Public verification**: Not documented. Platform-internal verification.
+- **API access**: Yes, an API exists for integration with other systems. Limited public documentation on API capabilities.
+- **Standard format**: WARC (ISO 28500).
+- **eIDAS support**: Not documented specifically, though they serve EU clients and reference UK FCA compliance.
+- **Where they're strong**: Financial services compliance (SEC 17a-4, FINRA 2210, FCA COBS 4). Multi-channel archiving (websites, social media, SMS, email). Dynamic content capture.
+- **Honest WRL differentiation**: WRL uses Ed25519 + RFC 3161 vs. MirrorWeb's SHA-1 signatures (SHA-1 is cryptographically deprecated). WRL has public verification; MirrorWeb is platform-locked. Note: MirrorWeb's SHA-1 usage is a genuine weakness, but be careful stating this -- they may have upgraded without updating all their public docs.
+
+##### Stillio
+
+- **Integrity/signing**: None documented. Screenshots with timestamp metadata only.
+- **Independent timestamps**: None. Internal timestamps only.
+- **Public verification**: None.
+- **API access**: Yes, basic API available. Zapier integration. Limited compared to a full REST API.
+- **Standard format**: PNG/JPEG screenshots. No WACZ, no WARC.
+- **eIDAS support**: None.
+- **Where they're strong**: Simple, affordable screenshot scheduling. Good for visual monitoring and brand tracking. Easy setup for non-technical users. $29/month starting price.
+- **Honest WRL differentiation**: Completely different categories. Stillio is a screenshot tool; WRL is an evidence tool. Stillio captures images with no integrity proof. Including Stillio in comparison mainly illustrates the gap between "screenshot services" and "evidence services."
+
+##### Archive-It (Internet Archive subscription service)
+
+- **Integrity/signing**: No cryptographic signing. Integrity via checksums (MD5 and SHA-1 via WASAPI). Institutional credibility of Internet Archive.
+- **Independent timestamps**: No RFC 3161. Crawl timestamps from the archiving process.
+- **Public verification**: Archives are publicly accessible. Checksum verification available via WASAPI for data integrity (not cryptographic authenticity).
+- **API access**: Yes. WASAPI (Web Archiving Systems API) for downloading WARC files with metadata. CDX/C API for querying captures.
+- **Standard format**: WARC (ISO 28500).
+- **eIDAS support**: None.
+- **Where they're strong**: Library/institution-grade archiving. Cultural heritage preservation. Strong in academic and government sectors. Part of the Internet Archive ecosystem.
+- **Honest WRL differentiation**: WRL adds cryptographic signing and independent timestamps on top of a similar capture-and-archive workflow. Archive-It is focused on preservation; WRL is focused on evidence. Archive-It serves institutions; WRL serves developers and legal professionals.
+
+##### Webrecorder (Browsertrix / ArchiveWeb.page)
+
+- **Integrity/signing**: The WACZ-Auth specification (authored by Webrecorder) defines signing for WACZ files using ECDSA with domain-name identity and optional RFC 3161 timestamps via FreeTSA. This is a *specification* -- actual implementation status in production tools varies. The `authsign` library and `py-wacz` CLI support signing. Browsertrix (the hosted service) does not appear to sign WACZ files by default.
+- **Independent timestamps**: The WACZ-Auth spec supports RFC 3161 via FreeTSA. Implementation in hosted Browsertrix: not confirmed as default behavior.
+- **Public verification**: Tools exist for verification (validator tools). Not a hosted public verification endpoint like WRL's.
+- **API access**: Browsertrix has an API for managing crawls, scheduling, and downloading archives. Self-hostable via Kubernetes.
+- **Standard format**: WACZ (they created the format). Also WARC.
+- **eIDAS support**: Not documented.
+- **Where they're strong**: They *invented* WACZ. High-fidelity browser-based capture. Open source. Strong in digital preservation community. Self-hostable. Active in government web archiving (End of Term Web Archive). ArchiveWeb.page browser extension for manual capture.
+- **Honest WRL differentiation**: WRL provides server-side signing + RFC 3161 timestamps + a hosted verification endpoint as default behavior on every capture. Webrecorder has the specification for this but does not appear to enable it by default on their hosted service. WRL is API-first (single call = signed evidence bundle); Webrecorder is crawl-oriented (multi-page site archiving). Different primary use cases: WRL = point-in-time evidence of a specific URL; Webrecorder = comprehensive site preservation. **Important caveat**: Webrecorder authored the WACZ-Auth spec that WRL effectively implements. Acknowledging this lineage builds credibility.
+
+##### Manual Screenshots + Notarization
+
+- **Integrity/signing**: Notary attestation (legally strong in many jurisdictions).
+- **Independent timestamps**: Notary timestamp (accepted by courts).
+- **Public verification**: Notary records can be verified through notary databases.
+- **API access**: None. Entirely manual.
+- **Standard format**: None. Typically PDF or image files with notary stamp.
+- **eIDAS support**: Notarization has its own EU legal framework, separate from eIDAS electronic timestamps.
+- **Where it's strong**: Legally established. Notary attestation is broadly accepted by courts. No technical knowledge required.
+- **Honest WRL differentiation**: WRL is 1000x faster, scalable, and cheaper. But notarization has centuries of legal precedent. WRL's cryptographic proof is technically superior but legally less tested.
+
+#### 2. Genuine WRL Differentiators (What No Competitor Matches)
+
+Based on the research, these are WRL's genuine unique differentiators -- capabilities where no competitor in this set matches WRL:
+
+1. **Ed25519 signing on every capture by default** -- PageFreezer and MirrorWeb sign, but with older algorithms (PKCS#1, SHA-1). Webrecorder has a spec but doesn't sign by default on their hosted service.
+2. **RFC 3161 independent timestamps on every capture by default** -- No competitor does this as a standard feature. PageFreezer uses proprietary atomic clock timestamps. Webrecorder's spec supports it but it's not default behavior.
+3. **Public verification endpoint (no account needed)** -- No competitor offers this. Every other service requires you to trust their platform for verification.
+4. **eIDAS-qualified timestamp option** -- No competitor offers this. This is a clear EU market differentiator.
+5. **WACZ as the default output format** -- Only Webrecorder also uses WACZ (they invented it). Every other competitor uses WARC, PDF, or proprietary formats.
+6. **MCP server for AI agent integration** -- Zero competitors occupy this niche.
+7. **Open source, self-hostable** -- Webrecorder/Browsertrix is also open source and self-hostable. But WRL combines open source with all the above signing/timestamp/verification features.
+8. **Single API call = complete signed evidence bundle** -- No competitor produces a signed, timestamped, verifiable evidence package from a single API call.
+
+#### 3. Where Competitors Are Genuinely Stronger Than WRL
+
+Honesty here builds credibility. The comparison table should NOT hide these:
+
+- **Scale**: Wayback Machine has 850B+ pages. WRL is a new service.
+- **Social media archiving**: PageFreezer, Hanzo, MirrorWeb archive Teams, Slack, social platforms. WRL captures web pages only.
+- **Dynamic content**: Hanzo's "Dynamic Capture Technology" handles SPAs, interactive elements, personalized pages better than a standard headless browser capture.
+- **Enterprise compliance certs**: PageFreezer (FedRAMP), Hanzo (SOC 2 Type 2), MirrorWeb (SOC 2) -- WRL has none of these.
+- **Legal services**: Page Vault's expert witness/affidavit service is a differentiated offering WRL cannot match.
+- **Site-wide archiving**: Webrecorder/Browsertrix and Archive-It are built for crawling entire sites. WRL captures one URL at a time.
+- **Legal track record**: Wayback Machine and Page Vault have actual court case history. WRL has none.
+
+#### 4. Feature List Structure and Messaging
+
+**Two audiences, one page, two visual treatments.**
+
+The feature list should serve both the non-technical buyer ("what does this prove?") and the developer ("what can I build with this?"). These are different decision-making frames:
+
+- **Non-technical (legal, compliance)**: Cares about *trust outcomes* -- "Is this admissible?", "Can my auditor verify this?", "Does this meet EU standards?"
+- **Developer/technical**: Cares about *integration capabilities* -- "Can I automate this?", "What format do I get back?", "Can I self-host?"
+
+**Proposed structure (landing page):**
+
+**Section title**: "What You Get" (concrete, outcome-oriented, not "Features")
+
+**Category 1: Evidence Integrity** (for the legal/compliance buyer)
+These map to the job "I need proof that will hold up."
+
+1. **Ed25519 Digital Signatures** -- Every capture is cryptographically signed. Proves who captured it and that nothing was altered.
+2. **RFC 3161 Independent Timestamps** -- A third-party authority records when the capture happened. No one -- not even WRL -- can backdate it.
+3. **Public Verification** -- Share a link. Anyone can confirm authenticity. No account, no trust in you required.
+4. **eIDAS Qualified Timestamps** -- Optional EU-standard timestamps with legal presumption of accuracy across all member states.
+
+**Category 2: Developer Experience** (for the builder)
+These map to the job "I need to integrate this into my workflow."
+
+5. **REST API** -- One POST, one signed evidence bundle. Batch captures, webhooks, scheduled captures.
+6. **MCP Server** -- Your AI agents can capture and verify web pages with cryptographic proof.
+7. **WACZ Standard Format** -- Open archive format used by Harvard, Library of Congress, Starling Lab. Not locked to any vendor.
+8. **Self-Hostable** -- Deploy on your infrastructure. Your keys, your storage, your evidence chain.
+
+This gives 8 items total (matching ux-strategy-minion's 6-8 recommendation), with a clean split between trust-oriented and capability-oriented messaging.
+
+**Ordering rationale**: Evidence Integrity first because it answers the "why should I care?" question. Developer Experience second because it answers "how do I use it?" The legal/compliance buyer stops at category 1 and is already interested. The developer scans both and sees the integration story.
+
+**Docs site feature list**: Expand each of the 8 items with 2-3 sentences of technical detail. Add items that don't belong on the landing page: cookie consent dismissal (dual screenshots), HTTP header capture, FRE 902(13) certification PDF, CLI verification tool, threat screening, audit logging.
+
+#### 5. Comparison Table Column Structure
+
+**Landing page (summary):** 4 columns, 4 competitors.
+
+Columns:
+1. **Cryptographic Signing** (the core differentiator)
+2. **Independent Timestamps** (second core differentiator)
+3. **Public Verification** (third core differentiator)
+4. **Open Standard Format** (WACZ/WARC -- tangible, verifiable)
+
+Competitors (selected for recognition and contrast):
+1. **Wayback Machine** -- everyone knows it; illustrates the "trust institution vs. trust math" gap
+2. **PageFreezer** -- the closest enterprise competitor; shows WRL's technical edge
+3. **Webrecorder** -- the closest technical competitor; shows WRL's API-first and default-signing advantage
+4. **Manual screenshots** -- the most common alternative in practice; makes the automation case
+
+This 4x4 matrix (plus WRL row = 5 rows) fits on a mobile screen and communicates the core story: WRL is the only service that signs, timestamps independently, verifies publicly, and outputs an open standard -- all by default.
+
+**Docs site (full):** 7 columns, 10 competitors.
+
+Columns:
+1. **Cryptographic Signing** -- algorithm and approach
+2. **Independent Timestamps** -- RFC 3161 or equivalent
+3. **Public Verification** -- anyone can verify without account
+4. **API Access** -- REST API, developer-accessible
+5. **Standard Format** -- WACZ, WARC, PDF, proprietary
+6. **eIDAS Qualified Timestamps** -- EU legal standard
+7. **Open Source / Self-Hostable** -- deployment control
+
+Competitors (all 9 from the task + "Build it yourself" and "Do nothing"):
+Wayback Machine, PageFreezer, Hanzo, Page Vault, MirrorWeb, Stillio, Archive-It, Webrecorder, Manual screenshots + notarization
+
+Each cell: checkmark, cross, partial indicator, or 2-3 word descriptor. No prose in cells.
+
+**Notes section**: One paragraph per competitor explaining nuances. This is where honesty lives -- "PageFreezer uses SHA-256 signing with their own timestamping infrastructure, which is compliant with the ESIGN Act but does not use an independent third-party TSA per RFC 3161." Link to sources.
+
+#### 6. Comparison Table Content: Cell-Level Recommendations
+
+I'll provide the recommended cell content for each competitor across the 7 docs-site columns. Use checkmarks, crosses, and short descriptors.
+
+**Legend:**
+- Full = fully supported as a default feature
+- Partial = supported with caveats
+- No = not supported
+- N/A = not applicable
+
+| | Crypto Signing | Independent Timestamps | Public Verification | API Access | Standard Format | eIDAS Qualified | Open Source |
+|---|---|---|---|---|---|---|---|
+| **WRL** | Ed25519 (every capture) | RFC 3161 (DigiCert TSA) | Yes (no account needed) | REST API, MCP | WACZ | Optional | Apache 2.0 |
+| **Wayback Machine** | No | No (crawl timestamps only) | Public access (no crypto verification) | Yes (rate-limited) | WARC | No | Partial (some tools) |
+| **PageFreezer** | SHA-256 + PKCS#1 | Stratum-1 clock (not RFC 3161) | No (platform-only) | Yes (partner API) | PDF | No | No |
+| **Hanzo** | Not documented | Not documented | No | No | WARC | No | No |
+| **Page Vault** | SHA-256 hashing | Internal timestamps | No (expert witness service) | No | Proprietary/PDF | No | No |
+| **MirrorWeb** | SHA-1 signatures | Timestamped (not RFC 3161) | No (platform-only) | Limited API | WARC | No | No |
+| **Stillio** | No | No (metadata only) | No | Basic API | PNG/JPEG | No | No |
+| **Archive-It** | No (checksums only) | No (crawl timestamps) | Public access (no crypto) | Yes (WASAPI) | WARC | No | No |
+| **Webrecorder** | WACZ-Auth spec (not default) | RFC 3161 in spec (not default) | Validator tools exist | Yes (Browsertrix API) | WACZ + WARC | No | Yes |
+| **Manual + Notary** | Notary attestation | Notary timestamp | Via notary records | No | N/A | Separate framework | N/A |
+
+**Important accuracy notes for the implementing agent:**
+
+- PageFreezer: I found references to both "SHA-256 digital signature" and "PKCS#1 v1.5" in their materials. The existing competitive analysis doc says "PKCS#1 v1.5." I cannot confirm whether they use both or one. The safest cell content is "SHA-256 signing" without specifying the algorithm further.
+- MirrorWeb: Their docs mention "SHA1 digital signature" but this may be outdated. SHA-1 is cryptographically deprecated. Consider softening to "Digital signatures (SHA-1 per docs)" with a note that this may have been updated.
+- Webrecorder: The WACZ-Auth spec supports signing, but whether Browsertrix (hosted) enables it by default is unclear from public docs. The cell should reflect the spec vs. default behavior distinction.
+- Hanzo: Multiple sources confirm "no API available." Their integrity approach is proprietary and not publicly documented. Cells should reflect this honestly.
+
+#### 7. Feature Messaging Vocabulary
+
+For the landing page, use the language each audience actually uses:
+
+**For legal/compliance buyers:**
+- "evidence" not "data"
+- "proof" not "verification"
+- "tamper-evident" not "signed"
+- "independently verifiable" not "open source"
+- "third-party timestamp authority" not "RFC 3161"
+- Reference FRE 901(b)(9), FRE 902(13)/902(14), eIDAS Art. 41(2) -- these are the standards their work revolves around
+
+**For developers:**
+- "Ed25519" not "digital signatures"
+- "RFC 3161" not "independent timestamps"
+- "WACZ" not "evidence bundle"
+- "REST API" / "MCP server" -- specific protocol names
+- "self-host" / "Apache 2.0" -- deployment and licensing specifics
+- "one POST = signed bundle" -- the integration story in one phrase
+
+The landing page feature list should lean toward the legal/compliance vocabulary (broader audience, less technical, higher emotional resonance) with the developer subsection switching to precise technical terms. The docs site uses full technical vocabulary throughout.
+
+### Proposed Tasks
+
+1. **Draft landing page feature list copy** -- 8 items in 2 categories ("Evidence Integrity" + "Developer Experience"). Each item: heading + one sentence. Total word budget: ~120 words. Heading for the section: "What You Get." This is content work, not implementation.
+
+2. **Draft landing page comparison summary** -- 4x4 matrix (WRL + 4 competitors, 4 columns). Determine exact cell content using checkmarks/crosses/short descriptors. Write intro sentence and link to full comparison. Total word budget: ~80 words (excluding table cells).
+
+3. **Draft docs site comparison page content** -- Full 7-column, 10-row matrix. Per-competitor notes section (3-5 sentences each). Methodology note with verification date. This produces the raw content that gets placed into `site/content/compare.md`.
+
+4. **Draft docs site expanded feature list** -- Expand each of the 8 landing-page items with 2-3 sentences of technical detail. Add secondary features (cookie consent, HTTP headers, FRE certification PDF, CLI verification, threat screening). This either lives on the compare page or as a standalone section.
+
+5. **Fact-check competitor claims before implementation** -- Every cell in the comparison table that I flagged with uncertainty (PageFreezer signing algorithm, MirrorWeb SHA-1 status, Webrecorder default signing behavior) should be verified by checking their current public documentation or testing their product. Flag any cell that cannot be verified with a footnote saying so.
+
+6. **Implement landing page HTML/CSS** -- Place feature list section and comparison summary in the page per ux-strategy-minion's placement recommendations. This is frontend-minion's task, consuming the content from tasks 1-2.
+
+7. **Implement docs site compare page** -- Create `site/content/compare.md` consuming content from tasks 3-4. Add nav entry per software-docs-minion's recommendations.
+
+### Risks and Concerns
+
+**Competitor accuracy is the highest-stakes risk.** Every claim about a competitor is verifiable by that competitor, their customers, and journalists. One factual error undermines the entire comparison. Specific concerns:
+
+- **PageFreezer's signing approach**: Multiple conflicting descriptions in their own materials. The comparison should state what their public docs claim and note the ambiguity rather than asserting a specific implementation.
+- **MirrorWeb's SHA-1**: If they've upgraded and we list SHA-1, we look uninformed. If they haven't and we omit it, we miss a genuine differentiator. Recommend noting "per their current public documentation" with a date.
+- **Webrecorder's WACZ-Auth**: WRL effectively implements a specification that Webrecorder authored. The comparison must acknowledge this lineage respectfully. "WRL implements WACZ signing as a default on every capture; Webrecorder authored the specification and provides tooling for it" is honest framing. Claiming WRL "invented" this approach when it builds on Webrecorder's spec would be dishonest and would be caught by the web archiving community instantly.
+- **Hanzo confusion**: "Hanzo" (hanzo.co) the web archiving company is distinct from "Hanzo AI" (hanzo.ai) the AI platform. Search results conflate these. All claims must reference hanzo.co specifically.
+
+**Staleness**: Competitor features change. The docs page needs a "Last verified: YYYY-MM-DD" date and an invitation to report inaccuracies via GitHub issues. This is not optional -- it's the primary credibility signal for developer audiences.
+
+**"Build it yourself" and "Do nothing" are the real competitors.** The comparison table focuses on named products, but the most common alternatives in practice are (a) writing a quick headless Chrome script and dumping to S3, and (b) not archiving at all. The feature list messaging should address these: "What you'd have to build yourself: signing infrastructure, timestamp integration, verification UI, standard format packaging, key management..."
+
+**Tone risk**: The comparison must be factual, not dismissive. "No cryptographic signing" is a fact. "Lacks real security" is an opinion. Every cell should state what the competitor does, not what they lack. "Checksums only" is better than "No real integrity."
+
+### Additional Agents Needed
+
+- **frontend-minion**: To implement the comparison table HTML/CSS with responsive behavior. The 4x4 landing summary and 7x10 docs table have very different responsive requirements.
+- **seo-minion**: To handle structured data updates (the existing `featureList` in the SoftwareApplication schema needs updating) and ensure the landing/docs split doesn't create duplicate content issues.
+- **ux-design-minion**: To review visual treatment of feature list (lightweight list vs. cards) and comparison table (badge colors, checkmark/cross styling) against the existing design system.

--- a/docs/history/nefario-reports/2026-03-26-044407-feature-list-competitor-comparison/phase2-seo-minion.md
+++ b/docs/history/nefario-reports/2026-03-26-044407-feature-list-competitor-comparison/phase2-seo-minion.md
@@ -1,0 +1,132 @@
+## Domain Plan Contribution: seo-minion
+
+### Recommendations
+
+#### 1. Update the SoftwareApplication structured data on the landing page
+
+The existing `featureList` array (lines 59-68 of `landing/public/index.html`) should be updated to reflect the full feature set presented in the new comparison content. Specifically:
+
+- **Expand `featureList`** to include every feature that appears in the comparison table. The current list has 8 items; the comparison will surface more capabilities. Each feature should be a concise, descriptive string (not marketing copy). Keep entries self-explanatory to someone reading raw structured data.
+- **Add `offers` property** to the SoftwareApplication schema. The pricing section already exists on the page but is not reflected in structured data. Adding an `Offer` with `price: "0"` and `priceCurrency: "EUR"` for the free tier makes the product eligible for richer search result presentation. Use `AggregateOffer` if representing multiple tiers.
+- **Add `applicationSubCategory`** with a value like `"Web Archiving"` or `"Digital Evidence"` to improve topical classification.
+- **Do NOT add a separate comparison/table schema** (there is no schema.org type for feature comparison tables that produces rich results). The value is in keeping `featureList` comprehensive and accurate.
+
+Example additions to `featureList`:
+```json
+"featureList": [
+  "Ed25519 digital signatures",
+  "RFC 3161 timestamps",
+  "WACZ evidence bundles",
+  "Public verification URLs",
+  "REST API and MCP server",
+  "Cookie consent dismissal",
+  "eIDAS-qualified timestamps (optional)",
+  "FRE 901/902 evidence authentication support",
+  "Batch capture API",
+  "Webhook notifications",
+  "Screenshot and rendered HTML capture",
+  "HTTP header recording",
+  "Scheduled captures",
+  "Usage-based pricing with free tier"
+]
+```
+
+The exact list should be derived from whatever the feature comparison defines -- the above is illustrative. The key principle: `featureList` in structured data should mirror the feature list visible on the page (consistency between markup and visible content is a Google quality signal).
+
+#### 2. Duplicate content: landing summary vs. docs full version
+
+**No meaningful risk, but handle it correctly.**
+
+- The landing page and docs site are on different subdomains (`webresourceledger.com` vs. `docs.webresourceledger.com`). Google treats subdomains as separate sites. Two versions of comparison content (summary vs. detailed) on separate sites with different depths of coverage is standard practice and will not trigger duplicate content signals.
+- **The content must genuinely differ in substance, not just length.** A truncated copy of the docs version on the landing page would be a weak signal. The landing version should be a distinct editorial piece: feature highlights, condensed comparison with a clear CTA linking to the full version. The docs version should be the comprehensive reference with notes, caveats, and methodology.
+- **Each page must have its own canonical tag pointing to itself.** The landing page already self-canonicalizes. The docs comparison page needs `<link rel="canonical" href="https://docs.webresourceledger.com/comparison/">` (or whatever the final URL path is).
+- **Do NOT cross-canonical** (don't point the docs page's canonical to the landing page or vice versa). They are different content serving different intents.
+- **Link between them explicitly.** The landing summary should link to the docs full version ("See the full comparison"). The docs version can link back to the landing page. These cross-links help Google understand the relationship without canonical confusion.
+
+#### 3. Structured data for the docs comparison page
+
+**Yes, but keep it minimal and purposeful.**
+
+The docs site currently has zero structured data (confirmed: `site/_includes/layouts/base.njk` has no JSON-LD). This is an opportunity to add foundational structured data to the docs site, starting with the comparison page:
+
+- **Article schema** for the comparison page. Use `@type: "TechArticle"` (a schema.org subtype of Article appropriate for technical documentation). Include `headline`, `description`, `datePublished`, `dateModified`, `author` (linking to the Organization entity on the landing page via `@id`), and `mainEntityOfPage`.
+- **Do NOT try to encode the comparison table itself as structured data.** There is no schema.org type that maps to feature comparison tables in a way that produces rich results. The value of structured data here is in surfacing the page as a tech article, not in marking up individual table cells.
+- **Consider adding a BreadcrumbList** to the docs site base template (`base.njk`). This is a low-effort, high-value addition that improves how all docs pages appear in search results (breadcrumb trail instead of raw URL). This is a site-wide improvement, not specific to the comparison page, but the comparison page work is a good trigger to add it.
+
+Recommended structured data for the docs comparison page:
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "TechArticle",
+  "headline": "WRL Feature Comparison",
+  "description": "Detailed feature comparison of web evidence and archiving tools.",
+  "datePublished": "2026-03-26",
+  "dateModified": "2026-03-26",
+  "author": {
+    "@type": "Organization",
+    "name": "Web Resource Ledger",
+    "url": "https://webresourceledger.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "Web Resource Ledger",
+    "url": "https://webresourceledger.com/",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://webresourceledger.com/assets/logo-w-check.svg"
+    }
+  },
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": "https://docs.webresourceledger.com/comparison/"
+  }
+}
+```
+
+#### 4. SEO opportunities from comparison content
+
+**Competitor name queries.** People search for "[competitor] alternative" and "[tool A] vs [tool B]". The comparison page on the docs site is the right place to target these queries. Specific opportunities:
+
+- **Title tag pattern for docs comparison page**: "WRL vs [Competitor] -- Web Evidence Tool Comparison" or "Web Archiving Tools Compared: WRL, [Competitor A], [Competitor B]". The title should name the most-searched competitors. Keep under 60 characters.
+- **Meta description**: Should mention the comparison angle and key differentiators (cryptographic signatures, independent verification, open source). This is the click-through hook.
+- **Heading structure**: Use h2s for each competitor or comparison dimension (e.g., "Cryptographic Verification", "Timestamp Standards", "Output Format", "Pricing Model"). Each h2 targets a feature-term query cluster.
+- **Feature terms as keywords**: Terms like "RFC 3161 timestamp", "WACZ archive", "Ed25519 signature", "eIDAS qualified timestamp", "web evidence", "web archiving API" are low-competition, high-intent terms. The comparison content naturally includes these. Ensure they appear in headings and early paragraph text, not just table cells (Google weights heading and paragraph text more than table content for ranking).
+- **Landing page summary version**: Should NOT target competitor name queries (that is the docs page's job). The landing summary should reinforce WRL's own brand terms and feature terms. Keep it focused on "what WRL does" rather than "how WRL compares."
+- **Internal linking**: The comparison page should link to relevant docs pages (verification, legal evidence, MCP, API reference) using descriptive anchor text. This distributes link equity from the comparison page (which will attract external links from "vs" searches) to the core docs pages.
+
+**Do NOT over-optimize.** The comparison must be factually accurate and fair. Google's helpful content system penalizes pages that exist solely for SEO -- the comparison must serve a genuine user need (helping someone evaluate tools). Inaccurate claims about competitors will also create reputational risk.
+
+### Proposed Tasks
+
+1. **Update `featureList` in SoftwareApplication schema** on landing page to reflect the full feature set from the comparison content. Add `offers` property for the free tier. (Landing page, implementation task)
+
+2. **Add self-referencing canonical tag** to the docs comparison page. Ensure the docs site base template supports canonical tags (it currently does not -- `base.njk` has no canonical link element). (Docs site, template-level fix)
+
+3. **Add TechArticle structured data** to the docs comparison page. Include headline, description, dates, author, publisher. (Docs site, page-level)
+
+4. **Add BreadcrumbList structured data** to docs site base template. This benefits all docs pages, not just the comparison. Low effort, high value. (Docs site, template-level)
+
+5. **Add Open Graph and Twitter Card meta tags** to the docs site base template. The docs site currently has none (confirmed in `base.njk`). At minimum: `og:title`, `og:description`, `og:url`, `og:type`, `twitter:card`. (Docs site, template-level)
+
+6. **Optimize title tag and meta description** for the docs comparison page to target "[competitor] alternative" and "vs" query patterns. (Docs site, page-level)
+
+7. **Update landing page sitemap.xml** to include any new landing page URL if the comparison summary is a new page (currently the sitemap only lists `/`, `/terms`, `/privacy`, `/refund-policy`, `/content-policy`). If the comparison is a section within the existing index.html, no sitemap change needed.
+
+8. **Cross-link between landing summary and docs full version.** Landing summary links to docs with "See the full comparison" anchor text. Docs version links back to landing page.
+
+### Risks and Concerns
+
+- **Competitor name accuracy**: Any claims in the comparison table about competitor features must be verifiable and current. Outdated or inaccurate competitor information damages credibility with users and can trigger manual review if competitors report it. Recommendation: include a "last verified" date on the docs comparison page and commit to periodic review.
+
+- **Docs site has no canonical tags, no OG tags, no structured data at all.** The comparison page will expose these gaps. Tasks 2, 4, and 5 above are template-level fixes that should be done before or alongside the comparison page, not after. Shipping a comparison page without canonicals on the docs site means Google has to guess which URL variant to index.
+
+- **Feature list drift.** If the `featureList` in structured data is updated to match the comparison content but never maintained afterward, it will drift from reality. Recommendation: treat `featureList` as a living property -- update it whenever features ship or are deprecated. Add a note in the evolution log or CLAUDE.md.
+
+- **Two subdomains, one brand.** Google sees `webresourceledger.com` and `docs.webresourceledger.com` as related but separate sites. The Organization schema on the landing page should be the canonical entity. The docs site should reference it via `@id` rather than duplicating it. This establishes entity coherence across subdomains.
+
+### Additional Agents Needed
+
+- **frontend-minion**: To implement the structured data changes in both `landing/public/index.html` and `site/_includes/layouts/base.njk`. The SEO spec above defines *what* to add; frontend-minion implements *how* (Eleventy data cascade for dynamic structured data, canonical URL generation from page metadata, etc.).
+
+- **content strategy / whoever is writing the comparison text**: SEO constraints to pass along -- the docs version needs proper heading hierarchy (h1 for page title, h2s for comparison dimensions), feature terms in headings not just tables, and a "last verified" date. The landing version should be editorially distinct (not a truncation of the docs version).

--- a/docs/history/nefario-reports/2026-03-26-044407-feature-list-competitor-comparison/phase2-software-docs-minion.md
+++ b/docs/history/nefario-reports/2026-03-26-044407-feature-list-competitor-comparison/phase2-software-docs-minion.md
@@ -1,0 +1,58 @@
+## Domain Plan Contribution: software-docs-minion
+
+### Recommendations
+
+**Single page, not two.** A "Features" page separate from "Comparison" creates a maintenance burden and forces the reader to cross-reference. The comparison table already implies feature coverage. One page titled **"Compare"** (nav label) / **"How WRL Compares"** (H1) keeps it tight. The table IS the feature list -- each row is a capability, each column is a product.
+
+**Nav position: between Architecture and Security & Compliance (position 11).** Reasoning:
+
+- The first 9 items (Getting Started through API Reference) are task-oriented: they help developers integrate. A comparison page does not belong in this sequence -- it interrupts the "do things" flow.
+- Architecture (position 10) shifts the docs from "how to use" to "how it works / why trust it." A comparison page fits naturally after Architecture and before Security & Compliance, because all three serve the **evaluator** persona rather than the integrator persona.
+- Placing it at the very top (position 2 or 3) is tempting for marketing but wrong for docs. Developers who land on docs.webresourceledger.com want to integrate first. Evaluators who want the comparison will scan the nav -- position 11 is visible without scrolling in a 17-item nav.
+
+**URL: `/compare/`** -- short, linkable, unambiguous. Not `/comparison/` (longer for no reason) or `/vs/` (too cute).
+
+**Title/label guidance:**
+- Nav label: `Compare` (one word, scans fast in sidebar)
+- Page H1: `How WRL Compares` (gives context when landing from search)
+- `<title>` / description: `How WRL compares to Wayback Machine, Archive.today, Conifer, and other web archiving tools` (SEO-facing, names competitors for search intent)
+
+**Content structure for the page itself:**
+
+1. **Lead paragraph** (2-3 sentences) -- what this page covers, who it is for, when it was last verified
+2. **Comparison table** -- the full matrix. Keep column headers short. Use checkmarks / x / partial indicators, not prose. Link footnote numbers to the notes section.
+3. **Notes by competitor** -- one H2 per competitor with 3-5 sentences explaining nuances the table cannot capture (e.g., "Archive.today captures are not downloadable as WARC/WACZ" or "Conifer requires self-hosting for API access"). Each note should link to the competitor's website or docs for verifiability.
+4. **Methodology note** -- brief footer explaining how data was gathered and when it was last checked. This is critical for credibility: "All claims verified against public documentation and direct testing as of [date]. If something has changed, open an issue."
+
+**Do NOT include:**
+- Pricing comparison (changes constantly, becomes stale immediately, and WRL pricing is not yet public)
+- Subjective quality judgments ("better," "best") -- let the feature matrix speak
+- Screenshots of competitor UIs (copyright concerns, staleness)
+
+### Proposed Tasks
+
+1. **Create `site/content/compare.md`** with frontmatter (`layout: layouts/doc.njk`, title, description) and the full content structure described above. The comparison data itself should come from whatever research the content-producing agent has done.
+
+2. **Add nav entry in `site/_data/site.js`** at position 11 (after Architecture, before Security & Compliance):
+   ```js
+   { title: "Compare", url: "/compare/" },
+   ```
+
+3. **Add a "last verified" date** in the page frontmatter or as visible text near the table. This is the single most important maintenance signal -- without it, readers cannot judge trustworthiness.
+
+4. **Cross-link from Getting Started** -- add one sentence near the top of the Getting Started page: "Not sure if WRL is the right tool? See [how WRL compares](/compare/) to other web archiving approaches." This catches evaluators who land on the docs homepage.
+
+### Risks and Concerns
+
+- **Staleness is the primary risk.** Competitor feature matrices go stale within months. The methodology note and last-verified date mitigate perception but not reality. Consider a quarterly review reminder (backlog item, not a docs concern).
+
+- **Table width on mobile.** A 7+ column comparison table will overflow on mobile viewports. The implementing agent should verify that the docs site's CSS handles horizontal scroll for wide tables, or use a responsive pattern (e.g., cards on mobile). Check the existing `doc.njk` layout and CSS for table handling before assuming it works.
+
+- **Accuracy liability.** Every claim about a competitor is a potential source of dispute. Stick to verifiable, factual statements (supports X: yes/no) rather than qualitative judgments. Link to sources where possible.
+
+- **SEO cannibalization.** The landing page (webresourceledger.com) likely also positions WRL against alternatives. Ensure the docs comparison page and the landing page serve different intents: landing page = quick positioning for buyers, docs page = detailed technical comparison for evaluators. Duplicate content between the two will hurt both.
+
+### Additional Agents Needed
+
+- **frontend-minion**: To verify/implement responsive table CSS in the docs layout. A 10-column table needs explicit overflow handling.
+- **seo-minion** (if one exists): To ensure the comparison page meta description and title tag are optimized for "web archiving comparison" / "wayback machine alternative" search queries, and to check for content overlap with the landing page.

--- a/docs/history/nefario-reports/2026-03-26-044407-feature-list-competitor-comparison/phase2-ux-strategy-minion.md
+++ b/docs/history/nefario-reports/2026-03-26-044407-feature-list-competitor-comparison/phase2-ux-strategy-minion.md
@@ -1,0 +1,94 @@
+## Domain Plan Contribution: ux-strategy-minion
+
+### Recommendations
+
+#### 1. Section Placement: Features after Use Cases, Comparison after How It Works
+
+The current narrative arc is: **Why this matters** (Use Cases) > **How it works** (mechanism) > **What it costs** (Pricing). This maps to the classic JTBD decision journey: understand the job, understand the solution, evaluate the price.
+
+Features and comparison serve different functions in this arc:
+
+- **Feature list** answers "what exactly do I get?" -- this is a *performance features* question (Kano) that naturally follows "why would I care?" (Use Cases). Place it between Use Cases and How It Works.
+- **Comparison table** answers "why this over alternatives?" -- this is a *switching cost* evaluation that only matters after the visitor understands both what WRL does and how. Place it between How It Works and Pricing.
+
+Proposed flow: **Hero > Use Cases > Features > How It Works > Compare > Pricing**
+
+Rationale: Pricing must remain the final section before conversion. It is the natural terminus -- the visitor has all the information they need and the CTA follows. Moving pricing away from the bottom would break the conversion funnel.
+
+#### 2. Content Density: Landing Gets Summaries, Docs Gets Depth
+
+**Landing page principle: signal, not data.** The current page works because every section can be scanned in under 10 seconds. Adding a 7x9 table would violate this. Hick's Law tells us that 63 cells of comparison data will increase decision time, not reduce it.
+
+**Feature list on landing:** 6-8 items maximum, grouped into 2 clear categories (e.g., "Evidence Integrity" and "Developer Experience"). Each item: a short heading + one sentence. No icons, no elaborate cards. Match the density of the existing Use Cases cards. Link to a full features page on docs.
+
+**Comparison table on landing:** Do NOT put the full 7-column, 9-row table on the landing page. Instead, use a **"highlight comparison"** format:
+- Show WRL vs. the 2-3 most recognizable competitors (not all 9)
+- Show only the 3-4 most differentiating columns (the ones where WRL wins clearly)
+- Use checkmarks/crosses for boolean features, short text for non-boolean
+- End with a clear link: "See full comparison with 9 services" pointing to docs
+
+This applies progressive disclosure correctly: the landing summary creates enough differentiation to sustain interest, while the full table is available for visitors in deep evaluation mode.
+
+**Docs site:** Host the complete feature list and the full 9-competitor, 7-column comparison table. These pages serve the bottom-of-funnel evaluator who has already decided this category is relevant and is now comparing options systematically. This audience expects and benefits from data density.
+
+#### 3. Landing Summary Formats
+
+**Feature list format:** A simple two-column grid of feature items (heading + one line of body text). No cards with borders -- cards create visual weight and the page already uses cards for Use Cases. Use a lightweight list or definition-list pattern instead. This creates visual contrast between sections and prevents card fatigue.
+
+**Comparison summary format:** A condensed table with 3-4 columns and 3-4 rows. Keep cells tight: checkmark, cross, or a 2-3 word descriptor. The table header row should be visually distinct. Include a footnote-style link to the full comparison.
+
+Avoid: carousel/tabs for comparison (hidden content doesn't compare), feature cards with icons (icon-shopping adds cognitive load without aiding comprehension), animated reveals (the page has none currently -- introducing them would break consistency).
+
+#### 4. Navigation: Add Features, Skip Compare
+
+The header nav currently has 5 items. Nielsen's research and Hick's Law both suggest keeping primary navigation to 5-7 items. Adding both new sections would push to 7, which is the upper bound.
+
+Recommendation:
+- **Add "Features" to nav** -- it is a primary decision factor and visitors actively look for it. Place it after "Use Cases": `Use Cases | Features | How It Works | Pricing | Docs | Sign in`
+- **Do NOT add "Compare" to nav** -- comparison is a secondary evaluation step, not a primary navigation target. Visitors who want it will scroll to it naturally (it sits between How It Works and Pricing). Adding it to nav would create 7 items plus the Sign in button, pushing into crowded territory.
+
+On the docs site, the comparison page should appear in the docs sidebar navigation where data-dense reference content belongs.
+
+#### 5. Cognitive Load Management
+
+The current page has approximately 4 decision units (sections). Adding 2 more increases cognitive load by 50%. Mitigation strategies:
+
+**Visual rhythm:** Alternate background treatments (white/muted) as the page already does. Features should get the muted background (matching How It Works' current treatment), and Compare should get white. This maintains the visual breathing pattern.
+
+**Section headers do the heavy lifting:** Each section header should be scannable and self-sufficient. A visitor scrolling fast should get the gist from headers alone: "Built for teams who need proof" > [features header] > "How It Works" > [compare header] > "Pricing". The headers for Features and Compare need to be as strong as the existing ones.
+
+**Word budget:** The landing page currently has roughly 450 words of body content (excluding nav/footer). Adding features and comparison summaries should not exceed 200 additional words combined. That means: ~8 feature items at ~15 words each (120 words) + comparison intro + table labels (~80 words). The full content lives on docs.
+
+**Clear exit ramps:** Both new sections must have a prominent "See full [features/comparison] on docs" link. This serves two purposes: (a) progressive disclosure for deep evaluators, and (b) a clear signal to casual scanners that "you've seen enough, scroll on."
+
+### Proposed Tasks
+
+1. **Determine landing feature list content** -- Select 6-8 features, grouped into 2 categories. Write heading + one-sentence description for each. Constraint: ~120 words total.
+
+2. **Determine landing comparison subset** -- Select 3-4 competitors and 3-4 columns for the landing summary table. Criteria: competitors visitors will recognize, columns where WRL differentiates clearly.
+
+3. **Write full feature list for docs site** -- Complete feature inventory with descriptions, organized by category. This is the canonical reference that the landing page links to.
+
+4. **Write full comparison table for docs site** -- All 9 competitors, all 7 columns, with methodology notes explaining how each cell was determined (transparency builds trust in comparison claims).
+
+5. **Implement landing page HTML/CSS for both sections** -- Features section between Use Cases and How It Works. Comparison summary between How It Works and Pricing. Maintain existing visual rhythm (alternating white/muted backgrounds).
+
+6. **Update header navigation** -- Add "Features" link between "Use Cases" and "How It Works". Do not add "Compare" to nav.
+
+7. **Cross-link between landing and docs** -- Each landing summary section links to its full docs counterpart. Docs pages link back to landing for visitors arriving directly.
+
+### Risks and Concerns
+
+**Risk: Scope creep into marketing copy.** Feature lists and comparison tables are inherently marketing artifacts. The current landing page succeeds because it reads as honest and technical, not salesy. Every feature claim and comparison cell must be verifiable. Comparison tables that cherry-pick dimensions to make the product look good erode trust with technical audiences. Mitigation: include methodology notes on the docs comparison page; only compare on dimensions where the data is objectively verifiable.
+
+**Risk: Comparison table maintenance burden.** 9 competitors x 7 columns = 63 data points that can go stale. Competitors ship features, change pricing, pivot. A stale comparison table is worse than no table -- it signals neglect. Mitigation: date-stamp the comparison ("Last verified: [date]") and build a lightweight review cadence. Consider whether 9 competitors is the right number -- 5-6 may be sufficient and more maintainable.
+
+**Risk: Breaking the page's conversion simplicity.** The current page is a 4-section funnel. Adding 2 sections means 50% more scrolling. On mobile, this is significant. Mitigation: keep landing summaries extremely concise (the word budget constraint above), ensure each section earns its scroll-depth with clear value, and verify with analytics that scroll-depth to Pricing doesn't degrade after launch.
+
+**Risk: Feature list overlapping with Use Cases.** Features and use cases can blur together. "Ed25519 signatures" is a feature; "Legal Evidence" is a use case that implies features. If the feature list merely re-states what Use Cases already communicates, it adds length without value. Mitigation: Use Cases should remain outcome-focused ("what you can do"), Features should be capability-focused ("what's in the box"). Review both sections together to eliminate redundancy.
+
+### Additional Agents Needed
+
+- **ux-design-minion** -- Needed for the visual design of both landing sections: feature list layout pattern, condensed comparison table styling, responsive behavior (the comparison table on mobile is a known hard problem), and ensuring visual consistency with existing sections.
+- **content-strategy or copywriting specialist** -- The feature list headings and one-liners need to be precise and differentiated. The comparison table column headers need to be unambiguous. This is specialized writing that benefits from dedicated attention.
+- **research/competitive-analysis specialist** -- Verifying the 63 data points in the full comparison table requires systematic research into each competitor's current capabilities. Claims must be accurate as of publication date. This is not a UX task -- it is a research task.

--- a/docs/history/nefario-reports/2026-03-26-044407-feature-list-competitor-comparison/phase3-synthesis-prompt.md
+++ b/docs/history/nefario-reports/2026-03-26-044407-feature-list-competitor-comparison/phase3-synthesis-prompt.md
@@ -1,0 +1,53 @@
+MODE: SYNTHESIS
+
+You are synthesizing specialist planning contributions into a final execution plan.
+
+## Original Task
+
+Feature list and competitor comparison table for WRL landing page and docs site (#144).
+
+Success criteria:
+- Landing site has feature list section with core capabilities + developer/technical benefits
+- Comparison table covers 9+ competitors with 7+ columns
+- Factually accurate competitor rows
+- Responsive on mobile
+- Landing page (summary) + docs site (full version with notes)
+- Pure HTML + CSS, no JS framework, match design-system.css
+
+## Specialist Contributions
+
+Read the following scratch files for full specialist contributions:
+- /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-0ldPyr/feature-list-competitor-comparison/phase2-product-marketing-minion.md
+- /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-0ldPyr/feature-list-competitor-comparison/phase2-ux-strategy-minion.md
+- /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-0ldPyr/feature-list-competitor-comparison/phase2-frontend-minion.md
+- /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-0ldPyr/feature-list-competitor-comparison/phase2-seo-minion.md
+- /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-0ldPyr/feature-list-competitor-comparison/phase2-software-docs-minion.md
+
+## Key consensus across specialists:
+
+1. product-marketing-minion: WRL's unique differentiator is Ed25519+RFC3161+public verification enabled by default. Feature list as "Evidence Integrity" (4 items) + "Developer Experience" (4 items). Landing gets 4x4 summary table, docs gets full 7x10 matrix. 3 competitor claims need verification.
+2. ux-strategy-minion: Place Features after Use Cases, Compare after How It Works. ~200 words total on landing. Full table on docs only. Add "Features" to nav, not "Compare". Word budget is critical.
+3. frontend-minion: Card-stack pattern for mobile responsive. Landing 5-column summary, docs full 8-column. Docs page must be .njk for data-label attributes. No design-system.css changes needed. Docs content column too narrow (42rem) -- needs breakout wrapper.
+4. seo-minion: Expand SoftwareApplication featureList. Docs has zero SEO infrastructure. Self-canonicalize both pages. Docs template SEO improvements are out of scope for this task.
+5. software-docs-minion: Single page at /compare/, nav position 11 (after Architecture, before Security), label "Compare".
+
+## External Skills Context
+
+No external skills detected.
+
+## Instructions
+
+1. Review all specialist contributions
+2. Resolve any conflicts between recommendations
+3. Incorporate risks and concerns into the plan
+4. Create the final execution plan in structured format
+5. Ensure every task has a complete, self-contained prompt
+
+Key decisions to resolve:
+- Landing comparison format: pm says 4x4, frontend says 5-column, ux says 3-4 columns. Pick one.
+- Docs SEO improvements: seo-minion wants template-level fixes. This is scope creep -- defer to backlog or include?
+- Section ordering: ux-strategy says Features after Use Cases, Compare after How It Works. Validate against product-marketing's messaging strategy.
+- Nav links: ux says add "Features" but not "Compare". Confirm.
+- Word budget: ux says ~200 words max on landing for both new sections combined. Ensure tasks respect this.
+
+6. Write your complete delegation plan to /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-0ldPyr/feature-list-competitor-comparison/phase3-synthesis.md

--- a/docs/history/nefario-reports/2026-03-26-044407-feature-list-competitor-comparison/phase3-synthesis.md
+++ b/docs/history/nefario-reports/2026-03-26-044407-feature-list-competitor-comparison/phase3-synthesis.md
@@ -1,0 +1,727 @@
+## Delegation Plan
+
+**Team name**: feature-comparison
+**Description**: Add feature list section and competitor comparison table to WRL landing page and docs site.
+
+### Conflict Resolutions
+
+Before the task breakdown, here are the key decisions made during synthesis:
+
+**Landing comparison columns**: product-marketing says 4 columns, frontend says 5 columns, ux-strategy says 3-4 columns. **Resolution: 5 columns** (Tool + 4 feature columns). The 4 feature columns from product-marketing are the right ones (Crypto Signing, Independent Timestamps, Public Verification, Standard Format). Adding the tool-name column makes it 5 total, which is what frontend-minion recommended. This fits mobile card-stack at < 768px.
+
+**Landing comparison rows**: product-marketing says 4 competitors (Wayback, PageFreezer, Webrecorder, Manual). ux-strategy says 3-4. **Resolution: 4 competitors + WRL = 5 rows**. These 4 were well-chosen: Wayback (brand recognition), PageFreezer (enterprise), Webrecorder (technical), Manual screenshots (common practice).
+
+**Features section title**: product-marketing proposes "What You Get", ux-strategy doesn't specify. **Resolution: "What You Get"** -- concrete and outcome-oriented, matches the page's honest tone.
+
+**Compare section on landing**: ux-strategy says no "Compare" in nav. **Resolution: Agree.** The comparison summary section on the landing page gets an id but no nav link. Only "Features" gets added to nav.
+
+**Docs page path**: software-docs-minion says `/compare/`, seo-minion doesn't specify. **Resolution: `/compare/`** -- short and linkable.
+
+**Docs page format**: frontend-minion says the comparison page must be `.njk` for `data-label` attributes on mobile. software-docs-minion proposes `.md`. **Resolution: `.njk`** -- the mobile card-stack pattern requires `data-label` attributes on `<td>` elements which Markdown cannot produce.
+
+**Docs site SEO improvements** (canonical tags, OG tags, BreadcrumbList, TechArticle): seo-minion wants template-level fixes. **Resolution: Defer all except self-canonical on the compare page itself.** Template-level SEO improvements are out of scope for this task (issue #144 is about feature list + comparison, not docs site SEO infrastructure). Add a backlog item.
+
+**Feature list visual treatment**: frontend-minion proposes cards with badges. ux-strategy-minion says "not cards -- cards create visual weight, page already uses cards for Use Cases." **Resolution: Lightweight list, not cards.** Use a definition-list-style pattern (heading + description) without `.card` borders. This creates visual contrast with the Use Cases card section above it and stays within ux-strategy's word budget.
+
+**Docs features page**: product-marketing proposes expanding the 8 landing features with technical detail on docs. software-docs-minion says the comparison table IS the feature list. **Resolution: No separate features page on docs.** The docs compare page covers capabilities through its full matrix + notes. The landing feature list links to the compare page, not to a separate features page. This keeps scope tight.
+
+### Task 1: Landing page -- features section and comparison summary
+- **Agent**: frontend-minion
+- **Delegation type**: standard
+- **Model**: sonnet
+- **Mode**: bypassPermissions
+- **Blocked by**: none
+- **Approval gate**: yes
+- **Gate reason**: This task produces 2 new sections on the public landing page and modifies the nav. The content claims about WRL capabilities and the competitor data must be reviewed for accuracy before going live. Multiple downstream tasks (docs comparison page, SEO updates) depend on the landing page content being approved.
+- **Gate rationale**: |
+    Chosen: Features section with lightweight list (not cards) + comparison summary with 5-column table (4 competitors)
+    Over: Card-based feature grid (rejected: visual conflict with Use Cases cards above), full comparison table on landing (rejected: too dense per ux-strategy)
+    Why: Lightweight list creates visual contrast with Use Cases section. Summary table communicates core differentiation without overwhelming mobile users.
+- **Prompt**: |
+    ## Task: Add Features Section and Comparison Summary to WRL Landing Page
+
+    You are modifying the WRL landing page (`landing/public/index.html`) and its stylesheet (`landing/public/css/landing.css`). Do NOT modify `design-system.css`.
+
+    ### What to Build
+
+    **Two new sections** inserted into the existing page:
+
+    1. **Features section** ("What You Get") -- placed AFTER the Use Cases section, BEFORE How It Works
+    2. **Comparison summary** -- placed AFTER How It Works, BEFORE Pricing
+
+    Plus: **Update the header nav** to add a "Features" link.
+
+    ### Section 1: Features ("What You Get")
+
+    **Section structure:**
+    - `id="features"`, class `landing-section landing-section--muted` (alternating bg: Use Cases is white, so Features is muted)
+    - Section header: `<h2>What You Get</h2>`
+    - Content: 8 feature items in 2 groups
+
+    **Visual treatment: Lightweight list, NOT cards.** Do not use `.card` class. Use a simple grid of feature items with heading + one-line description. No borders, no box shadows, no badges as icons. This must visually contrast with the card-heavy Use Cases section above it.
+
+    **Layout:**
+    ```css
+    .features-grid {
+      display: grid;
+      gap: var(--space-6);
+    }
+
+    .feature-item h3 {
+      margin: 0 0 var(--space-1);
+      font-size: var(--text-md);
+      font-weight: var(--weight-bold);
+      color: var(--color-text);
+    }
+
+    .feature-item p {
+      margin: 0;
+      color: var(--color-text-muted);
+      font-size: var(--text-sm);
+      line-height: var(--leading-relaxed);
+    }
+
+    @media (min-width: 768px) {
+      .features-grid { grid-template-columns: repeat(2, 1fr); }
+    }
+    @media (min-width: 1024px) {
+      .features-grid { grid-template-columns: repeat(4, 1fr); }
+    }
+    ```
+
+    **Feature content (2 categories, 4 items each):**
+
+    Group label (use a `<p>` with a small, uppercase, muted style -- similar to `.pricing-section-label`):
+
+    **Evidence Integrity**
+
+    1. **Ed25519 Digital Signatures** -- Every capture is cryptographically signed. Proves who captured it and that nothing was altered.
+    2. **Independent Timestamps** -- A third-party authority records when the capture happened. No one -- not even WRL -- can backdate it.
+    3. **Public Verification** -- Share a link. Anyone can confirm authenticity -- no account, no trust required.
+    4. **eIDAS Qualified Timestamps** -- Optional EU-standard timestamps with legal presumption of accuracy across all member states.
+
+    **Developer Experience**
+
+    5. **REST API** -- One POST, one signed evidence bundle. Batch captures, webhooks, scheduled captures.
+    6. **MCP Server** -- AI agents can capture and verify web pages with cryptographic proof.
+    7. **WACZ Standard Format** -- Open archive format. Not locked to any vendor.
+    8. **Self-Hostable** -- Deploy on your infrastructure. Your keys, your storage, your evidence chain.
+
+    After the feature grid, add a link: `<p class="features-more"><a href="https://docs.webresourceledger.com/compare/">Full feature comparison across 9 tools &rarr;</a></p>` -- style this like `.use-case-cta`.
+
+    Total word count for this section should be roughly 120 words (excluding heading and link).
+
+    ### Section 2: Comparison Summary
+
+    **Section structure:**
+    - `id="compare"`, class `landing-section landing-section--white` (How It Works is muted, so Compare is white)
+    - Section header: `<h2>How WRL Compares</h2>`
+
+    **Content: A 5-column summary table.**
+
+    Use a real `<table>` element with proper semantics:
+    - `<caption class="sr-only">Comparison of WRL with other web evidence tools</caption>`
+    - `scope="col"` on all `<th>` in thead
+    - `scope="row"` on the first cell of each body row (the tool name)
+    - `data-label` attributes on every `<td>` for the mobile card-stack pattern
+
+    **Table data:**
+
+    | | Crypto Signing | Independent Timestamps | Public Verification | Open Format |
+    |---|---|---|---|---|
+    | **WRL** | Ed25519 (every capture) | RFC 3161 (default) | Yes (no account) | WACZ |
+    | **Wayback Machine** | No | No | Public access (no crypto) | WARC |
+    | **PageFreezer** | SHA-256 | Proprietary clock | No | PDF |
+    | **Webrecorder** | Spec exists (not default) | In spec (not default) | Validator tools | WACZ + WARC |
+    | **Manual + Notary** | Notary attestation | Notary timestamp | Via notary records | N/A |
+
+    Use `.badge--pass` for "Yes" / clear positive values, `.badge--fail` for "No", `.badge--skip` for partial/qualified values. **Every badge must contain visible text** (not just color). For example: `<span class="badge badge--pass">Yes (no account)</span>`, `<span class="badge badge--fail">No</span>`, `<span class="badge badge--skip">Spec exists (not default)</span>`.
+
+    The WRL row should be visually highlighted. Add a `.comparison-highlight` class to WRL's `<tr>` with `background: var(--color-surface-muted);`.
+
+    After the table: `<p class="compare-more"><a href="https://docs.webresourceledger.com/compare/">Full comparison of 9 tools across 7 criteria &rarr;</a></p>`
+
+    **Responsive: Card-stack pattern at < 768px.**
+
+    Each row becomes a stacked card. Hide `thead` with `.sr-only`. Each `td` renders its column header via `data-label` attribute and `::before` pseudo-element:
+
+    ```css
+    @media (max-width: 767px) {
+      .comparison-table thead {
+        position: absolute; width: 1px; height: 1px;
+        overflow: hidden; clip: rect(0,0,0,0);
+      }
+      .comparison-table tr {
+        display: block;
+        border: 1px solid var(--color-border);
+        border-radius: var(--radius-lg);
+        padding: var(--space-4);
+        margin-bottom: var(--space-4);
+        background: var(--color-surface);
+      }
+      .comparison-table td {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: var(--space-2) 0;
+        border-bottom: 1px solid var(--color-border-subtle);
+      }
+      .comparison-table td::before {
+        content: attr(data-label);
+        font-weight: var(--weight-medium);
+        font-size: var(--text-xs);
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        color: var(--color-text-muted);
+        flex-shrink: 0;
+        margin-right: var(--space-3);
+      }
+      .comparison-table td:last-child { border-bottom: none; }
+      .comparison-table td:first-child {
+        font-weight: var(--weight-bold);
+        font-size: var(--text-md);
+        border-bottom: 1px solid var(--color-border);
+        padding-bottom: var(--space-3);
+        margin-bottom: var(--space-2);
+      }
+      .comparison-table td:first-child::before { display: none; }
+    }
+    ```
+
+    ### Navigation Update
+
+    Update the `<nav>` in the header to add "Features" between "Use Cases" and "How It Works":
+
+    ```html
+    <a href="#use-cases">Use Cases</a>
+    <a href="#features">Features</a>
+    <a href="#how-it-works">How It Works</a>
+    <a href="#pricing">Pricing</a>
+    ```
+
+    Do NOT add "Compare" to the nav. 6 items + Sign in button is fine.
+
+    ### What NOT to Do
+
+    - Do NOT modify `design-system.css`
+    - Do NOT add JavaScript
+    - Do NOT add SVG icons or images
+    - Do NOT create a separate comparison page (that is a different task)
+    - Do NOT add more than 4 competitors to the landing summary table
+    - Do NOT add cards with borders/shadows for the feature list
+    - Do NOT add the full 7-column comparison table to the landing page
+    - Do NOT add "Compare" to the navigation
+
+    ### Files to Modify
+
+    - `landing/public/index.html` -- add the two new sections and update nav
+    - `landing/public/css/landing.css` -- add CSS for `.features-grid`, `.feature-item`, `.feature-group-label`, `.comparison-table`, `.comparison-highlight`, `.compare-more`, `.features-more`, and the mobile card-stack media query
+
+    ### Verification
+
+    - Page loads without errors
+    - Section order is: Hero > Use Cases > Features > How It Works > Compare > Pricing
+    - Features section has muted background, Compare section has white background (alternating rhythm maintained)
+    - Nav links scroll to correct sections
+    - Table is accessible: proper `<caption>`, `scope` attributes, `data-label` on all `<td>`
+    - Badges have visible text content
+    - Mobile (< 768px): features are single column, comparison table becomes card stack
+    - Tablet (768px+): features are 2-column grid
+    - Desktop (1024px+): features are 4-column grid
+- **Deliverables**: Modified `landing/public/index.html` and `landing/public/css/landing.css`
+- **Success criteria**: Two new sections visible on landing page in correct order, responsive on mobile, accessible table markup, nav updated
+
+### Task 2: Docs site -- comparison page
+- **Agent**: frontend-minion
+- **Delegation type**: standard
+- **Model**: sonnet
+- **Mode**: bypassPermissions
+- **Blocked by**: none
+- **Approval gate**: yes
+- **Gate reason**: The full comparison table has 63 data points about competitors. Factual accuracy of every cell must be verified before publishing. This is the most legally sensitive deliverable in the plan.
+- **Gate rationale**: |
+    Chosen: Single `/compare/` page as .njk file with full 7-column matrix, per-competitor notes, and methodology section
+    Over: Separate features page + comparison page (rejected: maintenance burden, table IS the feature list), Markdown file (rejected: cannot produce data-label attributes for responsive cards)
+    Why: .njk format enables proper responsive card-stack pattern. Single page keeps evaluation content unified.
+- **Prompt**: |
+    ## Task: Create Full Comparison Page on WRL Docs Site
+
+    Create a new comparison page at `site/content/compare.njk` with the complete competitor matrix, add it to the docs nav, add responsive CSS to `site/css/docs.css`, and update the `featureList` in the landing page structured data.
+
+    ### File 1: `site/content/compare.njk`
+
+    **Frontmatter:**
+    ```
+    ---
+    layout: layouts/doc.njk
+    title: How WRL Compares
+    description: Feature comparison of WRL with Wayback Machine, PageFreezer, Webrecorder, and 6 other web archiving and evidence tools. Last verified March 2026.
+    ---
+    ```
+
+    **Page structure:**
+
+    1. **H1**: "How WRL Compares"
+
+    2. **Lead paragraph** (2-3 sentences): "A factual comparison of WRL with other web archiving and evidence tools. Each cell reflects publicly documented capabilities as of March 2026. If something has changed, <a href="https://github.com/benpeter/web-resource-ledger/issues">open an issue</a>."
+
+    3. **Full comparison table** -- use a real `<table>` element (not Markdown). This is why the file must be `.njk`.
+
+    Table semantics:
+    - `<caption class="sr-only">Feature comparison of web evidence and archiving tools</caption>`
+    - `scope="col"` on all `<th>` in `<thead>`
+    - `scope="row"` on the first `<th>` in each `<tbody>` row (the tool name)
+    - `data-label` attribute on every `<td>` matching the column header text
+    - Wrap the table in `<div class="comparison-table-wrapper">`
+    - Apply class `comparison-table` to the `<table>` element
+
+    **7 columns:**
+    1. Tool (row header)
+    2. Cryptographic Signing
+    3. Independent Timestamps
+    4. Public Verification
+    5. API Access
+    6. Standard Format
+    7. eIDAS Qualified
+    8. Open Source
+
+    **10 rows (including WRL):**
+
+    Use `.badge--pass` for clear yes/positive, `.badge--fail` for clear no, `.badge--skip` for partial/qualified. **Every badge must contain visible text.**
+
+    Here is the exact cell content for each row:
+
+    **WRL:**
+    - Crypto Signing: `<span class="badge badge--pass">Ed25519 (every capture)</span>`
+    - Independent Timestamps: `<span class="badge badge--pass">RFC 3161 (DigiCert TSA)</span>`
+    - Public Verification: `<span class="badge badge--pass">Yes (no account needed)</span>`
+    - API Access: `<span class="badge badge--pass">REST API, MCP</span>`
+    - Standard Format: `<span class="badge badge--pass">WACZ</span>`
+    - eIDAS Qualified: `<span class="badge badge--pass">Optional</span>`
+    - Open Source: `<span class="badge badge--pass">Apache 2.0</span>`
+
+    **Wayback Machine:**
+    - Crypto Signing: `<span class="badge badge--fail">No</span>`
+    - Independent Timestamps: `<span class="badge badge--fail">Crawl timestamps only</span>`
+    - Public Verification: `<span class="badge badge--skip">Public access (no crypto)</span>`
+    - API Access: `<span class="badge badge--skip">Yes (rate-limited)</span>`
+    - Standard Format: `<span class="badge badge--pass">WARC</span>`
+    - eIDAS Qualified: `<span class="badge badge--fail">No</span>`
+    - Open Source: `<span class="badge badge--skip">Partial (some tools)</span>`
+
+    **PageFreezer:**
+    - Crypto Signing: `<span class="badge badge--skip">SHA-256 signing</span>`
+    - Independent Timestamps: `<span class="badge badge--skip">Stratum-1 clock (not RFC 3161)</span>`
+    - Public Verification: `<span class="badge badge--fail">No (platform-only)</span>`
+    - API Access: `<span class="badge badge--skip">Partner API</span>`
+    - Standard Format: `<span class="badge badge--fail">PDF</span>`
+    - eIDAS Qualified: `<span class="badge badge--fail">No</span>`
+    - Open Source: `<span class="badge badge--fail">No</span>`
+
+    **Hanzo:**
+    - Crypto Signing: `<span class="badge badge--skip">Not documented</span>`
+    - Independent Timestamps: `<span class="badge badge--skip">Not documented</span>`
+    - Public Verification: `<span class="badge badge--fail">No</span>`
+    - API Access: `<span class="badge badge--fail">No</span>`
+    - Standard Format: `<span class="badge badge--pass">WARC</span>`
+    - eIDAS Qualified: `<span class="badge badge--fail">No</span>`
+    - Open Source: `<span class="badge badge--fail">No</span>`
+
+    **Page Vault:**
+    - Crypto Signing: `<span class="badge badge--skip">SHA-256 hashing</span>`
+    - Independent Timestamps: `<span class="badge badge--skip">Internal timestamps</span>`
+    - Public Verification: `<span class="badge badge--skip">Expert witness service</span>`
+    - API Access: `<span class="badge badge--fail">No</span>`
+    - Standard Format: `<span class="badge badge--fail">Proprietary / PDF</span>`
+    - eIDAS Qualified: `<span class="badge badge--fail">No</span>`
+    - Open Source: `<span class="badge badge--fail">No</span>`
+
+    **MirrorWeb:**
+    - Crypto Signing: `<span class="badge badge--skip">SHA-1 per docs</span>`
+    - Independent Timestamps: `<span class="badge badge--skip">Timestamped (not RFC 3161)</span>`
+    - Public Verification: `<span class="badge badge--fail">No (platform-only)</span>`
+    - API Access: `<span class="badge badge--skip">Limited API</span>`
+    - Standard Format: `<span class="badge badge--pass">WARC</span>`
+    - eIDAS Qualified: `<span class="badge badge--fail">No</span>`
+    - Open Source: `<span class="badge badge--fail">No</span>`
+
+    **Stillio:**
+    - Crypto Signing: `<span class="badge badge--fail">No</span>`
+    - Independent Timestamps: `<span class="badge badge--fail">Metadata only</span>`
+    - Public Verification: `<span class="badge badge--fail">No</span>`
+    - API Access: `<span class="badge badge--skip">Basic API</span>`
+    - Standard Format: `<span class="badge badge--fail">PNG / JPEG</span>`
+    - eIDAS Qualified: `<span class="badge badge--fail">No</span>`
+    - Open Source: `<span class="badge badge--fail">No</span>`
+
+    **Archive-It:**
+    - Crypto Signing: `<span class="badge badge--fail">Checksums only</span>`
+    - Independent Timestamps: `<span class="badge badge--fail">Crawl timestamps</span>`
+    - Public Verification: `<span class="badge badge--skip">Public access (no crypto)</span>`
+    - API Access: `<span class="badge badge--pass">Yes (WASAPI)</span>`
+    - Standard Format: `<span class="badge badge--pass">WARC</span>`
+    - eIDAS Qualified: `<span class="badge badge--fail">No</span>`
+    - Open Source: `<span class="badge badge--fail">No</span>`
+
+    **Webrecorder:**
+    - Crypto Signing: `<span class="badge badge--skip">WACZ-Auth spec (not default)</span>`
+    - Independent Timestamps: `<span class="badge badge--skip">RFC 3161 in spec (not default)</span>`
+    - Public Verification: `<span class="badge badge--skip">Validator tools exist</span>`
+    - API Access: `<span class="badge badge--pass">Browsertrix API</span>`
+    - Standard Format: `<span class="badge badge--pass">WACZ + WARC</span>`
+    - eIDAS Qualified: `<span class="badge badge--fail">No</span>`
+    - Open Source: `<span class="badge badge--pass">Yes</span>`
+
+    **Manual Screenshots + Notarization:**
+    - Crypto Signing: `<span class="badge badge--skip">Notary attestation</span>`
+    - Independent Timestamps: `<span class="badge badge--skip">Notary timestamp</span>`
+    - Public Verification: `<span class="badge badge--skip">Via notary records</span>`
+    - API Access: `<span class="badge badge--fail">No</span>`
+    - Standard Format: `<span class="badge badge--fail">N/A</span>`
+    - eIDAS Qualified: `<span class="badge badge--skip">Separate framework</span>`
+    - Open Source: `<span class="badge badge--fail">N/A</span>`
+
+    Highlight the WRL row with class `comparison-highlight` on the `<tr>`.
+
+    4. **Notes section** -- H2 "Notes", then one H3 per competitor with 3-5 sentences of nuance. Include these specific notes:
+
+    **Wayback Machine**: Massive scale (850B+ pages archived) and institutional credibility accepted by some courts. Captures have no cryptographic signatures -- integrity relies on trust in the Internet Archive as an institution. Rate-limited public API (15 req/min). The de facto reference for "what did this page look like" but not designed as an evidence tool.
+
+    **PageFreezer**: Enterprise-grade compliance platform (FedRAMP authorized, SOC 2). SHA-256 digital signatures with their own timestamping infrastructure (Stratum-1 atomic clock, ESIGN Act compliant). Timestamps are not from an independent third-party TSA per RFC 3161. Strong in social media archiving (Teams, Workplace) which WRL does not offer. Verification is internal to their platform.
+
+    **Hanzo**: Focused on dynamic content capture (SPAs, interactive elements) and eDiscovery workflows. SOC 2 Type 2 certified. No public API (confirmed by multiple review sources). Integrity approach is proprietary and not publicly documented. Note: Hanzo (hanzo.co) the web archiving company is distinct from Hanzo AI (hanzo.ai).
+
+    **Page Vault**: Purpose-built for US litigation. Provides expert witness testimony and affidavit services for court admissibility under FRE 901(b)(9) and FRE 902(13)/902(14). SHA-256 hashing with internal timestamps. No API -- browser extension and managed capture service. WRL provides machine-verifiable proof; Page Vault provides human-verifiable expert testimony.
+
+    **MirrorWeb**: Financial services compliance focus (SEC 17a-4, FINRA 2210, FCA COBS 4). Documentation references SHA-1 digital signatures, though this may have been updated (SHA-1 is cryptographically deprecated). SOC 2 certified. Multi-channel archiving including social media and SMS.
+
+    **Stillio**: Screenshot scheduling service, not an evidence tool. No integrity proofs, no cryptographic signing. Useful for visual monitoring and brand tracking. Starting at $29/month. Including Stillio illustrates the gap between screenshot services and evidence services.
+
+    **Archive-It**: Internet Archive's subscription archiving service for institutions. WARC format with MD5 and SHA-1 checksums via WASAPI (data integrity, not cryptographic authenticity). Strong in academic, government, and cultural heritage sectors. Public access to archives but no cryptographic verification.
+
+    **Webrecorder**: Created the WACZ format and authored the WACZ-Auth specification that defines signing for WACZ files. WRL implements signing as a default on every capture; Webrecorder provides the specification and tooling. Browsertrix (hosted service) does not appear to sign WACZ files by default. Open source, self-hostable via Kubernetes. Different primary use case: site-wide preservation vs. WRL's point-in-time evidence.
+
+    **Manual Screenshots + Notarization**: Legally established with centuries of precedent. Entirely manual, no automation possible. Notary attestation is broadly accepted by courts. Cost scales linearly with volume. WRL is faster, scalable, and cheaper but has less legal track record.
+
+    5. **Methodology section** -- H2 "Methodology". Text: "All claims are based on publicly available documentation, product pages, and review platforms as of March 2026. Where a capability could not be confirmed from public sources, the cell reads 'Not documented' rather than 'No'. We do not have accounts with every listed service -- claims reflect what each service publicly represents, not hands-on testing of every feature. If any information is outdated or incorrect, please <a href='https://github.com/benpeter/web-resource-ledger/issues/new'>open an issue</a>."
+
+    ### File 2: `site/_data/site.js`
+
+    Add the comparison page to the nav array at position 11 (after Architecture, before Security & Compliance):
+
+    ```js
+    { title: "Architecture", url: "/architecture/" },
+    { title: "Compare", url: "/compare/" },
+    // Security & Compliance
+    { title: "Security & Compliance", url: "/security/" },
+    ```
+
+    ### File 3: `site/css/docs.css`
+
+    Add these styles at the end of the file:
+
+    **Breakout wrapper** for the wide comparison table:
+    ```css
+    /* ------------------------------------------------------------------ */
+    /* Comparison table                                                     */
+    /* ------------------------------------------------------------------ */
+
+    .comparison-table-wrapper {
+      overflow-x: auto;
+      margin: var(--space-6) calc(-1 * var(--space-6));
+      padding: 0 var(--space-6);
+    }
+
+    .comparison-table {
+      width: 100%;
+      min-width: 800px;
+      border-collapse: collapse;
+    }
+
+    .comparison-table th {
+      background: var(--color-surface-muted);
+      font-weight: var(--weight-medium);
+      font-size: var(--text-xs);
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      padding: var(--space-2) var(--space-3);
+      text-align: left;
+      border-bottom: 1px solid var(--color-border);
+      white-space: nowrap;
+    }
+
+    .comparison-table td {
+      padding: var(--space-3);
+      border-bottom: 1px solid var(--color-border-subtle);
+      vertical-align: middle;
+      font-size: var(--text-sm);
+    }
+
+    .comparison-table th[scope="row"] {
+      font-weight: var(--weight-bold);
+      white-space: nowrap;
+    }
+
+    .comparison-highlight {
+      background: var(--color-surface-muted);
+    }
+
+    .comparison-highlight td {
+      font-weight: var(--weight-medium);
+    }
+    ```
+
+    **Mobile card-stack** (same pattern as landing, scoped to docs):
+    ```css
+    @media (max-width: 767px) {
+      .comparison-table-wrapper {
+        margin: var(--space-6) 0;
+        padding: 0;
+        overflow-x: visible;
+      }
+
+      .comparison-table {
+        min-width: 0;
+      }
+
+      .comparison-table thead {
+        position: absolute; width: 1px; height: 1px;
+        overflow: hidden; clip: rect(0,0,0,0);
+      }
+
+      .comparison-table tbody { display: block; }
+
+      .comparison-table tr {
+        display: block;
+        border: 1px solid var(--color-border);
+        border-radius: var(--radius-lg);
+        padding: var(--space-4);
+        margin-bottom: var(--space-4);
+        background: var(--color-surface);
+      }
+
+      .comparison-table td {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: var(--space-2) 0;
+        border-bottom: 1px solid var(--color-border-subtle);
+      }
+
+      .comparison-table td::before {
+        content: attr(data-label);
+        font-weight: var(--weight-medium);
+        font-size: var(--text-xs);
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        color: var(--color-text-muted-docs);
+        flex-shrink: 0;
+        margin-right: var(--space-3);
+      }
+
+      .comparison-table td:last-child { border-bottom: none; }
+
+      .comparison-table td:first-child {
+        font-weight: var(--weight-bold);
+        font-size: var(--text-md);
+        border-bottom: 1px solid var(--color-border);
+        padding-bottom: var(--space-3);
+        margin-bottom: var(--space-2);
+      }
+
+      .comparison-table td:first-child::before { display: none; }
+    }
+    ```
+
+    ### File 4: `landing/public/index.html` -- structured data update
+
+    Update the `featureList` array in the SoftwareApplication JSON-LD (around line 59) to:
+
+    ```json
+    "featureList": [
+      "Ed25519 digital signatures",
+      "RFC 3161 timestamps",
+      "WACZ evidence bundles",
+      "Public verification URLs",
+      "REST API and MCP server",
+      "Cookie consent dismissal",
+      "eIDAS-qualified timestamps (optional)",
+      "FRE 901/902 evidence authentication support",
+      "Batch capture API",
+      "Webhook notifications",
+      "Screenshot and rendered HTML capture",
+      "HTTP header recording",
+      "Self-hostable (Apache 2.0)"
+    ]
+    ```
+
+    Also add to the SoftwareApplication schema, after `isAccessibleForFree`:
+    ```json
+    "applicationSubCategory": "Web Evidence",
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "EUR",
+      "description": "Free tier: 200 captures/month"
+    }
+    ```
+
+    ### What NOT to Do
+
+    - Do NOT add canonical tags, OG tags, or BreadcrumbList to the docs site template (out of scope, deferred)
+    - Do NOT add TechArticle structured data to the compare page (deferred)
+    - Do NOT create a separate features page on the docs site
+    - Do NOT modify `design-system.css`
+    - Do NOT add JavaScript
+    - Do NOT include pricing in the comparison table
+    - Do NOT include screenshots of competitor UIs
+    - Do NOT use subjective language ("better", "best", "superior")
+
+    ### Verification
+
+    - `compare.njk` renders correctly in Eleventy (`cd site && npx @11ty/eleventy --serve`)
+    - Compare page appears in docs sidebar nav between Architecture and Security & Compliance
+    - Table is accessible: proper `<caption>`, `scope` attributes, `data-label` on all `<td>`
+    - Badges have visible text content
+    - Mobile card-stack works (test at 375px viewport)
+    - Desktop table scrolls horizontally if needed
+    - All competitor names link to their websites in the notes section
+    - Methodology section includes the "last verified" date and issue link
+    - `featureList` in landing page structured data is updated
+- **Deliverables**: `site/content/compare.njk`, modified `site/_data/site.js`, modified `site/css/docs.css`, modified `landing/public/index.html` (structured data only)
+- **Success criteria**: Full comparison page with 10 rows x 8 columns, responsive card-stack on mobile, per-competitor notes, methodology section, nav entry added
+
+### Task 3: Evolution log
+- **Agent**: software-docs-minion
+- **Delegation type**: standard
+- **Model**: sonnet
+- **Mode**: default
+- **Blocked by**: Task 1, Task 2
+- **Approval gate**: no
+- **Prompt**: |
+    ## Task: Create Evolution Log Entry for Feature List and Comparison Table
+
+    Create the evolution log directory and files for this phase. Determine the next sequence number by looking at existing directories in `docs/evolution/`.
+
+    ### Files to Create
+
+    **`docs/evolution/NNNN-feature-comparison/prompt.md`**:
+    Document that this phase implements GitHub issue #144: "Feature list and competitor comparison table for WRL landing page and docs site."
+
+    **`docs/evolution/NNNN-feature-comparison/decisions.md`**:
+    Key decisions:
+    1. Feature list uses lightweight list pattern (not cards) to contrast with Use Cases section
+    2. Landing comparison shows 4 competitors x 4 feature columns (summary), docs shows 9 competitors x 7 columns (full)
+    3. Docs comparison page is `.njk` not `.md` because responsive card-stack requires `data-label` attributes
+    4. Single `/compare/` page on docs (no separate features page) -- the table IS the feature list
+    5. "Features" added to landing nav, "Compare" not added (keeps nav to 6 items)
+    6. Docs SEO infrastructure improvements deferred (out of scope for this task)
+    7. Competitor data verified from public sources only, with methodology disclosure and "last verified" date
+
+    **`docs/evolution/NNNN-feature-comparison/outcome.md`**:
+    Write after reviewing what was actually built. Summarize:
+    - What was added to the landing page (2 sections, nav update, structured data)
+    - What was added to the docs site (compare page, nav entry, CSS)
+    - Backlog items created (docs site SEO infrastructure)
+
+    **Update `docs/evolution/README.md`**: Add the new entry.
+
+    **Update `docs/backlog.md`**: Add a deferred item for docs site SEO infrastructure (canonical tags, OG tags, BreadcrumbList structured data, TechArticle schema). Reference seo-minion's recommendations from this phase.
+
+    ### What NOT to Do
+    - Do NOT modify any source code files
+    - Do NOT create process.md (that is written by the orchestrator after PR creation)
+- **Deliverables**: Evolution log directory with prompt.md, decisions.md, outcome.md; updated README.md and backlog.md
+- **Success criteria**: Complete evolution log entry following the project's established pattern
+
+### Cross-Cutting Coverage
+
+- **Testing**: No dedicated test task. The deliverables are static HTML/CSS pages. Visual verification is sufficient per project rules ("For UI-only changes, visual verification is sufficient"). Phase 6 will run lint/build checks.
+- **Security**: No security concerns. Static content pages with no user input, no auth, no API surface. Competitor claims are the reputational risk, mitigated by methodology disclosure and "last verified" date.
+- **Usability -- Strategy**: Covered by incorporating ux-strategy-minion's recommendations directly into Task 1 prompt: section ordering, word budget (~200 words), progressive disclosure (summary on landing, full on docs), nav item selection.
+- **Usability -- Design**: No separate design task. ux-strategy-minion's visual treatment recommendations (lightweight list, no cards for features; card-stack for mobile tables) are incorporated into Task 1 and Task 2 prompts. accessibility-minion concerns are addressed via table semantics (caption, scope, data-label, visible badge text).
+- **Documentation**: Covered by Task 3 (evolution log). The comparison page itself IS documentation. software-docs-minion's recommendations on structure and nav placement are incorporated into Task 2.
+- **Observability**: Not applicable. Static content pages, no runtime components.
+
+### Architecture Review Agents
+
+- **Mandatory** (5): security-minion, test-minion, ux-strategy-minion, lucy, margo
+- **Discretionary picks**:
+  - accessibility-minion: Both tasks produce HTML tables that end users interact with. The mobile card-stack pattern with visually-hidden thead needs review for screen reader compatibility.
+    Review focus: Table semantics, badge text content, card-stack pattern a11y, color independence.
+  - seo-minion: Landing page structured data is being modified and a new public-facing page is created.
+    Review focus: featureList accuracy, canonical handling between landing and docs, meta description quality.
+- **Not selected**:
+  - ux-design-minion: The visual treatment follows existing design-system.css patterns with no new components. ux-strategy-minion's guidance on lightweight list vs. cards is sufficient.
+  - sitespeed-minion: Static HTML/CSS additions with no new assets, scripts, or runtime components. No performance budget impact.
+  - observability-minion: No runtime components.
+  - user-docs-minion: The comparison page itself is the user-facing documentation. software-docs-minion's structure recommendations are incorporated.
+
+### Decisions
+
+- **Feature list visual treatment**
+  Chosen: Lightweight grid items (heading + description, no borders)
+  Over: Card-based grid with `.card` class and badge icons (frontend-minion's recommendation)
+  Why: ux-strategy-minion correctly identified that the page already uses cards heavily in Use Cases. Using cards again creates "card fatigue" and no visual contrast between sections. The lightweight treatment lets the content breathe.
+
+- **Docs page format**
+  Chosen: Nunjucks template (`.njk`)
+  Over: Markdown (`.md`) per software-docs-minion
+  Why: The mobile responsive card-stack pattern requires `data-label` attributes on `<td>` elements. Markdown tables cannot produce custom HTML attributes. The `api-reference.njk` precedent confirms `.njk` is an established pattern for structured content in this docs site.
+
+- **No separate features page on docs**
+  Chosen: Single `/compare/` page serves both features and comparison
+  Over: Separate `/features/` + `/compare/` pages (product-marketing-minion's implicit structure)
+  Why: software-docs-minion's argument is compelling: the comparison table already implies feature coverage. A separate features page would duplicate information and create a maintenance burden with no clear user benefit.
+
+- **Docs SEO infrastructure deferred**
+  Chosen: Defer canonical tags, OG tags, BreadcrumbList, TechArticle schema to a separate task
+  Over: Including template-level docs site SEO fixes in this task (seo-minion's recommendation)
+  Why: Issue #144 scope is feature list + comparison table. Template-level SEO changes affect all 15+ docs pages and deserve their own review cycle. The self-referencing canonical on the compare page alone would be inconsistent if no other docs page has one. Better to do it properly in a dedicated task.
+
+- **Landing comparison competitor selection**
+  Chosen: Wayback Machine, PageFreezer, Webrecorder, Manual + Notary (4 competitors)
+  Over: Including all 9 competitors on landing (rejected: too dense for landing page)
+  Why: These 4 maximize recognition (Wayback), enterprise credibility (PageFreezer), technical respect (Webrecorder), and common practice (Manual). Each illustrates a different dimension of WRL's advantage.
+
+### Risks and Mitigations
+
+1. **Competitor accuracy** (HIGH risk): Every claim is verifiable by competitors, customers, and journalists. One factual error undermines the entire comparison.
+   - Mitigation: Methodology section with "last verified" date and issue link. Use "Not documented" rather than "No" when uncertain. product-marketing-minion flagged specific uncertainties (PageFreezer signing algorithm, MirrorWeb SHA-1 status, Webrecorder default signing) -- all are reflected with qualified language in the table cells.
+
+2. **Staleness** (MEDIUM risk): 63 data points that can go stale within months.
+   - Mitigation: Visible "last verified" date. Invitation to report inaccuracies via GitHub issues. Backlog item for quarterly review.
+
+3. **Webrecorder relationship** (MEDIUM risk): WRL implements a specification that Webrecorder authored. The web archiving community will scrutinize how WRL positions itself relative to Webrecorder.
+   - Mitigation: The notes section explicitly acknowledges Webrecorder's authorship of the WACZ-Auth spec. The table says "WACZ-Auth spec (not default)" rather than implying Webrecorder lacks the capability.
+
+4. **Word budget on landing** (LOW risk): Adding 2 sections risks making the page too long.
+   - Mitigation: Feature list is ~120 words, comparison summary is ~80 words. Combined ~200 words is within ux-strategy's budget. Both sections link to docs for full content.
+
+### Execution Order
+
+```
+Batch 1 (parallel):
+  Task 1: Landing page features + comparison (frontend-minion)
+  Task 2: Docs site comparison page (frontend-minion)
+
+  [GATE: Review Task 1 -- landing page content and layout]
+  [GATE: Review Task 2 -- docs comparison data accuracy]
+
+Batch 2 (sequential, after both gates approved):
+  Task 3: Evolution log (software-docs-minion)
+```
+
+### Verification Steps
+
+After all tasks complete:
+1. Landing page loads without errors, sections appear in correct order
+2. Nav scrolls to correct sections (Features, not Compare in nav)
+3. Landing comparison table is responsive (card-stack at mobile)
+4. Docs comparison page renders in Eleventy
+5. Docs sidebar shows "Compare" between Architecture and Security & Compliance
+6. Docs comparison table is responsive (card-stack at mobile)
+7. All badge elements contain visible text
+8. Structured data validates (test with Google's Rich Results Test)
+9. Cross-links work: landing "Full comparison" links to docs, docs "last verified" date is present
+10. Evolution log entry exists with correct structure

--- a/docs/history/nefario-reports/2026-03-26-044407-feature-list-competitor-comparison/phase3.5-accessibility-minion.md
+++ b/docs/history/nefario-reports/2026-03-26-044407-feature-list-competitor-comparison/phase3.5-accessibility-minion.md
@@ -1,0 +1,115 @@
+# Accessibility Review — Feature List and Competitor Comparison Table
+
+**Verdict: ADVISE**
+
+The plan is structurally sound and demonstrates genuine accessibility awareness. The table semantics, badge text-content requirement, and caption/scope specifications are all correct. Three issues need to be addressed at implementation time, none severe enough to block the delegation, but one is a WCAG 2.2 Level A violation that must not ship as-is.
+
+---
+
+## What the Plan Gets Right
+
+- `<caption class="sr-only">` on both tables — correct pattern, accessible name for the table object
+- `scope="col"` on `<thead>` cells and `scope="row"` on the first cell of each body row — correct for a simple grid table
+- Badge requirement: "Every badge must contain visible text" — this is the right call; no color-only pass/fail information
+- `data-label` on `<td>` elements for mobile card-stack — correct approach for responsive tables without destroying screen reader semantics
+- No JavaScript dependency — static HTML/CSS reduces interaction complexity and focus management concerns
+- Section landmark structure: the two new sections both have `id` attributes and live inside the existing `<main>` — no landmark violations expected
+
+---
+
+## Issues
+
+### 1. Mobile card-stack: `<thead>` is visually hidden but remains in the accessibility tree (WCAG 2.2 SC 1.3.1, Level A — must fix)
+
+The plan instructs:
+
+```css
+.comparison-table thead {
+  position: absolute; width: 1px; height: 1px;
+  overflow: hidden; clip: rect(0,0,0,0);
+}
+```
+
+This is the `.sr-only` / clip pattern. It hides content visually but keeps it in the accessibility tree, which is the correct intent for truly screen-reader-only content. However, the table structure changes at mobile: `tr` and `td` are set to `display: block`, which breaks the implicit table role mappings. NVDA and JAWS both lose table semantics when `display: block` is applied to table elements without explicit ARIA roles. The result is that on mobile, screen readers may announce the thead cells as plain text before the "card" content — creating duplicate, confusing announcements (column headers read by thead AND repeated by `data-label` via `::before`).
+
+**Required fix**: Add `role="presentation"` to the `<table>` element only within the mobile context — or, more practically, add `aria-hidden="true"` to `<thead>` at mobile breakpoints. Since CSS cannot set ARIA attributes, the cleanest cross-browser solution is to use `aria-hidden="true"` on the `<thead>` unconditionally (not just at mobile), since its content is already communicated to screen readers via `scope="col"` on the column header cells in `<tbody>` rows and via `data-label` attributes. The `<caption>` names the table; the `scope` attributes on `<th scope="row">` cells identify the row. The column headers in `<thead>` become redundant for screen readers once `data-label` carries the same information.
+
+**Concrete instruction to add to the Task 1 and Task 2 prompts**:
+
+```html
+<thead aria-hidden="true">
+  <tr>
+    <th scope="col">Tool</th>
+    ...
+  </tr>
+</thead>
+```
+
+This removes the thead from the accessibility tree entirely. Screen readers navigate by the `scope="row"` row headers and the `data-label`-backed `::before` text, which is sufficient. The `<caption>` still names the table. This pattern is well-established for responsive card-stack tables and avoids the duplicate-announcement problem at all viewport sizes without requiring JavaScript.
+
+Note: `aria-hidden` on `<thead>` is safe here because none of the `<th scope="col">` cells in thead are the source of an `aria-labelledby` reference on any other element. The information they carry is duplicated in `data-label`.
+
+### 2. Docs table: row header cells are specified as `<td>` not `<th>` (WCAG 2.2 SC 1.3.1, Level A — must fix)
+
+Task 2 specifies `scope="row"` on the first cell of each tbody row. The CSS rule references `th[scope="row"]`:
+
+```css
+.comparison-table th[scope="row"] {
+  font-weight: var(--weight-bold);
+  white-space: nowrap;
+}
+```
+
+This is correct — row headers should be `<th scope="row">`, not `<td>`. However, the plan's badge cell content examples all use `<td>` format, and no explicit markup example is given for the row header cell itself. If frontend-minion treats the first column as `<td scope="row">` (which some developers do by habit), the `scope` attribute on a `<td>` element has no semantic effect — `scope` is only valid on `<th>` elements. Screen readers would then announce the row without a row header.
+
+**Required fix**: The prompts for Task 1 and Task 2 must include an explicit markup example of the first column cell:
+
+```html
+<th scope="row">WRL</th>
+```
+
+Not:
+
+```html
+<td scope="row">WRL</td>
+```
+
+This is a one-word difference in the spec but a critical semantic one.
+
+### 3. Landing page `<td>` first-child styling hides the tool name label via `::before { display: none }` — acceptable but verify against `.sr-only` thead (informational)
+
+The mobile CSS suppresses the `::before` label on `td:first-child` (the tool name cell) with `display: none`. This is intentional — the tool name itself is the card heading and no column label is needed. Since `::before` is CSS-generated content, `display: none` correctly removes it from both visual and accessibility trees. No issue here, but worth noting for implementer clarity: the tool name cell does not announce a column label; it announces the tool name, which is its own `th scope="row"` value and visually bold. This is correct behavior.
+
+---
+
+## Focus Management
+
+No interactive elements beyond links. The new sections add anchor links (`href="#features"`, `href="#compare"`) and two outbound links to the docs site. These are standard `<a>` elements with descriptive text ("Full feature comparison across 9 tools →" and "Full comparison of 9 tools across 7 criteria →"). Both links have visible, non-color-dependent text. No focus management concerns.
+
+The `→` character (right arrow, U+2192) in the link text will be announced by screen readers. NVDA + Firefox announces it as "right arrow"; JAWS omits it. This is acceptable — the surrounding text is sufficient without the arrow character. Not blocking.
+
+---
+
+## Landmark Structure
+
+The two new sections do not introduce landmark violations. Both sections are `<section>` elements with `id` attributes inside the existing `<main>`. If the sections use `<section>` without an accessible name (no `aria-labelledby` or `aria-label`), they will not be exposed as named landmark regions — but unnamed `<section>` elements fall back to generic region and do not pollute the landmark list. This is fine for these content sections. The existing page structure already handles the `<main>` landmark.
+
+---
+
+## WCAG 2.2 New Criteria Check
+
+- **2.4.11 Focus Not Obscured / 2.4.13 Focus Appearance**: No sticky headers or overlapping elements introduced. The site header appears to be a normal flow header. No sticky positioning in the new sections. No focus appearance concerns.
+- **2.5.8 Target Size (Minimum)**: All interactive elements are links with text content. Text links are exempt from 2.5.8 per the WCAG 2.2 exception for inline text links. No icon-only buttons.
+- **3.3.7 Redundant Entry**: Not applicable — no forms in scope.
+- **3.3.8 Accessible Authentication**: Not applicable.
+
+---
+
+## Summary for Frontend-Minion
+
+Two required changes before these tasks ship:
+
+1. Add `aria-hidden="true"` to `<thead>` on both tables (landing and docs). This eliminates duplicate column-header announcements in the mobile card-stack pattern.
+2. Mark the row header cell as `<th scope="row">Tool Name</th>`, not `<td scope="row">`. The CSS selector `th[scope="row"]` in the plan already anticipates this — just make the element type match.
+
+Both changes are single-attribute/element-type corrections. No structural rework required.

--- a/docs/history/nefario-reports/2026-03-26-044407-feature-list-competitor-comparison/phase3.5-lucy.md
+++ b/docs/history/nefario-reports/2026-03-26-044407-feature-list-competitor-comparison/phase3.5-lucy.md
@@ -1,0 +1,81 @@
+# Lucy Review: Feature List and Competitor Comparison
+
+## Verdict: ADVISE
+
+The plan is well-structured, traceable to issue #144, and respects project conventions. Three issues need correction before execution; none are blocking individually, but uncorrected they will produce visible bugs or requirement gaps.
+
+---
+
+## Findings
+
+### 1. [DRIFT] Missing feature items from success criteria
+
+**Requirement** (prompt.md line 6-7): The feature list must include "capture", "scheduled captures", "CLI verification tool", and "webhooks" -- all explicitly named in the success criteria. The prompt also says the developer subsection should include "links to relevant docs pages."
+
+**Plan** (Task 1, lines 96-108): The 8 features listed are Ed25519 Signatures, Independent Timestamps, Public Verification, eIDAS Timestamps, REST API, MCP Server, WACZ Format, Self-Hostable. Missing from explicit feature items:
+- **"capture"** as a core capability (arguably implicit, but it is the product's primary function)
+- **"scheduled captures"** -- named in success criteria, only mentioned parenthetically inside REST API description ("Batch captures, webhooks, scheduled captures")
+- **"CLI verification tool"** -- explicitly required in the developer benefits, not present
+- **webhooks** -- explicitly required in the developer benefits, only mentioned parenthetically
+
+The prompt says "links to relevant docs pages" for the developer subsection. The plan includes one link to the compare page but no links from individual feature items to their respective docs pages (e.g., MCP Server -> `/mcp/`, Webhooks -> `/webhooks/`).
+
+**Fix**: Either add CLI verification tool and webhooks as standalone feature items (replacing or supplementing existing ones), or restructure so all success-criteria items are visibly addressed. Add doc page links to developer feature items.
+
+### 2. [CONVENTION] Background alternation broken by section insertion
+
+**Current landing page sections**: Use Cases (`--white`) -> How It Works (`--muted`) -> Pricing (`--white`).
+
+**Proposed order** (Task 1, lines 57 and 117): Use Cases (`--white`) -> Features (`--muted`) -> How It Works (`--muted`) -> Compare (`--white`) -> Pricing (`--white`).
+
+This creates two consecutive `--muted` sections (Features + How It Works) and two consecutive `--white` sections (Compare + Pricing). The plan itself says "alternating bg" at line 57 but the specified classes do not achieve alternation.
+
+**Fix**: Flip the backgrounds. Features should be `--muted`, How It Works flipped to `--white`, Compare to `--muted`, Pricing stays `--white`. Or swap the Compare section background to `--muted`. The point is: verify the full sequence produces actual alternation and update the Task 1 prompt accordingly.
+
+### 3. [SCOPE] Docs comparison table column count mismatch
+
+**Plan heading** (Task 2, line 278): "7 columns". **Actual enumeration** (lines 279-287): 8 items listed (Tool, Cryptographic Signing, Independent Timestamps, Public Verification, API Access, Standard Format, eIDAS Qualified, Open Source). The success criteria (line 592) also says "8 columns."
+
+This is a labeling error in the prompt text that will confuse the executing agent.
+
+**Fix**: Change "7 columns" to "8 columns" at line 278.
+
+---
+
+## Traceability Check
+
+| Requirement (from prompt.md) | Plan Element | Status |
+|---|---|---|
+| Feature list on landing (capture, signing, timestamps, verification, WACZ, MCP, scheduled captures) | Task 1: 8 features | PARTIAL -- "scheduled captures" buried in sub-text, "capture" implicit |
+| Developer benefits (REST API, MCP, Ed25519, WACZ, CLI verification tool, webhooks) with doc links | Task 1: features grid | GAP -- CLI verification tool missing, webhooks not standalone, no doc links |
+| Comparison table covers 9+ competitors | Task 2: 9 competitors + Manual | PASS |
+| Table columns (integrity, signing, timestamps, verification, API, format, eIDAS) | Task 2: 8 columns | PASS (exceeds: adds Open Source) |
+| Factual accuracy (no strawmanning) | Task 2: methodology section, qualified language | PASS |
+| Mobile responsive | Task 1 + Task 2: card-stack pattern | PASS |
+| Landing summary + docs full version + cross-links | Task 1 + Task 2: links between pages | PASS |
+| Pure HTML + CSS, no JS | Task 1 + Task 2: explicitly prohibited | PASS |
+| Match design-system.css | Task 1 + Task 2: uses design system vars, does not modify design-system.css | PASS |
+| Evolution log | Task 3 | PASS |
+
+## Scope Check
+
+No YAGNI violations detected. The plan appropriately defers docs SEO infrastructure, avoids separate features page on docs, and limits landing comparison to 4 competitors. The structured data additions (featureList update, applicationSubCategory, offers) in Task 2 are a minor scope expansion but directly serve the discoverability goal of the issue. The "Open Source" column is not in the original success criteria columns but is a reasonable addition given the competitive landscape (Webrecorder's open-source nature is a key differentiator).
+
+## CLAUDE.md Compliance
+
+- Evolution log: PASS (Task 3 follows the required structure)
+- No JS frameworks: PASS
+- YAGNI: PASS
+- KISS: PASS (lightweight patterns chosen over complex ones)
+- Fail loudly: N/A (no runtime code)
+- design-system.css not modified: PASS (explicitly prohibited in both task prompts)
+- `.njk` precedent exists: PASS (`api-reference.njk` confirms the pattern)
+
+## Summary
+
+Three issues to fix before delegating:
+1. Add CLI verification tool and webhooks as visible feature items; add doc page links to developer features
+2. Fix the background alternation sequence across all 5 sections
+3. Correct "7 columns" to "8 columns" in Task 2 prompt
+
+None of these require re-architecture. They are prompt corrections that take minutes.

--- a/docs/history/nefario-reports/2026-03-26-044407-feature-list-competitor-comparison/phase3.5-margo.md
+++ b/docs/history/nefario-reports/2026-03-26-044407-feature-list-competitor-comparison/phase3.5-margo.md
@@ -1,0 +1,35 @@
+# Margo Review: Feature List and Competitor Comparison
+
+## Verdict: ADVISE
+
+The plan is well-scoped for what it delivers. Two HTML/CSS sections on the landing page, one new page on the docs site, one evolution log entry -- three tasks, proportional to the work. No frameworks, no JavaScript, no new dependencies. The conflict resolutions are sound (lightweight list over cards, single compare page over separate features + compare, deferred SEO infrastructure). Good discipline shown throughout.
+
+Three items to watch:
+
+### 1. Card-stack CSS is duplicated across landing.css and docs.css
+
+The mobile card-stack pattern (lines 148-188 in Task 1, lines 476-533 in Task 2) is ~40 lines of nearly identical CSS written twice. This is accidental complexity from the separation of landing.css and docs.css.
+
+**Simpler alternative**: Extract the card-stack pattern into a shared `.comparison-table` block in `design-system.css`, or accept the duplication consciously and add a comment like `/* Duplicated in docs.css -- sync changes */` in both files. The plan says "do NOT modify design-system.css" which is fine -- but then acknowledge the duplication with a sync comment so the next person does not drift them apart.
+
+**Severity**: Non-blocking. 40 lines of CSS duplication across two files is manageable. Just make it visible.
+
+### 2. The .njk justification is thin -- check whether Eleventy Markdown can produce data-label attributes
+
+The plan says `.njk` is required because "Markdown tables cannot produce custom HTML attributes." This is true for pure Markdown, but Eleventy processes Markdown files through Nunjucks by default, and raw HTML inside `.md` files passes through unchanged. The comparison table is hand-written HTML (not generated from Markdown table syntax), so it could live in a `.md` file with an HTML block just as easily.
+
+**Why it matters**: `.md` files are the docs site's convention. Using `.njk` for one page is a precedent. If the HTML-in-Markdown approach works (it should -- `api-reference.njk` exists as precedent for `.njk`, but so does every other page as precedent for `.md`), the simpler choice is to stay with the convention.
+
+**Severity**: Non-blocking. Either format works. The `.njk` choice is defensible given `api-reference.njk` precedent. Just noting that the stated reason ("Markdown cannot produce data-label") does not hold when the table is raw HTML inside the Markdown file.
+
+### 3. Structured data additions in Task 2 touch a Task 1 file
+
+Task 2 modifies `landing/public/index.html` (structured data update to `featureList` and adding `applicationSubCategory` + `offers`). Task 1 also modifies `landing/public/index.html` (adding sections and nav). These run in parallel. This creates a merge conflict risk.
+
+**Simpler alternative**: Move the structured data update into Task 1's prompt since it is already modifying that file. Task 2 then only touches docs site files. This eliminates the parallel-write hazard entirely.
+
+**Severity**: Non-blocking but worth fixing before execution. Parallel writes to the same file are a predictable source of rework.
+
+---
+
+**Summary**: The plan is proportional to the problem. Three tasks for three deliverables, no unnecessary abstractions, no scope creep. The card-stack-in-two-places duplication and the parallel file edit are minor coordination issues, not architectural concerns. Ship it.

--- a/docs/history/nefario-reports/2026-03-26-044407-feature-list-competitor-comparison/phase3.5-security-minion.md
+++ b/docs/history/nefario-reports/2026-03-26-044407-feature-list-competitor-comparison/phase3.5-security-minion.md
@@ -1,0 +1,53 @@
+## Security Review: Feature List and Competitor Comparison Table
+
+### Verdict: APPROVE
+
+### Assessment
+
+This plan adds two static HTML sections and a static docs page. There is no
+user input, no backend surface, no JavaScript, no dynamic rendering, and no
+auth changes. The security attack surface introduced is effectively zero.
+
+**Specific checks:**
+
+**XSS**: No XSS vectors. All content is hardcoded static text authored by the
+developer, not user-supplied or fetched from any external source. The
+`content: attr(data-label)` CSS pseudo-element reads from HTML attributes that
+are also hardcoded -- no injection path exists.
+
+**Injection**: Not applicable. No SQL, no server-side templating with
+user-controlled variables, no shell execution. The `.njk` template uses
+hardcoded Nunjucks frontmatter with no variable interpolation on untrusted
+data.
+
+**Information disclosure**: No credentials, API keys, internal endpoints, or
+architecture details are added to the public page. The competitor data
+references publicly documented capabilities only. The GitHub issues link in
+the methodology section points to the already-public repo.
+
+**External links**: Two external links are present -- the GitHub issues link
+in the compare page (`github.com/benpeter/web-resource-ledger/issues`) and the
+cross-link from landing to docs (`docs.webresourceledger.com/compare/`). Both
+are first-party or controlled destinations. No user-controlled redirect targets.
+No `target="_blank"` links are specified, but if the frontend-minion adds them,
+`rel="noopener noreferrer"` should be included -- flag this at the approval gate
+review, not a blocker.
+
+**Supply chain / dependency risk**: No new dependencies introduced. Pure HTML
+and CSS only.
+
+**Content risk (not a blocker)**: The comparison data about competitors
+(PageFreezer, Hanzo, MirrorWeb, etc.) contains factual claims about their
+products. This is a reputational/legal risk to the operator, not a security
+vulnerability. The plan already flags this with an approval gate and a
+methodology section stating claims are based on public documentation. This is
+appropriately handled outside the security review scope.
+
+### Recommendations
+
+One non-blocking advisory: if the frontend-minion adds `target="_blank"` to
+any of the outbound links (GitHub, docs cross-link), ensure `rel="noopener
+noreferrer"` is included. This is a standard hardening measure for blank-target
+links. Verify at the Task 1 and Task 2 approval gates.
+
+No security blockers identified. Proceed.

--- a/docs/history/nefario-reports/2026-03-26-044407-feature-list-competitor-comparison/phase3.5-seo-minion.md
+++ b/docs/history/nefario-reports/2026-03-26-044407-feature-list-competitor-comparison/phase3.5-seo-minion.md
@@ -1,0 +1,86 @@
+# SEO Minion Review — Feature List and Competitor Comparison
+
+**Verdict: ADVISE**
+
+The plan is well-constructed and the execution prompts are specific. The structured data update is correct and the decision to defer template-level docs SEO is reasonable. Three items need attention before or during implementation.
+
+---
+
+## Issue 1: Compare page has no self-canonical — inconsistency creates soft duplicate risk (Medium)
+
+The plan explicitly defers canonical tags on the docs site (decision: "defer all except self-canonical on the compare page itself") but then the Task 2 prompt omits any canonical tag from `compare.njk`. The frontmatter only has `title` and `description`.
+
+The landing page links to `https://docs.webresourceledger.com/compare/` and the compare page itself has no canonical. If the docs framework generates both `/compare/` and `/compare/index.html` paths (common in Eleventy), or if the page is accessible with and without trailing slash, Google will see two URLs with identical content and no signal about which is preferred.
+
+**Fix**: Confirm whether the `layouts/doc.njk` template injects a self-canonical automatically. If it does not (which the zero-result grep on `canonical` in the docs templates confirms), add a self-canonical to the `compare.njk` frontmatter, or add a note to the Task 2 prompt instructing the agent to check whether the layout handles it.
+
+Check the doc layout:
+```
+site/layouts/doc.njk  (or wherever layouts live)
+```
+
+If no self-canonical is emitted, add to the compare.njk frontmatter:
+```yaml
+canonical: "https://docs.webresourceledger.com/compare/"
+```
+and pass it through to `<link rel="canonical">` in the layout for this page only.
+
+---
+
+## Issue 2: SoftwareApplication `offers` schema — `price: "0"` is correct but needs `priceValidUntil` or `availability` to be eligible for rich results (Low)
+
+The plan adds:
+```json
+"offers": {
+  "@type": "Offer",
+  "price": "0",
+  "priceCurrency": "EUR",
+  "description": "Free tier: 200 captures/month"
+}
+```
+
+For SoftwareApplication, Google's rich results spec requires `offers` to include `availability` when `price` is "0" to distinguish free from unavailable. Without it, the Offer is technically valid schema but may not produce a rich result. Also, `description` is not a standard property on `Offer` — use `name` instead (or omit; the featureList conveys the tier detail).
+
+**Fix** (minimal, does not require schema refactoring):
+```json
+"offers": {
+  "@type": "Offer",
+  "price": "0",
+  "priceCurrency": "EUR",
+  "availability": "https://schema.org/InStock",
+  "name": "Free tier: 200 captures/month"
+}
+```
+
+---
+
+## Issue 3: Cross-link from docs compare page back to landing is missing (Low)
+
+The landing summary table links forward to docs (`/compare/`). The docs compare page has no reciprocal link back to `webresourceledger.com` for users who arrive via search on the docs page and want to sign up or see pricing. This is not a duplicate content concern — it is a user journey gap that also affects internal link equity between the two domains.
+
+The plan's scope explicitly includes "links between the two" but only one direction is implemented (landing → docs). A brief sentence in the docs page lead paragraph or a CTA at the bottom of the compare page is sufficient: "Ready to try WRL? See pricing at webresourceledger.com."
+
+This is editorial and can be added to the Task 2 prompt without changing the page structure.
+
+---
+
+## What is explicitly approved
+
+- Deferring docs site template-level SEO (canonical, OG, BreadcrumbList, TechArticle) is correct. Doing it on one page without the others would be inconsistent and confusing to Google. The backlog item approach is right.
+- The `featureList` expansion is accurate and well-matched to the visible page content. No schema drift.
+- Adding `applicationSubCategory: "Web Evidence"` is valid and useful for entity disambiguation.
+- The landing page canonical (`https://webresourceledger.com/`) already exists and is self-referencing. The new sections do not affect it.
+- The landing and docs pages are on different origins (`webresourceledger.com` vs `docs.webresourceledger.com`), so there is no duplicate content relationship between the summary table and the full table. No canonical cross-linking needed between them.
+- The `<meta name="description">` on the compare page frontmatter is concise, includes the core keyword ("feature comparison"), and is within the 150–160 character target. No changes needed.
+
+---
+
+## Summary of required actions before merge
+
+| Issue | Severity | Action |
+|---|---|---|
+| Self-canonical on compare page | Medium | Verify doc.njk layout emits canonical; if not, add to frontmatter and thread it through |
+| `offers` schema `availability` + `name` | Low | Update in Task 2 prompt (it modifies landing index.html structured data) |
+| Reverse cross-link (docs → landing) | Low | Add one CTA sentence to Task 2 prompt |
+
+None of these require blocking the task. The agent executing Task 2 can handle all three within the existing file set. Adding them to the Task 2 prompt before dispatch is sufficient.

--- a/docs/history/nefario-reports/2026-03-26-044407-feature-list-competitor-comparison/phase3.5-test-minion.md
+++ b/docs/history/nefario-reports/2026-03-26-044407-feature-list-competitor-comparison/phase3.5-test-minion.md
@@ -1,0 +1,34 @@
+## Test Coverage Review
+
+**Verdict: APPROVE**
+
+### Scope Assessment
+
+This plan adds two new sections to the landing page (features list, comparison summary table) and a full comparison page to the docs site. All changes are pure HTML and CSS -- no JavaScript, no API modifications, no backend logic, no new interactive behavior.
+
+The project CLAUDE.md is explicit: "For UI-only changes (CSS, HTML, copy), visual verification is sufficient." This plan falls squarely in that category.
+
+### What Needs Testing
+
+**Visual verification at approval gate (Task 1):**
+- Feature grid renders at 1-column (mobile), 2-column (tablet), 4-column (desktop)
+- Card-stack pattern activates at < 768px with `data-label` pseudo-elements visible
+- Badge colors (pass/fail/skip) are distinguishable and contain visible text
+- WRL row highlight (`.comparison-highlight`) is visible but not garish
+- "Features" nav link scrolls correctly to `#features`
+
+**Visual verification at approval gate (Task 2 -- docs compare page):**
+- Full 9-row x 7-column table is readable on mobile (card-stack pattern)
+- Notes/footnotes render without obscuring table data
+- Page breadcrumb or navigation back to docs is present
+- Self-canonical tag is present in `<head>`
+
+### What Does NOT Need Automated Testing
+
+- No unit tests needed: no JavaScript logic to test
+- No integration tests needed: no API boundaries changed
+- No `npm test` run needed: the `@cloudflare/vitest-pool-workers` suite (~8 GB, slow) tests Worker runtime behavior, which is entirely unaffected by landing page HTML/CSS
+
+### Risk Notes
+
+Low risk overall. The one area worth careful human review at the approval gate is the competitor table data accuracy -- the plan correctly flags this as a gate reason. Badge classes (`.badge--pass`, `.badge--fail`, `.badge--skip`) must exist in `design-system.css` or be added to `landing.css`; frontend-minion should verify these exist before using them rather than assuming.

--- a/docs/history/nefario-reports/2026-03-26-044407-feature-list-competitor-comparison/phase3.5-ux-strategy-minion.md
+++ b/docs/history/nefario-reports/2026-03-26-044407-feature-list-competitor-comparison/phase3.5-ux-strategy-minion.md
@@ -1,0 +1,59 @@
+## UX Strategy Review: Feature List and Competitor Comparison
+
+**Verdict: APPROVE**
+
+---
+
+### Journey Coherence
+
+The planned section order is sound: Use Cases > Features > How It Works > Compare > Pricing.
+
+This follows the natural evaluation arc. Users arrive asking "what is this?" (Hero), see themselves in it (Use Cases), understand what they get (Features), learn how it works mechanically (How It Works), validate the claim against alternatives (Compare), then act (Pricing). The emotional logic progresses from recognition to understanding to conviction. That is correct.
+
+One coherence note that does not block approval: "How WRL Compares" placed after "How It Works" means skeptical users have to scroll past mechanical explanation before they can check WRL against alternatives. Some evaluators will want the comparison earlier. The current placement is defensible -- it keeps the comparison near Pricing where conversion intent is highest -- but worth monitoring with heatmaps post-launch.
+
+The decision to exclude "Compare" from nav is correct. Six nav items plus a sign-in button is already at the upper limit of scannable navigation. "Features" is the right addition; "Compare" is discoverable via scroll and via the "Full comparison" link at the bottom of the Features section.
+
+---
+
+### Cognitive Load
+
+The landing page additions are appropriately contained.
+
+**Features section**: 8 items in a lightweight definition-list grid is within working memory capacity (7±2). The two-group split (Evidence Integrity / Developer Experience) provides chunking that reduces cognitive load further. The ~120-word copy target is disciplined. No action required.
+
+**Comparison summary**: 5 rows x 4 feature columns = 20 data cells. This is on the edge of what a table can communicate without overwhelming, but the badge system (pass/fail/partial with visible text) makes the cells scannable rather than read. The WRL row highlight gives users an anchor so they do not have to hold context while scanning. Acceptable.
+
+**Docs comparison page**: 10 rows x 7 feature columns = 70 data cells. This is a reference document, not a conversion tool. Users arriving at `/compare/` have a specific evaluation job -- they are already comparing. Dense information is appropriate there. The Notes and Methodology sections add transparency without adding to the core scanning task (they are below the fold). No concern.
+
+The decision to not replicate the full 7-column table on the landing page is the most important simplification call in this plan. It was the right call. The summary table on landing and the full table on docs is correct progressive disclosure.
+
+---
+
+### Simplification Assessment
+
+The plan has already absorbed my prior input well -- the conflict resolution log shows "not cards -- cards create visual weight" and "no Compare in nav" were accepted. The remaining structure is lean.
+
+One minor observation on the feature copy: "Self-Hostable -- Deploy on your infrastructure. Your keys, your storage, your evidence chain." is doing more work than the other descriptions. The other seven descriptions are one sentence. This is two sentences plus a fragments list. It is not a blocking concern but the implementation agent could trim to one sentence without losing the idea.
+
+The docs page Notes section is appropriately detailed for a reference document. The Methodology disclaimer at the end is the right call -- it sets expectations for staleness and invites correction. This adds no cognitive load to the evaluation task because it lives after the table.
+
+---
+
+### Jobs-to-Be-Done Coverage
+
+The original request identifies three user jobs this content must serve:
+
+1. **"What is this?" visitor** wants to understand the value proposition at a glance -- served by Features section
+2. **Skeptical evaluator** wants to know how WRL compares to what they already know -- served by both the landing summary and the docs full table
+3. **Developer-minded visitor** wants to know if WRL is programmable and interoperable -- served by the Developer Experience feature group and the API/MCP/WACZ columns
+
+All three jobs are addressed. The docs comparison page with per-competitor notes serves a fourth implied job -- **the due-diligence researcher** who needs to understand exactly what they are and are not getting from each tool before bringing a recommendation to a team or legal department. The Notes section is the right format for that job.
+
+---
+
+### Summary
+
+The plan is coherent, the cognitive load is appropriate for each surface (landing: light, docs: detailed), and every section has a clear user job behind it. The conflict resolutions logged in the synthesis document reflect sound judgment. No structural changes needed.
+
+**APPROVE** -- proceed to execution.

--- a/docs/history/nefario-reports/2026-03-26-044407-feature-list-competitor-comparison/phase4-frontend-minion-task1-prompt.md
+++ b/docs/history/nefario-reports/2026-03-26-044407-feature-list-competitor-comparison/phase4-frontend-minion-task1-prompt.md
@@ -1,0 +1,1 @@
+Task 1: Landing page -- features section + comparison summary + structured data update

--- a/docs/history/nefario-reports/2026-03-26-044407-feature-list-competitor-comparison/phase4-frontend-minion-task2-prompt.md
+++ b/docs/history/nefario-reports/2026-03-26-044407-feature-list-competitor-comparison/phase4-frontend-minion-task2-prompt.md
@@ -1,0 +1,1 @@
+Task 2: Docs site -- comparison page + nav + CSS

--- a/docs/history/nefario-reports/2026-03-26-044407-feature-list-competitor-comparison/phase5-lucy.md
+++ b/docs/history/nefario-reports/2026-03-26-044407-feature-list-competitor-comparison/phase5-lucy.md
@@ -1,0 +1,67 @@
+# Lucy Review — Feature List & Competitor Comparison
+
+## VERDICT: ADVISE
+
+---
+
+## FINDINGS
+
+### [ADVISE] landing/public/index.html:288 — `aria-hidden="true"` on `<thead>` is incorrect
+
+The comparison table `<thead>` carries `aria-hidden="true"`, which hides the column headers from assistive technology. This is problematic: the `data-label` attributes on `<td>` cells replicate column header text only in the mobile card-stack view (via `::before` pseudo-content, which is not announced by all screen readers). On desktop, column-header information is suppressed for AT users entirely.
+
+The `aria-hidden` was likely added to suppress a redundancy concern in mobile view, but the correct solution is to let the table headers stand and allow the mobile card-stack's `data-label` pseudo-content serve as the mobile label — not to silence headers globally.
+
+FIX: Remove `aria-hidden="true"` from `<thead>` in `landing/public/index.html` line 288. The `<caption class="sr-only">` already provides the table summary. Column headers can remain visible to AT — they do not cause duplication problems.
+
+---
+
+### [ADVISE] landing/public/index.html:106–110 — Nav links to external domains missing `rel="noopener noreferrer"`
+
+`<a href="https://docs.webresourceledger.com">Docs</a>` (line 110) opens a cross-origin URL but has no `target="_blank"`, so `rel` is not strictly required. However, the review focus explicitly calls for auditing outbound links missing `rel="noopener noreferrer"` on `target="_blank"`. None of the nav links use `target="_blank"`, so this is a non-issue for the nav. Confirmed clean.
+
+Footer links at lines 437–440 include external URLs (`https://docs.webresourceledger.com`, `https://api.webresourceledger.com/ui`, `https://github.com/benpeter/web-resource-ledger`) — none use `target="_blank"`, so no `rel` attribute is required. Confirmed clean.
+
+No `target="_blank"` links found in any of the five changed files. This check PASSES.
+
+---
+
+### [NIT] landing/public/css/landing.css:533–573 — Mobile card-stack `thead` visually hidden but still technically in flow
+
+The mobile card-stack hides `<thead>` using absolute positioning + clipping (`position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0,0,0,0)`). This is the standard `.sr-only` pattern repurposed — it keeps the content available to AT. The above `aria-hidden="true"` finding makes this moot: if `aria-hidden` is removed, the `<thead>` is correctly available to AT on all viewport sizes.
+
+FIX: No CSS change required. The CSS is correct. The HTML attribute is the issue (see finding above).
+
+---
+
+### [NIT] site/content/compare.njk:17 — `aria-hidden="true"` on `<thead>` also present in docs comparison table
+
+Same pattern as the landing page. The docs comparison table at `site/content/compare.njk` line 17 also uses `aria-hidden="true"` on `<thead>`. The docs table has 8 columns vs. the landing table's 4 — the information loss for AT users is greater here.
+
+FIX: Remove `aria-hidden="true"` from `<thead>` in `site/content/compare.njk` line 17.
+
+---
+
+### [NIT] site/css/docs.css — No JavaScript added, design-system.css not modified
+
+Confirmed. `docs.css` adds only comparison table styles scoped to `.comparison-table-wrapper` and `.comparison-table` classes. It does not touch `design-system.css`. All values use design system tokens (`var(--color-*)`, `var(--space-*)`, `var(--text-*)`, `var(--radius-*)`). One raw color value is used: `--color-text-muted-docs: #5a5650` and `--color-link-docs: #2f6a85` — these are intentional accessible overrides with rationale documented inline. Acceptable.
+
+---
+
+## COMPLIANCE CHECKS
+
+| Check | Result |
+|---|---|
+| No JavaScript added | PASS — no `<script>` tags beyond existing structured data JSON-LD in `<head>`; no new JS files |
+| design-system.css not modified | PASS — not in changed file list; `landing.css` opens with explicit note "do NOT modify design-system.css" |
+| HTML semantics | PASS with the `aria-hidden` caveat above |
+| CSS uses design system tokens | PASS — all new CSS rules reference `var(--*)` tokens |
+| `target="_blank"` links have `rel="noopener noreferrer"` | PASS — no `target="_blank"` present in any changed file |
+| No framework dependencies introduced | PASS |
+| `CLAUDE.md` YAGNI / KISS | PASS — changes are additive, no speculative features |
+
+---
+
+## SUMMARY
+
+Two files use `aria-hidden="true"` on `<thead>` elements — this suppresses column headers from screen readers while the mobile card-stack fallback (CSS `::before` pseudo-content) is not universally announced. Removing the attribute resolves both instances. All other checks pass.

--- a/docs/history/nefario-reports/2026-03-26-044407-feature-list-competitor-comparison/phase5-margo.md
+++ b/docs/history/nefario-reports/2026-03-26-044407-feature-list-competitor-comparison/phase5-margo.md
@@ -1,0 +1,51 @@
+# Margo Complexity Review — Feature List + Competitor Comparison
+
+**VERDICT: ADVISE**
+
+The work is proportional to the problem and contains no YAGNI violations or scope inflation. Two findings require attention before close; neither blocks merge.
+
+---
+
+## Finding 1: Duplicated CSS block (accidental complexity)
+
+**What**: The mobile card-stack pattern for `.comparison-table` is duplicated verbatim across two files:
+- `landing/public/css/landing.css` lines 533–573
+- `site/css/docs.css` lines 571–627
+
+Both files carry explicit sync comments ("Sync note: equivalent pattern in...") acknowledging the duplication. Sync comments are not a solution — they are a flag that says "this will drift."
+
+**Why it appears accidental**: These two CSS contexts have no sharing mechanism today, which is why the duplication exists. The sync comment trades one problem (complexity of sharing) for another (maintenance drift). But the mobile card-stack is ~30 lines of non-trivial layout logic involving `display:block` overrides, `::before` pseudo-element label injection, and `clip` hiding. When one copy gets an edge case fix, the other will not.
+
+**Concrete difference already present**: `docs.css` uses `--color-text-muted-docs` in the `::before` label (line 612) while `landing.css` uses `--color-text-muted` (line 566). This is already diverged. Also `docs.css` resets `overflow-x: visible` and `margin: 0` on mobile (lines 573–575), `landing.css` does not — because the wrapper context differs. These differences are valid, which means the blocks are not truly duplicated — they are *similar but contextually distinct*, which makes a shared file even less appropriate than it first appears.
+
+**Revised assessment**: The divergence is intentional and contextually justified. The sync comments are a maintenance reminder, not a design flaw. This remains an ADVISE item — the team should be aware that these blocks will continue to diverge and should stop treating them as "in sync." The sync comments should be reworded to say "similar pattern — contexts differ, do not attempt to share."
+
+---
+
+## Finding 2: Landing comparison table is a subset of the docs table
+
+**What**: `index.html` shows 4 columns × 5 rows. `compare.njk` shows 8 columns × 10 rows. The landing table is a deliberate editorial summary, not duplication. This is fine.
+
+**No action needed.** The intent is clear (landing = teaser, docs = full detail) and both link to each other explicitly.
+
+---
+
+## Finding 3: Structured data `featureList` is a maintenance liability (minor)
+
+**What**: `index.html` lines 59–75 contain a 15-item `featureList` array in the `SoftwareApplication` JSON-LD block. Several items (e.g., "Batch capture API", "Webhook notifications", "Scheduled captures") describe features that are not covered in the visible landing page content.
+
+**Why it matters**: JSON-LD structured data requires manual sync with actual product capabilities. A feature listed here but not yet shipped, or removed without updating this block, creates a misleading signal to search engines and scrapers. The `featureList` is also the kind of aspirational list that tends to grow without pruning.
+
+**Simpler alternative**: Trim `featureList` to only features that appear in the landing page's visible content (the features grid and use cases sections). This gives structured data that cannot diverge from what a visitor actually sees. Items like "CLI verification tool" and "eIDAS-qualified timestamps" are covered on the page; items like "Scheduled captures" and "Webhook notifications" are not.
+
+---
+
+## Summary
+
+| # | Finding | Severity | Action |
+|---|---------|----------|--------|
+| 1 | CSS card-stack sync comments imply shared code that doesn't exist | Low | Reword sync comments to clarify intentional divergence |
+| 2 | Landing vs. docs table column difference | None | No action |
+| 3 | `featureList` in JSON-LD contains features absent from visible page content | Low | Trim to features visible on the landing page |
+
+No unjustified complexity budget spend. No YAGNI violations. No new dependencies. No abstraction layers. The comparison table and features grid are straightforward HTML+CSS delivering real user value. Infrastructure is unchanged.

--- a/docs/history/nefario-reports/2026-03-26-044407-feature-list-competitor-comparison/prompt.md
+++ b/docs/history/nefario-reports/2026-03-26-044407-feature-list-competitor-comparison/prompt.md
@@ -1,0 +1,20 @@
+Feature list and competitor comparison table for WRL landing page and docs site.
+
+**Outcome**: Prospective users can see at a glance how WRL compares to alternative web capture and archival approaches, making the value proposition concrete. A dedicated feature list and competition comparison table on the public site converts "what is this?" visitors into "I need this" users by showing WRL's cryptographic integrity advantage over every competitor. The feature list also highlights technical/developer capabilities (API, MCP server, Ed25519 signatures, WACZ format) so developer-minded visitors see that WRL is programmable and interoperable.
+
+**Success criteria**:
+- Landing site has a feature list section showing WRL's core capabilities (capture, signing, timestamps, verification, WACZ, MCP, scheduled captures)
+- Feature list includes a technical/developer benefits subsection covering: REST API, MCP server, Ed25519 signatures, WACZ standard format, CLI verification tool, webhooks — with links to relevant docs pages
+- Comparison table covers at least: Wayback Machine, PageFreezer, Hanzo, Page Vault, MirrorWeb, Stillio, Archive-It, Webrecorder, manual screenshots + notarization
+- Table columns include: integrity approach, cryptographic signing, independent timestamps, public verification, API access, standard format (WACZ), eIDAS support
+- Each competitor row is factually accurate (no strawmanning - cite what they actually provide)
+- Table renders well on mobile (responsive)
+- Hosted on both landing page (summary version) and docs site (full version with detailed notes)
+
+**Scope**:
+- In: Feature list section on landing page (including developer/technical benefits), full comparison table on docs site, summary comparison on landing page, links between the two
+- Out: Blog posts about competitors, SEO landing pages per competitor ("WRL vs PageFreezer"), pricing comparison (pricing is WRL-only)
+
+**Constraints**:
+- Pure HTML + CSS, no JS framework (consistent with existing landing page and docs site)
+- Must match existing design system (design-system.css)

--- a/landing/public/css/landing.css
+++ b/landing/public/css/landing.css
@@ -529,7 +529,7 @@ body {
 }
 
 /* Mobile card-stack for comparison table */
-/* Sync note: equivalent pattern exists in site/css/docs.css for the docs comparison table */
+/* Similar card-stack pattern in site/css/docs.css — contexts differ intentionally, do not merge */
 @media (max-width: 767px) {
   .comparison-table thead {
     position: absolute; width: 1px; height: 1px;

--- a/landing/public/css/landing.css
+++ b/landing/public/css/landing.css
@@ -417,7 +417,163 @@ body {
 }
 
 /* ===================================================================
-   12. Pricing section
+   12. Features section
+   =================================================================== */
+
+.features-grid {
+  display: grid;
+  gap: var(--space-6);
+}
+
+.feature-group-label {
+  margin: 0 0 var(--space-4);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-text-muted);
+  grid-column: 1 / -1;
+}
+
+.feature-group-label:not(:first-child) {
+  margin-top: var(--space-4);
+}
+
+.feature-item h3 {
+  margin: 0 0 var(--space-1);
+  font-size: var(--text-md);
+  font-weight: var(--weight-bold);
+  color: var(--color-text);
+}
+
+.feature-item p {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: var(--text-sm);
+  line-height: var(--leading-relaxed);
+}
+
+@media (min-width: 768px) {
+  .features-grid { grid-template-columns: repeat(2, 1fr); }
+}
+
+@media (min-width: 1024px) {
+  .features-grid { grid-template-columns: repeat(5, 1fr); }
+}
+
+/* ===================================================================
+   13. Comparison table section
+   =================================================================== */
+
+/* Comparison table */
+.comparison-table-wrapper {
+  overflow-x: auto;
+}
+
+.comparison-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.comparison-table th[scope="col"] {
+  background: var(--color-surface-muted);
+  font-weight: var(--weight-medium);
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: var(--space-2) var(--space-3);
+  text-align: left;
+  border-bottom: 1px solid var(--color-border);
+  white-space: nowrap;
+}
+
+.comparison-table th[scope="row"] {
+  font-weight: var(--weight-bold);
+  padding: var(--space-3);
+  border-bottom: 1px solid var(--color-border-subtle);
+  white-space: nowrap;
+}
+
+.comparison-table td {
+  padding: var(--space-3);
+  border-bottom: 1px solid var(--color-border-subtle);
+  vertical-align: middle;
+  font-size: var(--text-sm);
+}
+
+.comparison-highlight {
+  background: var(--color-surface-muted);
+}
+
+.comparison-highlight td,
+.comparison-highlight th {
+  font-weight: var(--weight-medium);
+}
+
+.compare-more,
+.features-more {
+  margin: var(--space-6) 0 0;
+  font-size: var(--text-sm);
+}
+
+.compare-more a,
+.features-more a {
+  color: var(--color-accent);
+  text-decoration: none;
+}
+
+.compare-more a:hover,
+.features-more a:hover {
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+/* Mobile card-stack for comparison table */
+/* Sync note: equivalent pattern exists in site/css/docs.css for the docs comparison table */
+@media (max-width: 767px) {
+  .comparison-table thead {
+    position: absolute; width: 1px; height: 1px;
+    overflow: hidden; clip: rect(0,0,0,0);
+  }
+  .comparison-table tbody { display: block; }
+  .comparison-table tr {
+    display: block;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+    padding: var(--space-4);
+    margin-bottom: var(--space-4);
+    background: var(--color-surface);
+  }
+  .comparison-table th[scope="row"] {
+    display: block;
+    font-size: var(--text-md);
+    border-bottom: 1px solid var(--color-border);
+    padding: 0 0 var(--space-3);
+    margin-bottom: var(--space-2);
+    white-space: normal;
+  }
+  .comparison-table td {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: var(--space-2) 0;
+    border-bottom: 1px solid var(--color-border-subtle);
+  }
+  .comparison-table td::before {
+    content: attr(data-label);
+    font-weight: var(--weight-medium);
+    font-size: var(--text-xs);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--color-text-muted);
+    flex-shrink: 0;
+    margin-right: var(--space-3);
+  }
+  .comparison-table td:last-child { border-bottom: none; }
+}
+
+/* ===================================================================
+   14. Pricing section
    =================================================================== */
 
 .pricing-grid {
@@ -519,7 +675,7 @@ body {
 }
 
 /* ===================================================================
-   13. Footer
+   15. Footer
    =================================================================== */
 
 .site-footer {
@@ -616,7 +772,7 @@ body {
 }
 
 /* ===================================================================
-   14. Article / prose layout (legal pages)
+   16. Article / prose layout (legal pages)
    =================================================================== */
 
 .article {
@@ -714,7 +870,7 @@ body {
 }
 
 /* ===================================================================
-   15. Responsive adjustments
+   17. Responsive adjustments
    =================================================================== */
 
 @media (max-width: 767px) {

--- a/landing/public/index.html
+++ b/landing/public/index.html
@@ -285,7 +285,7 @@
         <div class="comparison-table-wrapper">
           <table class="comparison-table">
             <caption class="sr-only">Comparison of WRL with other web evidence tools</caption>
-            <thead aria-hidden="true">
+            <thead>
               <tr>
                 <th scope="col">Tool</th>
                 <th scope="col">Crypto Signing</th>

--- a/landing/public/index.html
+++ b/landing/public/index.html
@@ -64,10 +64,25 @@
       "REST API and MCP server",
       "Cookie consent dismissal",
       "eIDAS-qualified timestamps (optional)",
-      "FRE 901/902 evidence authentication support"
+      "FRE 901/902 evidence authentication support",
+      "Batch capture API",
+      "Webhook notifications",
+      "CLI verification tool",
+      "Screenshot and rendered HTML capture",
+      "HTTP header recording",
+      "Self-hostable (Apache 2.0)",
+      "Scheduled captures"
     ],
     "license": "https://github.com/benpeter/web-resource-ledger/blob/main/LICENSE",
     "isAccessibleForFree": true,
+    "applicationSubCategory": "Web Evidence",
+    "offers": {
+      "@type": "Offer",
+      "name": "Free tier",
+      "price": "0",
+      "priceCurrency": "EUR",
+      "availability": "https://schema.org/InStock"
+    },
     "author": {
       "@type": "Organization",
       "name": "Web Resource Ledger",
@@ -89,6 +104,7 @@
       </a>
       <nav aria-label="Main">
         <a href="#use-cases">Use Cases</a>
+        <a href="#features">Features</a>
         <a href="#how-it-works">How It Works</a>
         <a href="#pricing">Pricing</a>
         <a href="https://docs.webresourceledger.com">Docs</a>
@@ -155,8 +171,81 @@
       </div>
     </section>
 
+    <!-- Features -->
+    <section id="features" class="landing-section landing-section--muted" aria-labelledby="features-heading">
+      <div class="container">
+        <div class="section-header">
+          <h2 id="features-heading">What You Get</h2>
+        </div>
+        <div class="features-grid">
+
+          <p class="feature-group-label">Evidence Integrity</p>
+
+          <div class="feature-item">
+            <h3>Ed25519 Digital Signatures</h3>
+            <p>Every capture is cryptographically signed. Proves who captured it and that nothing was altered.</p>
+          </div>
+
+          <div class="feature-item">
+            <h3>Independent Timestamps</h3>
+            <p>A third-party authority records when the capture happened. No one -- not even WRL -- can backdate it.</p>
+          </div>
+
+          <div class="feature-item">
+            <h3>Public Verification</h3>
+            <p>Share a link. Anyone can confirm authenticity -- no account, no trust required.</p>
+            <p class="use-case-cta"><a href="https://docs.webresourceledger.com/verification/">How verification works &rarr;</a></p>
+          </div>
+
+          <div class="feature-item">
+            <h3>eIDAS Qualified Timestamps</h3>
+            <p>Optional EU-standard timestamps with legal presumption of accuracy across all member states.</p>
+            <p class="use-case-cta"><a href="https://docs.webresourceledger.com/legal-evidence/">Legal evidence guide &rarr;</a></p>
+          </div>
+
+          <div class="feature-item">
+            <h3>CLI Verification Tool</h3>
+            <p>Verify captures offline with a single command. No network, no trust in us required.</p>
+            <p class="use-case-cta"><a href="https://docs.webresourceledger.com/verification/">Verification docs &rarr;</a></p>
+          </div>
+
+          <p class="feature-group-label">Developer Experience</p>
+
+          <div class="feature-item">
+            <h3>REST API</h3>
+            <p>One POST, one signed evidence bundle. Batch captures, scheduled captures.</p>
+            <p class="use-case-cta"><a href="https://docs.webresourceledger.com/api-reference/">API reference &rarr;</a></p>
+          </div>
+
+          <div class="feature-item">
+            <h3>MCP Server</h3>
+            <p>AI agents can capture and verify web pages with cryptographic proof.</p>
+            <p class="use-case-cta"><a href="https://docs.webresourceledger.com/mcp/">MCP docs &rarr;</a></p>
+          </div>
+
+          <div class="feature-item">
+            <h3>Webhooks</h3>
+            <p>Get notified when captures complete. Integrate into any workflow.</p>
+            <p class="use-case-cta"><a href="https://docs.webresourceledger.com/webhooks/">Webhook docs &rarr;</a></p>
+          </div>
+
+          <div class="feature-item">
+            <h3>WACZ Standard Format</h3>
+            <p>Open archive format. Not locked to any vendor.</p>
+          </div>
+
+          <div class="feature-item">
+            <h3>Self-Hostable</h3>
+            <p>Deploy on your infrastructure. Your keys, your storage, your evidence chain.</p>
+          </div>
+
+        </div>
+        <p class="features-more"><a href="https://docs.webresourceledger.com/compare/">Full feature comparison across 9 tools &rarr;</a></p>
+      </div>
+    </section>
+
     <!-- How It Works -->
-    <section id="how-it-works" class="landing-section landing-section--muted" aria-labelledby="how-it-works-heading">
+    <section id="how-it-works" class="landing-section landing-section--white" aria-labelledby="how-it-works-heading">
       <div class="container">
         <div class="section-header">
           <h2 id="how-it-works-heading">How It Works</h2>
@@ -184,6 +273,67 @@
             </div>
           </li>
         </ol>
+      </div>
+    </section>
+
+    <!-- Compare -->
+    <section id="compare" class="landing-section landing-section--muted" aria-labelledby="compare-heading">
+      <div class="container">
+        <div class="section-header">
+          <h2 id="compare-heading">How WRL Compares</h2>
+        </div>
+        <div class="comparison-table-wrapper">
+          <table class="comparison-table">
+            <caption class="sr-only">Comparison of WRL with other web evidence tools</caption>
+            <thead aria-hidden="true">
+              <tr>
+                <th scope="col">Tool</th>
+                <th scope="col">Crypto Signing</th>
+                <th scope="col">Independent Timestamps</th>
+                <th scope="col">Public Verification</th>
+                <th scope="col">Open Format</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr class="comparison-highlight">
+                <th scope="row">WRL</th>
+                <td data-label="Crypto Signing"><span class="badge badge--pass">Ed25519 (every capture)</span></td>
+                <td data-label="Independent Timestamps"><span class="badge badge--pass">RFC 3161 (default)</span></td>
+                <td data-label="Public Verification"><span class="badge badge--pass">Yes (no account)</span></td>
+                <td data-label="Open Format"><span class="badge badge--pass">WACZ</span></td>
+              </tr>
+              <tr>
+                <th scope="row">Wayback Machine</th>
+                <td data-label="Crypto Signing"><span class="badge badge--fail">No</span></td>
+                <td data-label="Independent Timestamps"><span class="badge badge--fail">No</span></td>
+                <td data-label="Public Verification"><span class="badge badge--skip">Public access (no crypto)</span></td>
+                <td data-label="Open Format"><span class="badge badge--pass">WARC</span></td>
+              </tr>
+              <tr>
+                <th scope="row">PageFreezer</th>
+                <td data-label="Crypto Signing"><span class="badge badge--skip">SHA-256</span></td>
+                <td data-label="Independent Timestamps"><span class="badge badge--skip">Proprietary clock</span></td>
+                <td data-label="Public Verification"><span class="badge badge--fail">No</span></td>
+                <td data-label="Open Format"><span class="badge badge--fail">PDF</span></td>
+              </tr>
+              <tr>
+                <th scope="row">Webrecorder</th>
+                <td data-label="Crypto Signing"><span class="badge badge--skip">Spec exists (not default)</span></td>
+                <td data-label="Independent Timestamps"><span class="badge badge--skip">In spec (not default)</span></td>
+                <td data-label="Public Verification"><span class="badge badge--skip">Validator tools</span></td>
+                <td data-label="Open Format"><span class="badge badge--pass">WACZ + WARC</span></td>
+              </tr>
+              <tr>
+                <th scope="row">Manual + Notary</th>
+                <td data-label="Crypto Signing"><span class="badge badge--skip">Notary attestation</span></td>
+                <td data-label="Independent Timestamps"><span class="badge badge--skip">Notary timestamp</span></td>
+                <td data-label="Public Verification"><span class="badge badge--skip">Via notary records</span></td>
+                <td data-label="Open Format"><span class="badge badge--fail">N/A</span></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="compare-more"><a href="https://docs.webresourceledger.com/compare/">Full comparison of 9 tools across 8 criteria &rarr;</a></p>
       </div>
     </section>
 

--- a/site/_data/site.js
+++ b/site/_data/site.js
@@ -12,6 +12,7 @@ export default {
     { title: "MCP Server", url: "/mcp/" },
     { title: "API Reference", url: "/api-reference/" },
     { title: "Architecture", url: "/architecture/" },
+    { title: "Compare", url: "/compare/" },
     // Security & Compliance
     { title: "Security & Compliance", url: "/security/" },
     { title: "Security Whitepaper", url: "/security/whitepaper/" },

--- a/site/content/compare.njk
+++ b/site/content/compare.njk
@@ -14,7 +14,7 @@ description: Feature comparison of WRL with Wayback Machine, PageFreezer, Webrec
 <div class="comparison-table-wrapper">
   <table class="comparison-table">
     <caption class="sr-only">Feature comparison of web evidence and archiving tools</caption>
-    <thead aria-hidden="true">
+    <thead>
       <tr>
         <th scope="col">Tool</th>
         <th scope="col">Cryptographic Signing</th>

--- a/site/content/compare.njk
+++ b/site/content/compare.njk
@@ -1,0 +1,216 @@
+---
+layout: layouts/doc.njk
+title: How WRL Compares
+description: Feature comparison of WRL with Wayback Machine, PageFreezer, Webrecorder, and 6 other web archiving and evidence tools. Last verified March 2026.
+---
+<h1>How WRL Compares</h1>
+
+<p>
+  A factual comparison of WRL with other web archiving and evidence tools. Each cell reflects publicly
+  documented capabilities as of March 2026. If something has changed,
+  <a href="https://github.com/benpeter/web-resource-ledger/issues">open an issue</a>.
+</p>
+
+<div class="comparison-table-wrapper">
+  <table class="comparison-table">
+    <caption class="sr-only">Feature comparison of web evidence and archiving tools</caption>
+    <thead aria-hidden="true">
+      <tr>
+        <th scope="col">Tool</th>
+        <th scope="col">Cryptographic Signing</th>
+        <th scope="col">Independent Timestamps</th>
+        <th scope="col">Public Verification</th>
+        <th scope="col">API Access</th>
+        <th scope="col">Standard Format</th>
+        <th scope="col">eIDAS Qualified</th>
+        <th scope="col">Open Source</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr class="comparison-highlight">
+        <th scope="row">WRL</th>
+        <td data-label="Cryptographic Signing"><span class="badge badge--pass">Ed25519 (every capture)</span></td>
+        <td data-label="Independent Timestamps"><span class="badge badge--pass">RFC 3161 (DigiCert TSA)</span></td>
+        <td data-label="Public Verification"><span class="badge badge--pass">Yes (no account needed)</span></td>
+        <td data-label="API Access"><span class="badge badge--pass">REST API, MCP</span></td>
+        <td data-label="Standard Format"><span class="badge badge--pass">WACZ</span></td>
+        <td data-label="eIDAS Qualified"><span class="badge badge--pass">Optional</span></td>
+        <td data-label="Open Source"><span class="badge badge--pass">Apache 2.0</span></td>
+      </tr>
+      <tr>
+        <th scope="row">Wayback Machine</th>
+        <td data-label="Cryptographic Signing"><span class="badge badge--fail">No</span></td>
+        <td data-label="Independent Timestamps"><span class="badge badge--fail">Crawl timestamps only</span></td>
+        <td data-label="Public Verification"><span class="badge badge--skip">Public access (no crypto)</span></td>
+        <td data-label="API Access"><span class="badge badge--skip">Yes (rate-limited)</span></td>
+        <td data-label="Standard Format"><span class="badge badge--pass">WARC</span></td>
+        <td data-label="eIDAS Qualified"><span class="badge badge--fail">No</span></td>
+        <td data-label="Open Source"><span class="badge badge--skip">Partial (some tools)</span></td>
+      </tr>
+      <tr>
+        <th scope="row">PageFreezer</th>
+        <td data-label="Cryptographic Signing"><span class="badge badge--skip">SHA-256 signing</span></td>
+        <td data-label="Independent Timestamps"><span class="badge badge--skip">Stratum-1 clock (not RFC 3161)</span></td>
+        <td data-label="Public Verification"><span class="badge badge--fail">No (platform-only)</span></td>
+        <td data-label="API Access"><span class="badge badge--skip">Partner API</span></td>
+        <td data-label="Standard Format"><span class="badge badge--fail">PDF</span></td>
+        <td data-label="eIDAS Qualified"><span class="badge badge--fail">No</span></td>
+        <td data-label="Open Source"><span class="badge badge--fail">No</span></td>
+      </tr>
+      <tr>
+        <th scope="row">Hanzo</th>
+        <td data-label="Cryptographic Signing"><span class="badge badge--skip">Not documented</span></td>
+        <td data-label="Independent Timestamps"><span class="badge badge--skip">Not documented</span></td>
+        <td data-label="Public Verification"><span class="badge badge--fail">No</span></td>
+        <td data-label="API Access"><span class="badge badge--fail">No</span></td>
+        <td data-label="Standard Format"><span class="badge badge--pass">WARC</span></td>
+        <td data-label="eIDAS Qualified"><span class="badge badge--fail">No</span></td>
+        <td data-label="Open Source"><span class="badge badge--fail">No</span></td>
+      </tr>
+      <tr>
+        <th scope="row">Page Vault</th>
+        <td data-label="Cryptographic Signing"><span class="badge badge--skip">SHA-256 hashing</span></td>
+        <td data-label="Independent Timestamps"><span class="badge badge--skip">Internal timestamps</span></td>
+        <td data-label="Public Verification"><span class="badge badge--skip">Expert witness service</span></td>
+        <td data-label="API Access"><span class="badge badge--fail">No</span></td>
+        <td data-label="Standard Format"><span class="badge badge--fail">Proprietary / PDF</span></td>
+        <td data-label="eIDAS Qualified"><span class="badge badge--fail">No</span></td>
+        <td data-label="Open Source"><span class="badge badge--fail">No</span></td>
+      </tr>
+      <tr>
+        <th scope="row">MirrorWeb</th>
+        <td data-label="Cryptographic Signing"><span class="badge badge--skip">SHA-1 per docs</span></td>
+        <td data-label="Independent Timestamps"><span class="badge badge--skip">Timestamped (not RFC 3161)</span></td>
+        <td data-label="Public Verification"><span class="badge badge--fail">No (platform-only)</span></td>
+        <td data-label="API Access"><span class="badge badge--skip">Limited API</span></td>
+        <td data-label="Standard Format"><span class="badge badge--pass">WARC</span></td>
+        <td data-label="eIDAS Qualified"><span class="badge badge--fail">No</span></td>
+        <td data-label="Open Source"><span class="badge badge--fail">No</span></td>
+      </tr>
+      <tr>
+        <th scope="row">Stillio</th>
+        <td data-label="Cryptographic Signing"><span class="badge badge--fail">No</span></td>
+        <td data-label="Independent Timestamps"><span class="badge badge--fail">Metadata only</span></td>
+        <td data-label="Public Verification"><span class="badge badge--fail">No</span></td>
+        <td data-label="API Access"><span class="badge badge--skip">Basic API</span></td>
+        <td data-label="Standard Format"><span class="badge badge--fail">PNG / JPEG</span></td>
+        <td data-label="eIDAS Qualified"><span class="badge badge--fail">No</span></td>
+        <td data-label="Open Source"><span class="badge badge--fail">No</span></td>
+      </tr>
+      <tr>
+        <th scope="row">Archive-It</th>
+        <td data-label="Cryptographic Signing"><span class="badge badge--fail">Checksums only</span></td>
+        <td data-label="Independent Timestamps"><span class="badge badge--fail">Crawl timestamps</span></td>
+        <td data-label="Public Verification"><span class="badge badge--skip">Public access (no crypto)</span></td>
+        <td data-label="API Access"><span class="badge badge--pass">Yes (WASAPI)</span></td>
+        <td data-label="Standard Format"><span class="badge badge--pass">WARC</span></td>
+        <td data-label="eIDAS Qualified"><span class="badge badge--fail">No</span></td>
+        <td data-label="Open Source"><span class="badge badge--fail">No</span></td>
+      </tr>
+      <tr>
+        <th scope="row">Webrecorder</th>
+        <td data-label="Cryptographic Signing"><span class="badge badge--skip">WACZ-Auth spec (not default)</span></td>
+        <td data-label="Independent Timestamps"><span class="badge badge--skip">RFC 3161 in spec (not default)</span></td>
+        <td data-label="Public Verification"><span class="badge badge--skip">Validator tools exist</span></td>
+        <td data-label="API Access"><span class="badge badge--pass">Browsertrix API</span></td>
+        <td data-label="Standard Format"><span class="badge badge--pass">WACZ + WARC</span></td>
+        <td data-label="eIDAS Qualified"><span class="badge badge--fail">No</span></td>
+        <td data-label="Open Source"><span class="badge badge--pass">Yes</span></td>
+      </tr>
+      <tr>
+        <th scope="row">Manual Screenshots + Notarization</th>
+        <td data-label="Cryptographic Signing"><span class="badge badge--skip">Notary attestation</span></td>
+        <td data-label="Independent Timestamps"><span class="badge badge--skip">Notary timestamp</span></td>
+        <td data-label="Public Verification"><span class="badge badge--skip">Via notary records</span></td>
+        <td data-label="API Access"><span class="badge badge--fail">No</span></td>
+        <td data-label="Standard Format"><span class="badge badge--fail">N/A</span></td>
+        <td data-label="eIDAS Qualified"><span class="badge badge--skip">Separate framework</span></td>
+        <td data-label="Open Source"><span class="badge badge--fail">N/A</span></td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+<h2>Notes</h2>
+
+<h3>Wayback Machine</h3>
+<p>
+  Massive scale (850B+ pages archived) and institutional credibility accepted by some courts. Captures
+  have no cryptographic signatures -- integrity relies on trust in the Internet Archive as an institution.
+  Rate-limited public API (15 req/min). The de facto reference for "what did this page look like" but not
+  designed as an evidence tool.
+</p>
+
+<h3>PageFreezer</h3>
+<p>
+  Enterprise-grade compliance platform (FedRAMP authorized, SOC 2). SHA-256 digital signatures with their
+  own timestamping infrastructure (Stratum-1 atomic clock, ESIGN Act compliant). Timestamps are not from
+  an independent third-party TSA per RFC 3161. Strong in social media archiving (Teams, Workplace) which
+  WRL does not offer. Verification is internal to their platform.
+</p>
+
+<h3>Hanzo</h3>
+<p>
+  Focused on dynamic content capture (SPAs, interactive elements) and eDiscovery workflows. SOC 2 Type 2
+  certified. No public API (confirmed by multiple review sources). Integrity approach is proprietary and
+  not publicly documented. Note: Hanzo (hanzo.co) the web archiving company is distinct from Hanzo AI
+  (hanzo.ai).
+</p>
+
+<h3>Page Vault</h3>
+<p>
+  Purpose-built for US litigation. Provides expert witness testimony and affidavit services for court
+  admissibility under FRE 901(b)(9) and FRE 902(13)/902(14). SHA-256 hashing with internal timestamps.
+  No API -- browser extension and managed capture service. WRL provides machine-verifiable proof; Page
+  Vault provides human-verifiable expert testimony.
+</p>
+
+<h3>MirrorWeb</h3>
+<p>
+  Financial services compliance focus (SEC 17a-4, FINRA 2210, FCA COBS 4). Documentation references
+  SHA-1 digital signatures, though this may have been updated (SHA-1 is cryptographically deprecated).
+  SOC 2 certified. Multi-channel archiving including social media and SMS.
+</p>
+
+<h3>Stillio</h3>
+<p>
+  Screenshot scheduling service, not an evidence tool. No integrity proofs, no cryptographic signing.
+  Useful for visual monitoring and brand tracking. Including Stillio illustrates the gap between
+  screenshot services and evidence services.
+</p>
+
+<h3>Archive-It</h3>
+<p>
+  Internet Archive's subscription archiving service for institutions. WARC format with MD5 and SHA-1
+  checksums via WASAPI (data integrity, not cryptographic authenticity). Strong in academic, government,
+  and cultural heritage sectors. Public access to archives but no cryptographic verification.
+</p>
+
+<h3>Webrecorder</h3>
+<p>
+  Created the WACZ format and authored the WACZ-Auth specification that defines signing for WACZ files.
+  WRL implements signing as a default on every capture; Webrecorder provides the specification and
+  tooling. Browsertrix (hosted service) does not appear to sign WACZ files by default. Open source,
+  self-hostable via Kubernetes. Different primary use case: site-wide preservation vs. WRL's
+  point-in-time evidence.
+</p>
+
+<h3>Manual Screenshots + Notarization</h3>
+<p>
+  Legally established with centuries of precedent. Entirely manual, no automation possible. Notary
+  attestation is broadly accepted by courts. Cost scales linearly with volume. WRL is faster, scalable,
+  and cheaper but has less legal track record.
+</p>
+
+<h2>Methodology</h2>
+
+<p>
+  All claims are based on publicly available documentation, product pages, and review platforms as of
+  March 2026. Where a capability could not be confirmed from public sources, the cell reads "Not
+  documented" rather than "No". We do not have accounts with every listed service -- claims reflect
+  what each service publicly represents, not hands-on testing of every feature. If any information is
+  outdated or incorrect, please
+  <a href="https://github.com/benpeter/web-resource-ledger/issues/new">open an issue</a>.
+</p>
+
+<p>See also the <a href="https://webresourceledger.com/#compare">summary comparison</a> on our landing page.</p>

--- a/site/css/docs.css
+++ b/site/css/docs.css
@@ -513,3 +513,115 @@ pre:focus-within .copy-btn {
   padding: var(--space-4);
   margin: 0;
 }
+
+/* ------------------------------------------------------------------ */
+/* Comparison table                                                     */
+/* Sync note: equivalent mobile card-stack pattern in landing.css       */
+/* ------------------------------------------------------------------ */
+
+.comparison-table-wrapper {
+  overflow-x: auto;
+  margin: var(--space-6) calc(-1 * var(--space-6));
+  padding: 0 var(--space-6);
+}
+
+.comparison-table {
+  width: 100%;
+  min-width: 800px;
+  border-collapse: collapse;
+}
+
+.comparison-table th[scope="col"] {
+  background: var(--color-surface-muted);
+  font-weight: var(--weight-medium);
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: var(--space-2) var(--space-3);
+  text-align: left;
+  border-bottom: 1px solid var(--color-border);
+  white-space: nowrap;
+}
+
+.comparison-table th[scope="row"] {
+  font-weight: var(--weight-bold);
+  padding: var(--space-3);
+  border-bottom: 1px solid var(--color-border-subtle);
+  white-space: nowrap;
+}
+
+.comparison-table td {
+  padding: var(--space-3);
+  border-bottom: 1px solid var(--color-border-subtle);
+  vertical-align: middle;
+  font-size: var(--text-sm);
+}
+
+.comparison-highlight {
+  background: var(--color-surface-muted);
+}
+
+.comparison-highlight td,
+.comparison-highlight th {
+  font-weight: var(--weight-medium);
+}
+
+/* Mobile card-stack */
+/* Sync note: equivalent pattern in landing/public/css/landing.css */
+@media (max-width: 767px) {
+  .comparison-table-wrapper {
+    margin: var(--space-6) 0;
+    padding: 0;
+    overflow-x: visible;
+  }
+
+  .comparison-table {
+    min-width: 0;
+  }
+
+  .comparison-table thead {
+    position: absolute; width: 1px; height: 1px;
+    overflow: hidden; clip: rect(0,0,0,0);
+  }
+
+  .comparison-table tbody { display: block; }
+
+  .comparison-table tr {
+    display: block;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+    padding: var(--space-4);
+    margin-bottom: var(--space-4);
+    background: var(--color-surface);
+  }
+
+  .comparison-table td {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: var(--space-2) 0;
+    border-bottom: 1px solid var(--color-border-subtle);
+  }
+
+  .comparison-table td::before {
+    content: attr(data-label);
+    font-weight: var(--weight-medium);
+    font-size: var(--text-xs);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--color-text-muted-docs);
+    flex-shrink: 0;
+    margin-right: var(--space-3);
+  }
+
+  .comparison-table td:last-child { border-bottom: none; }
+
+  .comparison-table th[scope="row"] {
+    display: block;
+    font-size: var(--text-md);
+    border-bottom: 1px solid var(--color-border);
+    padding: 0 0 var(--space-3);
+    margin-bottom: var(--space-2);
+    white-space: normal;
+  }
+}

--- a/site/css/docs.css
+++ b/site/css/docs.css
@@ -516,7 +516,7 @@ pre:focus-within .copy-btn {
 
 /* ------------------------------------------------------------------ */
 /* Comparison table                                                     */
-/* Sync note: equivalent mobile card-stack pattern in landing.css       */
+/* Similar card-stack pattern in landing.css -- contexts differ, do not merge */
 /* ------------------------------------------------------------------ */
 
 .comparison-table-wrapper {
@@ -567,7 +567,7 @@ pre:focus-within .copy-btn {
 }
 
 /* Mobile card-stack */
-/* Sync note: equivalent pattern in landing/public/css/landing.css */
+/* Similar pattern in landing/public/css/landing.css -- contexts differ, do not merge */
 @media (max-width: 767px) {
   .comparison-table-wrapper {
     margin: var(--space-6) 0;


### PR DESCRIPTION
## Summary

- Adds a **"What You Get" feature list** section to the landing page: 10 capabilities in two groups (Evidence Integrity + Developer Experience), responsive grid (1→2→5 columns)
- Adds a **summary comparison table** to the landing page: WRL vs 4 competitors (Wayback Machine, PageFreezer, Webrecorder, Manual + Notarization) across 4 key differentiators
- Adds a **full comparison page** (`/compare/`) on the docs site: 9 competitors × 7 columns with per-competitor notes and methodology disclosure
- Mobile-responsive card-stack pattern for both tables (CSS-only, no JS)
- Expanded JSON-LD structured data (15 features, applicationSubCategory, offers)
- "Features" nav link added to landing page header

## Files changed

| File | Change |
|------|--------|
| `landing/public/index.html` | Feature list section, summary comparison table, nav link, JSON-LD |
| `landing/public/css/landing.css` | Feature grid, comparison table, mobile card-stack styles |
| `site/content/compare.njk` | **New**: Full 9-competitor comparison page |
| `site/css/docs.css` | Comparison table styles with mobile card-stack |
| `site/_data/site.js` | Added "Compare" to docs nav |

## Test plan

- [ ] Verify landing page feature list renders correctly at mobile/tablet/desktop
- [ ] Verify landing summary comparison table renders as card-stack on mobile
- [ ] Verify docs `/compare/` page loads with all 9 competitor rows
- [ ] Verify docs comparison table card-stack on mobile
- [ ] Verify "Features" nav link scrolls to features section
- [ ] Verify cross-links between landing and docs comparison pages
- [ ] Screen reader check: table headers, row headers, sr-only caption

Resolves #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)
