### PR TITLE
feat(verify): add --legal flag for court-admissible reports

### DIFF
--- a/docs/evolution/0092-legal-flag-verify-cli/decisions.md
+++ b/docs/evolution/0092-legal-flag-verify-cli/decisions.md
@@ -1,0 +1,104 @@
+# Decisions: --legal flag for verify CLI
+
+## Separate module vs extending format.js
+
+**Decision**: Created `format-legal.js` as a standalone module rather than
+adding to `format.js`.
+
+**Rationale**: Legal output has fundamentally different characteristics from
+the existing formatters: no ANSI codes (structural, not flag-based), no
+timestamp merging (timestamps shown individually), untruncated values, and
+a 7-section document structure. Extending `format.js` would require either
+heavy conditional branching or a shared-but-incompatible code path.
+devx-minion and security-minion both recommended separation.
+
+**Alternative considered**: Adding a `legal` parameter to `formatHuman()`.
+Rejected because the output share almost no formatting code — different
+structure, different content, different presentation rules.
+
+## Report structure: 7 sections modeled on forensic declarations
+
+**Decision**: Structured the report as a 7-section document:
+1. Summary, 2. Subject of Verification, 3. Verification Checks Performed,
+4. Chain of Custody, 5. Applicable Legal Standards, 6. Methodology,
+7. Full Technical Details.
+
+**Rationale**: user-docs-minion proposed this based on forensic expert
+declaration formats. Each section serves a specific evidentiary purpose.
+The structure was validated by security-minion who confirmed it covers
+the chain of custody and trust model requirements.
+
+## Factual assertions only — no legal conclusions
+
+**Decision**: The report describes what was verified and what the results
+were, but never claims the evidence "is admissible" or "proves" anything.
+Legal references cite FRE 901(b)(9) and eIDAS Art. 41 with factual
+descriptions of what those frameworks provide.
+
+**Rationale**: The issue explicitly required "without claiming
+admissibility." security-minion reinforced this — claiming admissibility
+would be practicing law and could undermine the report's credibility.
+A disclaimer at the end of Section 5 defers admissibility determination
+to the court.
+
+## Timestamps shown separately (not merged)
+
+**Decision**: In legal mode, `timestamp` and `qualifiedTimestamp` checks
+are shown as separate subsections in Section 3, unlike `formatHuman` which
+merges them into a single "Time verification" row.
+
+**Rationale**: Legal proceedings require distinguishing RFC 3161 standard
+timestamps from eIDAS qualified timestamps because they carry different
+legal weight. The merging done in `formatHuman` is a UX simplification
+that would hide legally significant distinctions.
+
+## Trust model warning leads Section 1 for embedded keys
+
+**Decision**: When `--trust-embedded` is used, the SELF-ASSERTED warning
+is the first thing in Section 1 (before the pass/fail summary) and is
+repeated in Section 7 next to the embedded public key value.
+
+**Rationale**: security-minion argued that trust model must lead the
+report when embedded keys are used, not be buried. The warning is repeated
+in Section 7 because someone reading technical details needs the context
+without scrolling back.
+
+## Reproducibility command built from result, not process.argv
+
+**Decision**: The reproducibility command in Section 6 is reconstructed
+from the verification result object, not from `process.argv`.
+
+**Rationale**: security-minion identified that `process.argv` could leak
+local filesystem paths (e.g., `--key-file /Users/alice/.ssh/wrl-key`).
+Building from the result object ensures only the source, key resolution
+method, and origin appear in the command. A note about `--trust-root`
+was added since those paths can't be inferred from the result.
+
+## Shell quoting in reproducibility command
+
+**Decision**: Source paths and origin URLs in the reproducibility command
+are wrapped in single quotes with proper escaping.
+
+**Rationale**: Code review identified that filenames with spaces would
+produce a broken command in a document whose purpose is reproducibility.
+Added `shellQuote()` helper.
+
+## Report format version (WRL-LEGAL-1.0)
+
+**Decision**: Include a format version string in both text and JSON output.
+
+**Rationale**: devx-minion proposed this. Legal reports submitted in
+proceedings may need to be cross-referenced with the report format. If the
+format changes, the version allows distinguishing which format produced
+a given report. This is one constant, not a versioning framework.
+
+## Summary count scoped to Section 3 checks
+
+**Decision**: The "All N checks passed" count in Section 1 uses only
+checks that appear in Section 3 (the `checkOrder` list).
+
+**Rationale**: Code review identified that if a future check type were
+added to the verifier but not to `checkOrder`, the summary would count
+more checks than Section 3 displays. In a legal document, a numerical
+discrepancy between the executive summary and the evidence section is
+a factual inconsistency.

--- a/docs/evolution/0092-legal-flag-verify-cli/outcome.md
+++ b/docs/evolution/0092-legal-flag-verify-cli/outcome.md
@@ -1,0 +1,66 @@
+# Outcome: --legal flag for verify CLI
+
+## What was built
+
+Added `--legal` flag to `@w-r-l/verify` CLI that produces comprehensive,
+plain-language verification reports suitable for submission in legal
+proceedings. Two output modes:
+
+- `--legal` produces a 7-section plain-text report (no ANSI codes)
+- `--legal --json` produces machine-readable JSON with enriched explanations
+
+### Files created
+- `packages/verify/lib/format-legal.js` (~720 lines) — formatLegal() and formatLegalJson()
+- `packages/verify/test/format-legal.test.js` (~500 lines) — 82 structural tests
+
+### Files modified
+- `packages/verify/lib/cli.js` — --legal flag parsing, 3-way format routing
+- `packages/verify/lib/format.js` — exported checkLabel() and CHECK_LABELS
+- `packages/verify/test/cli-args.test.js` — --legal parseArgs tests
+- `packages/verify/README.md` — --legal flag documentation
+- `site/content/verification.md` — legal report section
+- `site/content/legal-evidence.md` — legal evidence guide section
+
+### Test results
+- 230 total tests, 0 failures
+- 82 new tests for format-legal.js (14 suites)
+- 3 new tests in cli-args.test.js
+
+## Success criteria verification
+
+| Criterion | Status |
+|-----------|--------|
+| `--legal` produces structured report with 7 sections | Done |
+| Language precise but accessible to legal professionals | Done — inline explanations for all crypto terms |
+| All values untruncated | Done — Section 7 shows full hashes, signatures, key IDs |
+| Distinguishes RFC 3161 vs eIDAS qualified timestamps | Done — separate subsections with legal weight explanation |
+| `--legal --json` variant | Done — enriched JSON with explanations, legal context |
+| Default output unchanged | Done — existing formatHuman/formatJson paths untouched |
+| No ANSI codes in --legal mode | Done — structural (no ANSI helpers imported) |
+| References FRE 901(b)(9) and eIDAS Art. 41 | Done — factual citations, no admissibility claims |
+
+## Surface consistency
+
+| Surface | Action |
+|---------|--------|
+| OpenAPI spec | No update needed — --legal is CLI-only, not an API endpoint |
+| Docs site | Updated — verification.md and legal-evidence.md |
+| Landing page | No update needed — no pricing/tier changes |
+| MCP server | No update needed — no new API endpoints |
+| Legal pages | No update needed — no new data collection or services |
+
+## Backlog changes
+
+No backlog changes. Issue #166 was not in the backlog (it was a direct
+feature request). No items were deferred or created.
+
+## Deviations from plan
+
+1. Code review identified shell-quoting issue in reproducibility command —
+   fixed by adding `shellQuote()` helper
+2. Code review identified summary count could disagree with Section 3 —
+   fixed by scoping count to `checkOrder`
+3. Unused `CHECK_LABELS` import and dead `legalMode` variable cleaned up
+   during review fixes
+4. Pre-existing `getVersion()` silent catch noted but not fixed (out of
+   scope — pre-existing code, not introduced by this PR)

--- a/docs/evolution/0092-legal-flag-verify-cli/process.md
+++ b/docs/evolution/0092-legal-flag-verify-cli/process.md
@@ -1,0 +1,144 @@
+# Process: --legal flag for verify CLI
+
+**TL;DR**: Four specialists planned a CLI legal report feature in parallel,
+architecture review by five agents caught trust-model positioning and
+regression test gaps, implementation was two tasks by the orchestrator plus
+two delegated (tests + docs), and code review surfaced three fixable issues
+(shell quoting, count scoping, unused imports). 230 tests pass. One PR,
+four commits.
+
+## Phase 1: Meta-plan
+
+Nefario selected six specialists: user-docs-minion, devx-minion,
+security-minion, software-docs-minion, frontend-minion, and
+ux-strategy-minion. Lucy reviewed the team and cut frontend-minion and
+ux-strategy-minion — this is a CLI text output feature, not a UI task.
+Final team: four specialists.
+
+## Phase 2: Specialist planning (4 agents, parallel)
+
+### user-docs-minion
+Proposed the 7-section report structure modeled on forensic expert
+declarations. Key argument: each section serves a specific evidentiary
+purpose (summary for the judge, methodology for opposing counsel's expert,
+full technical details for independent verification). Recommended against
+merging timestamp rows in legal mode — the distinction between standard
+and qualified timestamps is legally significant.
+
+### devx-minion
+Argued for a separate `format-legal.js` module rather than extending
+`format.js`. Reasoning: legal output shares almost no formatting code
+with the existing formatters — different structure, no ANSI, no merging,
+untruncated values. Also proposed the `WRL-LEGAL-1.0` format version and
+3-way routing in `run()`.
+
+### security-minion
+Three key contributions:
+1. Trust model must lead the report when `--trust-embedded` is used (not
+   buried in Section 7). Users reading a legal report need to immediately
+   know the trust level.
+2. Reproducibility command must be built from the result object, not
+   `process.argv`, to avoid leaking local filesystem paths.
+3. Three timestamps must be clearly distinguished: capture time
+   (self-asserted), TSA time (independent), verification time (report
+   generation). Each has different evidentiary weight.
+
+### software-docs-minion
+Scoped documentation to README update, verification.md section, and
+legal-evidence.md section. Explicitly rejected standalone spec file and
+openapi.yaml changes (no new API endpoints).
+
+## Phase 3: Synthesis
+
+No conflicts between specialists — their recommendations were complementary.
+The synthesis produced a 4-task execution plan:
+1. CLI integration (--legal flag, argument parsing, routing)
+2. format-legal.js (formatLegal + formatLegalJson)
+3. Tests (format-legal.test.js)
+4. Documentation (README, verification.md, legal-evidence.md)
+
+Tasks 1-2 had a gate after Task 2 (legal report text is load-bearing for
+credibility). Tasks 3-4 were parallelizable after the gate.
+
+## Phase 3.5: Architecture review (5 reviewers)
+
+Five mandatory reviewers: security-minion, test-minion, ux-strategy-minion,
+lucy, margo.
+
+- **security-minion**: ADVISE — credential-bearing URLs must be stripped
+  from reproducibility command, key-file paths shouldn't leak. Both
+  addressed by building command from result object.
+- **test-minion**: ADVISE — positional assertion needed for embedded
+  warning (should appear before Section 2, not just anywhere), CLI routing
+  subprocess test needed.
+- **ux-strategy-minion**: APPROVE — report structure maps well to legal
+  professional mental model.
+- **lucy**: APPROVE — requirements fully traceable.
+- **margo**: APPROVE with note — WRL-LEGAL-1.0 version constant is the
+  minimum needed, not a versioning framework.
+
+## Phase 4: Execution
+
+Tasks 1-2 were implemented directly by the orchestrator (not delegated)
+because they required careful prose authoring for legal accuracy. The
+orchestrator wrote ~720 lines of format-legal.js with the EXPLANATIONS
+constant containing per-check `what`, `pass`, `fail`, `skip`, and
+`significance` text.
+
+### Task 2 gate — Lucy reviewed
+Lucy traced all 8 success criteria to specific code sections. Verdict:
+ADVISE with 3 minor findings:
+1. Unused `CHECK_LABELS` import
+2. Dead `legalMode` variable in cli.js
+3. Reproducibility command missing `--trust-root` note
+
+All three fixed before proceeding.
+
+### Tasks 3-4 (parallel)
+- test-minion wrote 82 tests across 14 suites covering structural
+  assertions, no-ANSI invariant, untruncated values, timestamp separation,
+  trust model visibility, legal references, graceful degradation, JSON
+  schema, and reproducibility note.
+- user-docs-minion updated README.md, verification.md, and
+  legal-evidence.md.
+
+## Post-execution
+
+### Code review (code-review-minion)
+Found 4 issues:
+1. **Shell quoting** (blocking): Reproducibility command not safe for
+   filenames with spaces. Fixed with `shellQuote()`.
+2. **getVersion() silent catch** (blocking per convention): Pre-existing
+   code, not introduced by this PR. Left unfixed (scope creep).
+3. **Summary count mismatch** (blocking): Summary counted all checks but
+   Section 3 only showed checks in `checkOrder`. Fixed by filtering.
+4. **Missing --legal in cli-args.test.js** (blocking): Every other boolean
+   flag had tests. Added 3 tests.
+
+Also noted: duplicate `publicKey` in JSON output (captured in both
+`capture.embeddedPublicKey` and `keyResolution.publicKey`). This is
+intentional — `capture` holds the raw value, `keyResolution` holds it
+with trust context.
+
+### Test execution
+230 tests, 0 failures. The 82 new format-legal tests all pass, and no
+existing tests regressed.
+
+### Documentation
+Updated in Task 4. Surface consistency check confirmed no other surfaces
+needed updating (OpenAPI, landing page, MCP server, legal pages all
+unaffected by a CLI-only feature).
+
+## What I'd do differently
+
+The `getVersion()` silent catch is a pre-existing convention violation
+that code review correctly flagged. It's technically out of scope for
+this PR, but it feeds directly into the legal report's version field.
+If `package.json` is missing, the report will show version `0.0.0`,
+which undermines reproducibility. A follow-up should fix this.
+
+## Where to read more
+
+- Specialist contributions: scratch files in the nefario report
+- Architecture review: phase 3.5 scratch files
+- Code review findings: commit `9ec90c3` addresses all actionable items

--- a/docs/evolution/0092-legal-flag-verify-cli/prompt.md
+++ b/docs/evolution/0092-legal-flag-verify-cli/prompt.md
@@ -1,0 +1,15 @@
+The `@w-r-l/verify` CLI can produce a comprehensive, plain-language verification report suitable for submission in legal proceedings. When a paralegal, attorney, or forensic examiner runs verification with this flag, the output explains not just the pass/fail results but *what was verified, how, and why the result is trustworthy* — in terms a judge or opposing counsel can follow without cryptographic expertise.
+
+Source: GitHub issue #166
+
+Success criteria:
+- `npx @w-r-l/verify --legal <url>` produces a structured report
+- Report language is precise but accessible to legal professionals
+- All hash values, key identifiers, timestamps, TSA details untruncated
+- Distinguishes standard RFC 3161 vs eIDAS qualified timestamps
+- `--legal --json` variant produces machine-readable output
+- Default output unchanged
+
+Constraints:
+- No ANSI codes in --legal mode
+- Reference FRE 901(b)(9) and eIDAS Art. 41 without claiming admissibility

--- a/docs/evolution/README.md
+++ b/docs/evolution/README.md
@@ -100,3 +100,4 @@ software development.
 | [0089-landing-legal-section-ordering](0089-landing-legal-section-ordering/) | Landing page section reorder: Use Cases above How It Works, trust bar rejected, legal claims stay in use case card (Issue #207) |
 | [0090-feature-list-competitor-comparison](0090-feature-list-competitor-comparison/) | Feature list and competitor comparison table on landing page and docs site (Issue #144) |
 | [0091-seo-geo-optimization](0091-seo-geo-optimization/) | SEO + GEO optimization for landing page and docs site — structured data, FAQ, sitemaps, llms.txt (Issue #215) |
+| [0092-legal-flag-verify-cli](0092-legal-flag-verify-cli/) | --legal flag for verify CLI: 7-section plain-text and JSON legal reports with FRE 901(b)(9) and eIDAS Art. 41 references (Issue #166) |

--- a/packages/verify/README.md
+++ b/packages/verify/README.md
@@ -63,6 +63,27 @@ npx @w-r-l/verify capture.wacz --trust-embedded
 
 Uses the key embedded in the WACZ. This proves the archive is internally consistent, but not that it came from a trusted operator.
 
+### Legal report
+
+```bash
+npx @w-r-l/verify capture.wacz --origin https://api.webresourceledger.com --legal
+```
+
+Produces a structured plain-text report designed for use in legal proceedings or formal documentation. No ANSI color codes are written -- the output is safe to redirect to a file or attach as a document.
+
+The report is organized into seven sections: a plain-language summary, a description of the subject (captured URL, capture time), per-check explanations in non-technical terms, a chain of custody narrative, applicable legal standards (FRE 901(b)(9) and eIDAS Art. 41), a methodology description, and full technical details with untruncated cryptographic values. The format version is WRL-LEGAL-1.0, which appears in the report header.
+
+Standard and qualified timestamps are reported separately when both are present. A standard RFC 3161 timestamp (DigiCert) is included for every capture. An eIDAS-qualified timestamp appears only when the capturing account has opted into a qualified Trust Service Provider; the report identifies which tier applies and what legal weight it carries.
+
+```bash
+# Machine-readable version of the same report
+npx @w-r-l/verify capture.wacz --origin https://api.webresourceledger.com --legal --json
+```
+
+`--legal --json` produces a JSON object with the same seven sections as structured fields. All cryptographic values are untruncated in both output modes.
+
+For a full explanation of the legal context and frameworks the report references, see the [Legal Evidence guide](https://webresourceledger.com/legal-evidence/).
+
 ### JSON output
 
 ```bash
@@ -121,6 +142,7 @@ The tool bundles the DigiCert Trusted Root G4 certificate. Use `--trust-root` to
 --key-file <path>    Read public key from file
 --trust-embedded     Use the embedded key (insecure)
 --trust-root <path>  Additional trusted root certificate (PEM)
+--legal              Produce a structured plain-text legal report (WRL-LEGAL-1.0)
 --json               Output machine-readable JSON to stdout
 --no-color           Disable colored output
 -h, --help           Show this help message
@@ -128,6 +150,8 @@ The tool bundles the DigiCert Trusted Root G4 certificate. Use `--trust-root` to
 ```
 
 `--origin`, `--key`, `--key-file`, and `--trust-embedded` are mutually exclusive.
+
+`--legal` can be combined with `--json` for a machine-readable version of the same report. `--legal` implies `--no-color` -- ANSI codes are never written in legal mode.
 
 ## Requirements
 

--- a/packages/verify/lib/cli.js
+++ b/packages/verify/lib/cli.js
@@ -21,6 +21,7 @@ import { dirname, join } from 'node:path';
 import { verifyWacz } from './verify.js';
 import { loadTrustedRoots } from './cms-verify.js';
 import { formatHuman, formatJson, formatJsonError } from './format.js';
+import { formatLegal, formatLegalJson } from './format-legal.js';
 import {
   resolveKey,
   isWrlCaptureUrl,
@@ -51,6 +52,7 @@ OPTIONS
   --trust-embedded     Use the embedded key (insecure, see below)
   --trust-root <path>  Additional trusted root certificate (PEM)
   --json               Output machine-readable JSON to stdout
+  --legal              Detailed verification report for legal proceedings
   --no-color           Disable colored output
   -h, --help           Show this help message
   --version            Show version number
@@ -84,6 +86,7 @@ TRUST MODEL
  *   trustEmbedded: boolean,
  *   trustRoots: string[],
  *   json: boolean,
+ *   legal: boolean,
  *   noColor: boolean,
  *   help: boolean,
  *   version: boolean,
@@ -99,13 +102,14 @@ export function parseArgs(argv) {
     trustEmbedded: false,
     trustRoots:    [],
     json:          false,
+    legal:         false,
     noColor:       false,
     help:          false,
     version:       false,
   };
 
   const VALUE_FLAGS = new Set(['--origin', '--key', '--key-file', '--trust-root']);
-  const BOOL_FLAGS  = new Set(['--trust-embedded', '--json', '--no-color', '-h', '--help', '--version']);
+  const BOOL_FLAGS  = new Set(['--trust-embedded', '--json', '--legal', '--no-color', '-h', '--help', '--version']);
 
   let i = 0;
   while (i < argv.length) {
@@ -131,6 +135,12 @@ export function parseArgs(argv) {
 
     if (arg === '--json') {
       opts.json = true;
+      i++;
+      continue;
+    }
+
+    if (arg === '--legal') {
+      opts.legal = true;
       i++;
       continue;
     }
@@ -397,7 +407,13 @@ export async function run(argv) {
     // -----------------------------------------------------------------------
     // Format and output
     // -----------------------------------------------------------------------
-    if (opts.json) {
+    if (opts.legal) {
+      if (opts.json) {
+        formatLegalJson(result, { version: getVersion() });
+      } else {
+        formatLegal(result, { version: getVersion() });
+      }
+    } else if (opts.json) {
       formatJson(result);
     } else {
       formatHuman(result, { noColor: opts.noColor });

--- a/packages/verify/lib/format-legal.js
+++ b/packages/verify/lib/format-legal.js
@@ -168,6 +168,10 @@ const ALGORITHMS = [
 const LINE = '---------------------------------------------------------------------------';
 const DOUBLE = '===========================================================================';
 
+function shellQuote(s) {
+  return "'" + String(s ?? '').replace(/'/g, "'\\''") + "'";
+}
+
 function toolLine(version) {
   return `@w-r-l/verify ${version} (Node.js ${process.versions.node}, ` +
     `${process.platform} ${process.arch})`;
@@ -236,8 +240,20 @@ export function formatLegal(result, opts = {}) {
   }
 
   const checks = result.checks ?? [];
-  const applicable = checks.filter(c => c.status !== 'skip');
-  const passed = applicable.filter(c => c.status === 'pass');
+
+  // Display order for legal report -- all checks shown individually
+  const checkOrder = [
+    'artifactHashes',
+    'bundleHash',
+    'signature',
+    'timestamp',
+    'qualifiedTimestamp',
+    'timestampChain',
+  ];
+
+  // Summary counts use only checks that appear in Section 3
+  const reportedChecks = checks.filter(c => checkOrder.includes(c.name));
+  const applicable = reportedChecks.filter(c => c.status !== 'skip');
   const failed = applicable.filter(c => c.status === 'fail');
 
   if (failed.length === 0) {
@@ -285,16 +301,6 @@ export function formatLegal(result, opts = {}) {
   out.push('3. VERIFICATION CHECKS PERFORMED');
   out.push(LINE);
   out.push('');
-
-  // Display order for legal report -- all checks shown individually
-  const checkOrder = [
-    'artifactHashes',
-    'bundleHash',
-    'signature',
-    'timestamp',
-    'qualifiedTimestamp',
-    'timestampChain',
-  ];
 
   let subNum = 1;
   for (const name of checkOrder) {
@@ -482,9 +488,9 @@ export function formatLegal(result, opts = {}) {
   ));
   out.push('');
   // Build command from result, not process.argv (security: avoid leaking paths)
-  let cmd = `  npx @w-r-l/verify@${version} ${result.source ?? '<file-or-url>'}`;
+  let cmd = `  npx @w-r-l/verify@${version} ${shellQuote(result.source ?? '<file-or-url>')}`;
   if (kr?.source === 'origin' && kr.origin) {
-    cmd += ` --origin ${kr.origin}`;
+    cmd += ` --origin ${shellQuote(kr.origin)}`;
   } else if (kr?.source === 'embedded') {
     cmd += ' --trust-embedded';
   }

--- a/packages/verify/lib/format-legal.js
+++ b/packages/verify/lib/format-legal.js
@@ -1,0 +1,715 @@
+/**
+ * format-legal.js -- Legal verification report formatters for wrl-verify.
+ *
+ * Produces comprehensive, plain-language verification reports suitable for
+ * submission in legal proceedings. No ANSI codes. All values untruncated.
+ * Timestamps shown separately (not merged like formatHuman).
+ *
+ * Two output modes:
+ *   formatLegal()     -- structured plain text for terminal/file
+ *   formatLegalJson() -- machine-readable JSON for document assembly
+ */ // tva
+
+import { checkLabel } from './format.js';
+
+// ---------------------------------------------------------------------------
+// Report format version -- bumped when report structure changes
+// ---------------------------------------------------------------------------
+
+const REPORT_FORMAT = 'WRL-LEGAL-1.0';
+
+// ---------------------------------------------------------------------------
+// Explanatory content constants
+// ---------------------------------------------------------------------------
+
+const EXPLANATIONS = {
+  artifactHashes: {
+    what: 'Each file within the web archive was independently verified by ' +
+      'recomputing its SHA-256 hash (a cryptographic fingerprint standardized ' +
+      'by NIST in FIPS 180-4) and comparing it to the hash recorded in the ' +
+      'archive manifest.',
+    pass: 'All files within the archive match their recorded hashes. No ' +
+      'file has been added, removed, or modified since the archive was created.',
+    fail: 'One or more files within the archive do not match their recorded ' +
+      'hashes. The archive contents may have been modified after creation.',
+    skip: 'File integrity verification was not applicable for this archive.',
+    significance: 'Establishes that the individual captured resources ' +
+      '(HTML pages, images, scripts) are identical to those recorded at ' +
+      'capture time.',
+  },
+  bundleHash: {
+    what: 'The archive manifest (a JSON document listing all captured ' +
+      'resources and their properties) was re-serialized using canonical ' +
+      'JSON encoding, and its SHA-256 hash was compared to the hash ' +
+      'recorded in the signed digest.',
+    pass: 'The manifest hash matches. The list of captured resources and ' +
+      'their metadata have not been altered.',
+    fail: 'The manifest hash does not match. The archive metadata may ' +
+      'have been modified after signing.',
+    skip: 'Bundle integrity verification was not applicable.',
+    significance: 'Establishes that the archive metadata (resource list, ' +
+      'file sizes, individual hashes) is identical to what was originally signed.',
+  },
+  signature: {
+    what: 'The digital signature on the archive was verified using Ed25519 ' +
+      '(an elliptic-curve signature algorithm standardized in RFC 8032). ' +
+      'The signature covers the bundle hash, binding the archive contents ' +
+      'to the signing key.',
+    pass: 'The digital signature is valid. The archive was signed by the ' +
+      'holder of the corresponding private key, and the signed content has ' +
+      'not been modified.',
+    fail: 'The digital signature is invalid. Either the archive contents ' +
+      'have been modified after signing, or the wrong verification key was used.',
+    skip: 'Digital signature verification was not applicable.',
+    significance: 'Establishes that a specific party (identified by their ' +
+      'signing key) attested to the archive contents at the time of signing.',
+  },
+  timestamp: {
+    what: 'An independent timestamp was obtained from a Time Stamping ' +
+      'Authority (TSA) at the time of capture, using the RFC 3161 protocol. ' +
+      'The TSA signed a timestamp token containing the bundle hash and the ' +
+      'current time, providing independent evidence of when the archive existed.',
+    pass: 'The RFC 3161 timestamp is valid. The bundle hash embedded in ' +
+      'the timestamp token matches the archive, confirming the archive ' +
+      'existed at the recorded time.',
+    fail: 'The RFC 3161 timestamp verification failed. The timestamp may ' +
+      'be corrupt or may not correspond to this archive.',
+    skip: 'No independent timestamp was obtained for this capture. The ' +
+      'TSA may have been unreachable at capture time.',
+    significance: 'Provides independent, third-party evidence of the date ' +
+      'and time at which the archive existed in its current form. Unlike the ' +
+      'capture service\'s self-asserted creation time, this timestamp comes ' +
+      'from an independent authority.',
+  },
+  qualifiedTimestamp: {
+    what: 'A qualified electronic timestamp was obtained from a Qualified ' +
+      'Trust Service Provider (QTSP) under the eIDAS Regulation (EU) ' +
+      'No 910/2014. Qualified timestamps carry additional legal significance ' +
+      'beyond standard RFC 3161 timestamps.',
+    pass: 'The qualified timestamp is valid. The bundle hash embedded in ' +
+      'the timestamp token matches the archive.',
+    fail: 'The qualified timestamp verification failed structurally.',
+    skip: 'No qualified timestamp was requested or obtained for this capture.',
+    significance: 'Under eIDAS Regulation (EU) No 910/2014, Article 41(2), ' +
+      'a qualified electronic timestamp enjoys a presumption of accuracy of ' +
+      'the date and time it indicates, and of the integrity of the data to ' +
+      'which the date and time are bound. This presumption is rebuttable but ' +
+      'shifts the burden of proof.',
+  },
+  timestampChain: {
+    what: 'The TSA certificate chain was validated against trusted root ' +
+      'certificates using CMS/PKCS#7 (RFC 5652) signature verification. ' +
+      'This confirms the timestamp was issued by a legitimate TSA whose ' +
+      'identity can be traced to a known certificate authority.',
+    pass: 'The TSA certificate chain is valid. The timestamp was issued ' +
+      'by a TSA whose certificate chains to a trusted root.',
+    fail: 'The TSA certificate chain could not be validated.',
+    skip: 'Certificate chain verification was not performed. No trusted ' +
+      'root certificates were provided for chain validation.',
+    significance: 'Establishes the identity and legitimacy of the Time ' +
+      'Stamping Authority that issued the timestamp.',
+  },
+};
+
+const TRUST_MODELS = {
+  embedded:
+    'TRUST LEVEL: SELF-ASSERTED (LIMITED)\n\n' +
+    'This verification used the signing key embedded within the archive\n' +
+    'itself. This confirms the archive\'s contents have not been modified\n' +
+    'since they were last signed, but it does not establish who performed\n' +
+    'the signing or whether the archive originated from a trusted source.\n' +
+    'A party who modifies the archive could also replace the embedded key\n' +
+    'and re-sign it.',
+  origin:
+    'The signing key was retrieved from the capture service operator\'s\n' +
+    'HTTPS endpoint. This establishes that the operator published this\n' +
+    'key as their signing key at the time of verification. The trust in\n' +
+    'this verification depends on the authenticity of the operator\'s\n' +
+    'HTTPS endpoint and the integrity of the TLS connection used to\n' +
+    'retrieve the key.',
+  pinned:
+    'The signing key was provided directly by the verifier. The trust\n' +
+    'in this verification depends on the verifier\'s confidence that\n' +
+    'this key belongs to the expected signing party.',
+};
+
+const LEGAL_DISCLAIMER =
+  'This report is a technical verification document. It does not\n' +
+  'constitute legal advice. The admissibility of this evidence and\n' +
+  'the legal weight of the verification results are matters for\n' +
+  'determination by the relevant court or tribunal.';
+
+const LIMITATIONS = [
+  'This tool verifies cryptographic integrity only. It does not ' +
+    'verify the accuracy, legality, or completeness of the captured ' +
+    'web content itself.',
+  'CRL/OCSP certificate revocation checking is not performed. This ' +
+    'tool is designed for offline verification where network access to ' +
+    'revocation services may be unavailable.',
+  'This tool does not independently verify a TSA\'s eIDAS ' +
+    'qualification status against the EU Trusted List. The ' +
+    'qualification of a timestamp service provider should be ' +
+    'confirmed through official channels.',
+  'Cryptographic verification is deterministic: the same archive ' +
+    'and signing key will always produce the same verification result.',
+];
+
+const ALGORITHMS = [
+  { name: 'SHA-256', standard: 'FIPS 180-4 (NIST)', purpose: 'Hash computation for file and bundle integrity' },
+  { name: 'Ed25519', standard: 'RFC 8032', purpose: 'Digital signature verification' },
+  { name: 'RFC 3161', standard: 'RFC 3161 (IETF)', purpose: 'Timestamp token verification' },
+  { name: 'CMS/PKCS#7', standard: 'RFC 5652', purpose: 'Timestamp certificate chain validation' },
+];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const LINE = '---------------------------------------------------------------------------';
+const DOUBLE = '===========================================================================';
+
+function toolLine(version) {
+  return `@w-r-l/verify ${version} (Node.js ${process.versions.node}, ` +
+    `${process.platform} ${process.arch})`;
+}
+
+function wrap(text, indent = 0, width = 78) {
+  const prefix = ' '.repeat(indent);
+  const maxLen = width - indent;
+  const words = text.split(/\s+/);
+  const lines = [];
+  let current = '';
+  for (const word of words) {
+    if (current.length + 1 + word.length > maxLen && current.length > 0) {
+      lines.push(prefix + current);
+      current = word;
+    } else {
+      current = current ? current + ' ' + word : word;
+    }
+  }
+  if (current) lines.push(prefix + current);
+  return lines.join('\n');
+}
+
+function statusLabel(status) {
+  if (status === 'pass') return 'PASSED';
+  if (status === 'fail') return 'FAILED';
+  return 'NOT APPLICABLE';
+}
+
+// ---------------------------------------------------------------------------
+// formatLegal -- Plain-text legal report
+// ---------------------------------------------------------------------------
+
+/**
+ * Formats a verification result as a comprehensive plain-text legal report.
+ * No ANSI codes. All values untruncated. Timestamps shown separately.
+ *
+ * @param {object} result  The verification result from verifyWacz()
+ * @param {{ version: string }} opts  Options including tool version
+ */
+export function formatLegal(result, opts = {}) {
+  const out = [];
+  const version = opts.version ?? '0.0.0';
+  const verifiedAt = new Date().toISOString();
+
+  // Header
+  out.push(DOUBLE);
+  out.push('VERIFICATION REPORT: WEB RESOURCE CAPTURE');
+  out.push(DOUBLE);
+  out.push('');
+  out.push(`Format:    ${REPORT_FORMAT}`);
+  out.push(`Generated: ${verifiedAt}`);
+  out.push(`Tool:      ${toolLine(version)}`);
+  out.push('');
+
+  // Section 1: Summary
+  out.push('1. SUMMARY');
+  out.push(LINE);
+  out.push('');
+
+  // Trust model warning leads if embedded key
+  const kr = result.keyResolution;
+  if (kr?.source === 'embedded') {
+    out.push(TRUST_MODELS.embedded);
+    out.push('');
+  }
+
+  const checks = result.checks ?? [];
+  const applicable = checks.filter(c => c.status !== 'skip');
+  const passed = applicable.filter(c => c.status === 'pass');
+  const failed = applicable.filter(c => c.status === 'fail');
+
+  if (failed.length === 0) {
+    out.push(wrap(
+      `Result: All ${applicable.length} cryptographic checks passed. ` +
+      'No evidence of modification was detected.'
+    ));
+  } else {
+    out.push(wrap(
+      `Result: ${failed.length} of ${applicable.length} check(s) failed. ` +
+      'This capture cannot be verified as unmodified.'
+    ));
+  }
+  out.push('');
+  out.push(`Source:    ${result.source ?? 'unknown'}`);
+  out.push(`Verified:  ${verifiedAt}`);
+  out.push('');
+
+  // Section 2: Subject of Verification
+  out.push('2. SUBJECT OF VERIFICATION');
+  out.push(LINE);
+  out.push('');
+  out.push(wrap(
+    'A web resource capture is a snapshot of web content (HTML pages, ' +
+    'images, stylesheets, and other resources) preserved in a WACZ ' +
+    '(Web Archive Collection Zipped) archive format. The archive ' +
+    'includes a cryptographic manifest listing each captured resource ' +
+    'and its hash, a digital signature binding the manifest to a ' +
+    'signing key, and optionally one or more timestamps from ' +
+    'independent authorities.'
+  ));
+  out.push('');
+
+  const capture = result.capture ?? {};
+  out.push(`Source:        ${result.source ?? 'unknown'}`);
+  if (capture.signedAt) {
+    out.push(`Created:       ${capture.signedAt}`);
+  }
+  if (capture.bundleHash) {
+    out.push(`Bundle hash:   ${capture.bundleHash}`);
+  }
+  out.push('');
+
+  // Section 3: Verification Checks Performed
+  out.push('3. VERIFICATION CHECKS PERFORMED');
+  out.push(LINE);
+  out.push('');
+
+  // Display order for legal report -- all checks shown individually
+  const checkOrder = [
+    'artifactHashes',
+    'bundleHash',
+    'signature',
+    'timestamp',
+    'qualifiedTimestamp',
+    'timestampChain',
+  ];
+
+  let subNum = 1;
+  for (const name of checkOrder) {
+    const check = checks.find(c => c.name === name);
+    if (!check) continue;
+
+    const label = checkLabel(name);
+    const expl = EXPLANATIONS[name];
+
+    out.push(`3.${subNum} ${label}`);
+    out.push('');
+    out.push(`Status: ${statusLabel(check.status)}`);
+    out.push('');
+
+    if (expl) {
+      out.push(wrap(expl.what));
+      out.push('');
+
+      if (check.status === 'pass') {
+        out.push(wrap(expl.pass));
+      } else if (check.status === 'fail') {
+        out.push(wrap(expl.fail));
+        if (check.detail) {
+          out.push('');
+          out.push(wrap(`Detail: ${check.detail}`));
+        }
+      } else {
+        out.push(wrap(expl.skip));
+        if (check.detail) {
+          out.push('');
+          out.push(wrap(`Detail: ${check.detail}`));
+        }
+      }
+      out.push('');
+      out.push(wrap(`Evidentiary significance: ${expl.significance}`));
+    }
+    out.push('');
+
+    // Timestamp-specific details
+    if (name === 'timestamp' && capture.timestamp) {
+      out.push(`  TSA:      ${capture.timestamp.tsa}`);
+      out.push(`  Time:     ${capture.timestamp.genTime}`);
+      out.push('');
+    }
+    if (name === 'qualifiedTimestamp' && capture.qualifiedTimestamp) {
+      out.push(`  QTSA:     ${capture.qualifiedTimestamp.tsa}`);
+      out.push(`  Time:     ${capture.qualifiedTimestamp.genTime}`);
+      out.push('');
+      out.push(wrap(
+        'A standard RFC 3161 timestamp provides cryptographic evidence of ' +
+        'time from an independent authority. A qualified electronic ' +
+        'timestamp additionally carries a legal presumption under eIDAS ' +
+        'Regulation (EU) No 910/2014, Article 41(2), that the date, time, ' +
+        'and data integrity are accurate until proven otherwise.'
+      ));
+      out.push('');
+    }
+
+    subNum++;
+  }
+
+  // Section 4: Chain of Custody
+  out.push('4. CHAIN OF CUSTODY');
+  out.push(LINE);
+  out.push('');
+  out.push(wrap(
+    `The archive was obtained from: ${result.source ?? 'unknown'}`
+  ));
+  out.push('');
+
+  if (kr) {
+    if (kr.source === 'origin' && kr.origin) {
+      out.push(wrap(
+        `The signing key (ID: ${kr.keyId ?? 'unknown'}) was retrieved ` +
+        `from the capture service operator's HTTPS endpoint at ` +
+        `${kr.origin}. The key retrieval was performed over an ` +
+        'encrypted TLS connection.'
+      ));
+    } else if (kr.source === 'embedded') {
+      out.push(wrap(
+        `The signing key (ID: ${kr.keyId ?? 'unknown'}) was extracted ` +
+        'from the archive itself (embedded key). See the trust level ' +
+        'warning in Section 1.'
+      ));
+    } else if (kr.source === 'pinned') {
+      out.push(wrap(
+        `The signing key (ID: ${kr.keyId ?? 'unknown'}) was provided ` +
+        'directly by the party performing this verification.'
+      ));
+    }
+    out.push('');
+  }
+
+  out.push(wrap(
+    'Verification was performed locally on the machine identified in ' +
+    'the Methodology section. No data was transmitted to external ' +
+    'services during verification.'
+  ));
+  out.push('');
+  out.push(wrap(
+    'This report is plain text and is not itself digitally signed. ' +
+    'The integrity of the verification results can be confirmed by ' +
+    're-running the verification using the instructions in the ' +
+    'Methodology section.'
+  ));
+  out.push('');
+
+  // Section 5: Applicable Legal Standards
+  out.push('5. APPLICABLE LEGAL STANDARDS');
+  out.push(LINE);
+  out.push('');
+  out.push(wrap(
+    'United States -- Federal Rule of Evidence 901(b)(9): This rule ' +
+    'provides for authentication of evidence through "evidence ' +
+    'describing a process or system and showing that it produces an ' +
+    'accurate result." This report is structured to support ' +
+    'authentication under this provision by describing the ' +
+    'verification process, the cryptographic algorithms employed, ' +
+    'and the results obtained.'
+  ));
+  out.push('');
+
+  // eIDAS section -- always present, but qualified timestamp significance
+  // highlighted when one exists
+  const hasQualified = checks.some(
+    c => c.name === 'qualifiedTimestamp' && c.status === 'pass'
+  );
+  out.push(wrap(
+    'European Union -- eIDAS Regulation (EU) No 910/2014: Article 41(1) ' +
+    'provides that an electronic timestamp shall not be denied legal ' +
+    'effect and admissibility as evidence in legal proceedings solely ' +
+    'on the grounds that it is in electronic form or that it does not ' +
+    'meet the requirements of a qualified electronic timestamp.'
+  ));
+  out.push('');
+
+  if (hasQualified) {
+    out.push(wrap(
+      'This capture includes a qualified electronic timestamp. Under ' +
+      'Article 41(2), a qualified electronic timestamp enjoys a ' +
+      'presumption of the accuracy of the date and time it indicates ' +
+      'and of the integrity of the data to which the date and time ' +
+      'are bound.'
+    ));
+    out.push('');
+  }
+
+  out.push(wrap(LEGAL_DISCLAIMER));
+  out.push('');
+
+  // Section 6: Methodology
+  out.push('6. METHODOLOGY');
+  out.push(LINE);
+  out.push('');
+  out.push(`Tool:        @w-r-l/verify`);
+  out.push(`Version:     ${version}`);
+  out.push(`Source:      https://www.npmjs.com/package/@w-r-l/verify`);
+  out.push(`Runtime:     Node.js ${process.versions.node}`);
+  out.push(`Platform:    ${process.platform} ${process.arch}`);
+  out.push('');
+
+  out.push('Cryptographic algorithms:');
+  for (const alg of ALGORITHMS) {
+    out.push(`  ${alg.name.padEnd(12)} ${alg.standard.padEnd(20)} ${alg.purpose}`);
+  }
+  out.push('');
+
+  out.push(wrap(
+    'All cryptographic operations use the Node.js built-in crypto ' +
+    'module (Web Crypto API for Ed25519 signature verification).'
+  ));
+  out.push('');
+
+  out.push('Limitations:');
+  for (const lim of LIMITATIONS) {
+    out.push(wrap(`- ${lim}`, 2));
+  }
+  out.push('');
+
+  // Reproducibility
+  out.push('Reproducibility:');
+  out.push(wrap(
+    'To independently verify this capture, install @w-r-l/verify ' +
+    `version ${version} and run:`
+  ));
+  out.push('');
+  // Build command from result, not process.argv (security: avoid leaking paths)
+  let cmd = `  npx @w-r-l/verify@${version} ${result.source ?? '<file-or-url>'}`;
+  if (kr?.source === 'origin' && kr.origin) {
+    cmd += ` --origin ${kr.origin}`;
+  } else if (kr?.source === 'embedded') {
+    cmd += ' --trust-embedded';
+  }
+  cmd += ' --legal';
+  out.push(cmd);
+  out.push('');
+  out.push(wrap(
+    'If custom trust root certificates were used during the original ' +
+    'verification (via --trust-root), they must be supplied again when ' +
+    're-running the command above.'
+  ));
+  out.push('');
+
+  // Section 7: Full Technical Details
+  out.push('7. FULL TECHNICAL DETAILS');
+  out.push(LINE);
+  out.push('');
+  out.push(wrap(
+    'The following values are provided untruncated for independent ' +
+    'verification and cross-reference with other records.'
+  ));
+  out.push('');
+
+  if (capture.bundleHash) {
+    out.push(`Bundle hash:       ${capture.bundleHash}`);
+  }
+  if (capture.signature) {
+    out.push(`Signature:         ${capture.signature}`);
+  }
+  if (capture.publicKey) {
+    out.push(`Embedded key:      ${capture.publicKey}`);
+    // Repeat trust warning inline for embedded key
+    if (kr?.source === 'embedded') {
+      out.push('                   (SELF-ASSERTED -- see trust warning in');
+      out.push('                   Section 1)');
+    }
+  }
+  if (kr?.keyId) {
+    out.push(`Key ID:            ${kr.keyId}`);
+  }
+  if (kr?.source) {
+    const sourceLabel = kr.source === 'origin'
+      ? `operator (${kr.origin ?? 'unknown'})`
+      : kr.source === 'embedded'
+        ? 'embedded in archive (self-asserted)'
+        : 'user-provided';
+    out.push(`Key source:        ${sourceLabel}`);
+  }
+  out.push('');
+
+  out.push('Timestamps:');
+  out.push('');
+  if (capture.signedAt) {
+    out.push(`  Capture time:      ${capture.signedAt}`);
+    out.push('                     (self-asserted by capture service)');
+  }
+  if (capture.timestamp) {
+    out.push(`  TSA time:          ${capture.timestamp.genTime}`);
+    out.push(`  TSA identity:      ${capture.timestamp.tsa}`);
+    out.push('                     (independent RFC 3161 timestamp)');
+  }
+  if (capture.qualifiedTimestamp) {
+    out.push(`  QTSA time:         ${capture.qualifiedTimestamp.genTime}`);
+    out.push(`  QTSA identity:     ${capture.qualifiedTimestamp.tsa}`);
+    out.push('                     (qualified timestamp -- eIDAS Art. 41)');
+  }
+  out.push(`  Verification time: ${verifiedAt}`);
+  out.push('                     (time this report was generated)');
+  out.push('');
+
+  out.push(DOUBLE);
+  out.push('END OF VERIFICATION REPORT');
+  out.push(DOUBLE);
+  out.push('');
+
+  process.stdout.write(out.join('\n'));
+}
+
+// ---------------------------------------------------------------------------
+// formatLegalJson -- JSON legal report
+// ---------------------------------------------------------------------------
+
+/**
+ * Formats a verification result as a JSON legal report.
+ * Includes explanatory fields, legal context, and methodology.
+ *
+ * @param {object} result  The verification result from verifyWacz()
+ * @param {{ version: string }} opts  Options including tool version
+ */
+export function formatLegalJson(result, opts = {}) {
+  const version = opts.version ?? '0.0.0';
+  const verifiedAt = new Date().toISOString();
+  const capture = result.capture ?? {};
+  const kr = result.keyResolution ?? {};
+  const checks = result.checks ?? [];
+
+  const applicable = checks.filter(c => c.status !== 'skip');
+  const failed = applicable.filter(c => c.status === 'fail');
+
+  let summaryStatement;
+  if (failed.length === 0) {
+    summaryStatement =
+      `All ${applicable.length} cryptographic checks passed. ` +
+      'No evidence of modification was detected.';
+  } else {
+    summaryStatement =
+      `${failed.length} of ${applicable.length} check(s) failed. ` +
+      'This capture cannot be verified as unmodified.';
+  }
+
+  const enrichedChecks = checks.map(c => {
+    const expl = EXPLANATIONS[c.name] ?? {};
+    return {
+      name: c.name,
+      label: checkLabel(c.name),
+      status: c.status,
+      detail: c.detail ?? null,
+      explanation: expl.what ?? null,
+      result: expl[c.status] ?? null,
+      significance: expl.significance ?? null,
+    };
+  });
+
+  // Timestamps -- separate standard and qualified
+  const timestamps = {};
+  if (capture.timestamp) {
+    timestamps.standard = {
+      genTime: capture.timestamp.genTime,
+      tsa: capture.timestamp.tsa,
+      type: 'RFC 3161',
+    };
+  }
+  if (capture.qualifiedTimestamp) {
+    timestamps.qualified = {
+      genTime: capture.qualifiedTimestamp.genTime,
+      tsa: capture.qualifiedTimestamp.tsa,
+      type: 'eIDAS qualified (EU No 910/2014, Art. 41)',
+    };
+  }
+  if (capture.signedAt) {
+    timestamps.capture = {
+      time: capture.signedAt,
+      source: 'self-asserted by capture service',
+    };
+  }
+  timestamps.verification = {
+    time: verifiedAt,
+    source: 'generated by verification tool',
+  };
+
+  // Key resolution with trust model
+  let trustModel;
+  if (kr.source === 'embedded') {
+    trustModel = 'Self-asserted (limited). The signing key was embedded ' +
+      'in the archive. This proves internal consistency only, not provenance.';
+  } else if (kr.source === 'origin') {
+    trustModel = `Operator-published. The signing key was retrieved from ` +
+      `${kr.origin ?? 'the operator'} over HTTPS.`;
+  } else if (kr.source === 'pinned') {
+    trustModel = 'User-provided. The signing key was supplied directly ' +
+      'by the verifier.';
+  } else {
+    trustModel = null;
+  }
+
+  const out = {
+    reportFormat: REPORT_FORMAT,
+    verified: result.verified ?? null,
+    tool: {
+      name: '@w-r-l/verify',
+      version,
+      nodeVersion: process.versions.node,
+      platform: process.platform,
+      arch: process.arch,
+    },
+    summary: {
+      statement: summaryStatement,
+      verified: result.verified ?? null,
+      source: result.source ?? null,
+      captureDate: capture.signedAt ?? null,
+    },
+    checks: enrichedChecks,
+    capture: {
+      bundleHash: capture.bundleHash ?? null,
+      signature: capture.signature ?? null,
+      embeddedPublicKey: capture.publicKey ?? null,
+      signedAt: capture.signedAt ?? null,
+    },
+    timestamps,
+    keyResolution: {
+      keyId: kr.keyId ?? null,
+      source: kr.source ?? null,
+      origin: kr.origin ?? null,
+      endpoint: kr.endpoint ?? null,
+      publicKey: capture.publicKey ?? null,
+      trustModel,
+    },
+    legalContext: {
+      disclaimer: LEGAL_DISCLAIMER.replace(/\n/g, ' '),
+      applicableFrameworks: [
+        {
+          jurisdiction: 'United States',
+          reference: 'Federal Rule of Evidence 901(b)(9)',
+          relevance: 'Authentication of evidence through description of ' +
+            'a process or system showing it produces an accurate result.',
+        },
+        {
+          jurisdiction: 'European Union',
+          reference: 'eIDAS Regulation (EU) No 910/2014, Article 41',
+          relevance: 'Electronic timestamps shall not be denied legal ' +
+            'effect solely on the grounds of electronic form.',
+        },
+      ],
+    },
+    methodology: {
+      algorithms: ALGORITHMS.map(a => ({
+        name: a.name,
+        standard: a.standard,
+        purpose: a.purpose,
+      })),
+      cryptoLibrary: 'Node.js built-in crypto (Web Crypto API for Ed25519)',
+      limitations: LIMITATIONS,
+    },
+    verifiedAt,
+  };
+
+  process.stdout.write(JSON.stringify(out, null, 2) + '\n');
+}

--- a/packages/verify/lib/format.js
+++ b/packages/verify/lib/format.js
@@ -67,9 +67,11 @@ const CHECK_ORDER = [
  * @param {string} name
  * @returns {string}
  */
-function checkLabel(name) {
+export function checkLabel(name) {
   return CHECK_LABELS[name] ?? name;
 }
+
+export { CHECK_LABELS };
 
 // ---------------------------------------------------------------------------
 // Timestamp check merging

--- a/packages/verify/test/cli-args.test.js
+++ b/packages/verify/test/cli-args.test.js
@@ -60,6 +60,17 @@ describe('parseArgs -- boolean flags', () => {
     const opts = parseArgs(['--trust-embedded', 'file.wacz']);
     assert.strictEqual(opts.trustEmbedded, true);
   });
+
+  it('--legal sets legal: true', () => {
+    const opts = parseArgs(['--legal', 'file.wacz']);
+    assert.strictEqual(opts.legal, true);
+  });
+
+  it('--legal --json sets both legal and json to true', () => {
+    const opts = parseArgs(['--legal', '--json', 'file.wacz']);
+    assert.strictEqual(opts.legal, true);
+    assert.strictEqual(opts.json, true);
+  });
 });
 
 describe('parseArgs -- value flags', () => {
@@ -147,6 +158,7 @@ describe('parseArgs -- defaults', () => {
     assert.strictEqual(opts.trustEmbedded, false);
     assert.deepStrictEqual(opts.trustRoots, []);
     assert.strictEqual(opts.json, false);
+    assert.strictEqual(opts.legal, false);
     assert.strictEqual(opts.noColor, false);
     assert.strictEqual(opts.help, false);
     assert.strictEqual(opts.version, false);

--- a/packages/verify/test/format-legal.test.js
+++ b/packages/verify/test/format-legal.test.js
@@ -1,0 +1,775 @@
+/**
+ * format-legal.test.js -- Legal report formatter tests
+ *
+ * Tests formatLegal() and formatLegalJson() from lib/format-legal.js.
+ *
+ * Because these functions write to process.stdout, we capture stdout using
+ * the same pipe-and-restore approach as format.test.js.
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { formatLegal, formatLegalJson } from '../lib/format-legal.js';
+
+// ---------------------------------------------------------------------------
+// Stdout capture helper
+// ---------------------------------------------------------------------------
+
+let stdoutOutput = '';
+let originalWrite;
+
+function captureStdout() {
+  stdoutOutput = '';
+  originalWrite = process.stdout.write.bind(process.stdout);
+  process.stdout.write = (chunk) => {
+    stdoutOutput += typeof chunk === 'string' ? chunk : chunk.toString();
+    return true;
+  };
+}
+
+function restoreStdout() {
+  if (originalWrite) {
+    process.stdout.write = originalWrite;
+    originalWrite = null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Test data factories
+// ---------------------------------------------------------------------------
+
+function makeBaseResult(overrides = {}) {
+  return {
+    verified: true,
+    checks: [
+      { name: 'artifactHashes', status: 'pass', detail: null },
+      { name: 'bundleHash',     status: 'pass', detail: null },
+      { name: 'signature',      status: 'pass', detail: null },
+    ],
+    capture: {
+      bundleHash: 'sha256:' + 'a'.repeat(64),
+      signature:  'dGVzdHNpZ25hdHVyZWRhdGE=',
+      publicKey:  'dGVzdHB1YmxpY2tleWRhdGE=',
+      signedAt:   '2026-03-16T12:00:00.000Z',
+    },
+    keyResolution: {
+      keyId:    'aabbccdd11223344',
+      source:   'pinned',
+      origin:   null,
+      endpoint: null,
+    },
+    source: 'test.wacz',
+    ...overrides,
+  };
+}
+
+function makeEmbeddedResult() {
+  return makeBaseResult({
+    keyResolution: {
+      keyId:    'aabbccdd11223344',
+      source:   'embedded',
+      origin:   null,
+      endpoint: null,
+    },
+  });
+}
+
+function makeOriginResult() {
+  return makeBaseResult({
+    keyResolution: {
+      keyId:    'aabbccdd11223344',
+      source:   'origin',
+      origin:   'https://keys.example.com/.well-known/wrl-key',
+      endpoint: 'https://keys.example.com/.well-known/wrl-key',
+    },
+  });
+}
+
+function makeWithTimestamps() {
+  return makeBaseResult({
+    checks: [
+      { name: 'artifactHashes',    status: 'pass', detail: null },
+      { name: 'bundleHash',        status: 'pass', detail: null },
+      { name: 'signature',         status: 'pass', detail: null },
+      { name: 'timestamp',         status: 'pass', detail: 'TSA: tsa.example.com' },
+      { name: 'qualifiedTimestamp', status: 'pass', detail: 'QTSA: qtsa.example.com' },
+    ],
+    capture: {
+      bundleHash:  'sha256:' + 'b'.repeat(64),
+      signature:   'dGVzdHNpZ25hdHVyZWRhdGE=',
+      publicKey:   'dGVzdHB1YmxpY2tleWRhdGE=',
+      signedAt:    '2026-03-16T12:00:00.000Z',
+      timestamp: {
+        genTime: '2026-03-16T12:00:01.000Z',
+        tsa:     'tsa.example.com',
+      },
+      qualifiedTimestamp: {
+        genTime: '2026-03-16T12:00:02.000Z',
+        tsa:     'qtsa.example.com',
+      },
+    },
+  });
+}
+
+function makeNoTimestampResult() {
+  return makeBaseResult({
+    checks: [
+      { name: 'artifactHashes', status: 'pass', detail: null },
+      { name: 'bundleHash',     status: 'pass', detail: null },
+      { name: 'signature',      status: 'pass', detail: null },
+      { name: 'timestamp',      status: 'skip', detail: 'No independent timestamp was obtained for this capture' },
+    ],
+  });
+}
+
+function makeFailResult() {
+  return makeBaseResult({
+    verified: false,
+    checks: [
+      { name: 'artifactHashes', status: 'fail', detail: 'Hash mismatch detected in main.html' },
+      { name: 'bundleHash',     status: 'pass', detail: null },
+      { name: 'signature',      status: 'pass', detail: null },
+    ],
+  });
+}
+
+function makeMinimalResult() {
+  // No timestamp, no qualifiedTimestamp, no keyResolution -- tests graceful degradation
+  return {
+    verified: true,
+    checks: [
+      { name: 'artifactHashes', status: 'pass', detail: null },
+      { name: 'bundleHash',     status: 'pass', detail: null },
+      { name: 'signature',      status: 'pass', detail: null },
+    ],
+    capture: {},
+    keyResolution: null,
+    source: 'minimal.wacz',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// formatLegal -- Section structure
+// ---------------------------------------------------------------------------
+
+describe('formatLegal -- section headers', () => {
+  beforeEach(captureStdout);
+  afterEach(restoreStdout);
+
+  it('includes Section 1 header', () => {
+    formatLegal(makeBaseResult());
+    assert.match(stdoutOutput, /1\. SUMMARY/);
+  });
+
+  it('includes Section 2 header', () => {
+    formatLegal(makeBaseResult());
+    assert.match(stdoutOutput, /2\. SUBJECT OF VERIFICATION/);
+  });
+
+  it('includes Section 3 header', () => {
+    formatLegal(makeBaseResult());
+    assert.match(stdoutOutput, /3\. VERIFICATION CHECKS PERFORMED/);
+  });
+
+  it('includes Section 4 header', () => {
+    formatLegal(makeBaseResult());
+    assert.match(stdoutOutput, /4\. CHAIN OF CUSTODY/);
+  });
+
+  it('includes Section 5 header', () => {
+    formatLegal(makeBaseResult());
+    assert.match(stdoutOutput, /5\. APPLICABLE LEGAL STANDARDS/);
+  });
+
+  it('includes Section 6 header', () => {
+    formatLegal(makeBaseResult());
+    assert.match(stdoutOutput, /6\. METHODOLOGY/);
+  });
+
+  it('includes Section 7 header', () => {
+    formatLegal(makeBaseResult());
+    assert.match(stdoutOutput, /7\. FULL TECHNICAL DETAILS/);
+  });
+
+  it('report format version is present', () => {
+    formatLegal(makeBaseResult());
+    assert.match(stdoutOutput, /WRL-LEGAL-1\.0/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatLegal -- No ANSI invariant
+// ---------------------------------------------------------------------------
+
+describe('formatLegal -- no ANSI escape sequences', () => {
+  beforeEach(captureStdout);
+  afterEach(restoreStdout);
+
+  it('pass result contains no ANSI codes', () => {
+    formatLegal(makeBaseResult());
+    // eslint-disable-next-line no-control-regex
+    assert.doesNotMatch(stdoutOutput, /\x1b\[/);
+  });
+
+  it('fail result contains no ANSI codes', () => {
+    formatLegal(makeFailResult());
+    // eslint-disable-next-line no-control-regex
+    assert.doesNotMatch(stdoutOutput, /\x1b\[/);
+  });
+
+  it('embedded key result contains no ANSI codes', () => {
+    formatLegal(makeEmbeddedResult());
+    // eslint-disable-next-line no-control-regex
+    assert.doesNotMatch(stdoutOutput, /\x1b\[/);
+  });
+
+  it('result with timestamps contains no ANSI codes', () => {
+    formatLegal(makeWithTimestamps());
+    // eslint-disable-next-line no-control-regex
+    assert.doesNotMatch(stdoutOutput, /\x1b\[/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatLegal -- Untruncated values
+// ---------------------------------------------------------------------------
+
+describe('formatLegal -- untruncated values in Section 7', () => {
+  beforeEach(captureStdout);
+  afterEach(restoreStdout);
+
+  it('bundle hash is present in full', () => {
+    const result = makeBaseResult();
+    formatLegal(result);
+    assert.match(stdoutOutput, new RegExp('sha256:' + 'a'.repeat(64)));
+  });
+
+  it('bundle hash contains no ellipsis truncation marker', () => {
+    formatLegal(makeBaseResult());
+    // The hash value line must not be truncated
+    const lines = stdoutOutput.split('\n');
+    const hashLine = lines.find(l => l.includes('Bundle hash:') && l.includes('sha256:'));
+    assert.ok(hashLine, 'Bundle hash line should be present');
+    assert.doesNotMatch(hashLine, /\.\.\./);
+  });
+
+  it('signature value is present in full', () => {
+    const result = makeBaseResult();
+    formatLegal(result);
+    assert.match(stdoutOutput, /dGVzdHNpZ25hdHVyZWRhdGE=/);
+  });
+
+  it('key ID is present in full', () => {
+    const result = makeBaseResult();
+    formatLegal(result);
+    assert.match(stdoutOutput, /aabbccdd11223344/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatLegal -- Timestamp separation (NOT merged like formatHuman)
+// ---------------------------------------------------------------------------
+
+describe('formatLegal -- timestamp separation', () => {
+  beforeEach(captureStdout);
+  afterEach(restoreStdout);
+
+  it('shows standard timestamp as its own subsection (3.N)', () => {
+    const result = makeWithTimestamps();
+    formatLegal(result);
+    // timestamp and qualifiedTimestamp each get their own 3.N subsection
+    assert.match(stdoutOutput, /Timestamp imprint/);
+  });
+
+  it('shows qualified timestamp as its own subsection (3.N)', () => {
+    const result = makeWithTimestamps();
+    formatLegal(result);
+    assert.match(stdoutOutput, /Qualified timestamp/);
+  });
+
+  it('shows both timestamp types when both are present', () => {
+    const result = makeWithTimestamps();
+    formatLegal(result);
+    // Both labels must appear -- they are NOT merged into one row
+    assert.match(stdoutOutput, /Timestamp imprint/);
+    assert.match(stdoutOutput, /Qualified timestamp/);
+  });
+
+  it('shows TSA identity separately from QTSA identity', () => {
+    const result = makeWithTimestamps();
+    formatLegal(result);
+    assert.match(stdoutOutput, /tsa\.example\.com/);
+    assert.match(stdoutOutput, /qtsa\.example\.com/);
+  });
+
+  it('shows capture time and TSA time as separate entries in Section 7', () => {
+    const result = makeWithTimestamps();
+    formatLegal(result);
+    assert.match(stdoutOutput, /Capture time/);
+    assert.match(stdoutOutput, /TSA time/);
+    assert.match(stdoutOutput, /QTSA time/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatLegal -- Trust model visibility (embedded key)
+// ---------------------------------------------------------------------------
+
+describe('formatLegal -- embedded key trust warning', () => {
+  beforeEach(captureStdout);
+  afterEach(restoreStdout);
+
+  it('SELF-ASSERTED warning appears in Section 1 when source is embedded', () => {
+    formatLegal(makeEmbeddedResult());
+    // The warning must appear before Section 2 (i.e., in Section 1)
+    const section1End = stdoutOutput.indexOf('2. SUBJECT OF VERIFICATION');
+    assert.ok(section1End > 0, 'Section 2 header must be present');
+    const section1 = stdoutOutput.slice(0, section1End);
+    assert.match(section1, /SELF-ASSERTED/);
+  });
+
+  it('SELF-ASSERTED warning appears in Section 7 when source is embedded', () => {
+    formatLegal(makeEmbeddedResult());
+    const section7Start = stdoutOutput.indexOf('7. FULL TECHNICAL DETAILS');
+    assert.ok(section7Start > 0, 'Section 7 header must be present');
+    const section7 = stdoutOutput.slice(section7Start);
+    assert.match(section7, /SELF-ASSERTED/);
+  });
+
+  it('no SELF-ASSERTED warning when source is pinned', () => {
+    formatLegal(makeBaseResult()); // pinned source
+    assert.doesNotMatch(stdoutOutput, /SELF-ASSERTED/);
+  });
+
+  it('no SELF-ASSERTED warning when source is origin', () => {
+    formatLegal(makeOriginResult());
+    assert.doesNotMatch(stdoutOutput, /SELF-ASSERTED/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatLegal -- Legal references
+// ---------------------------------------------------------------------------
+
+describe('formatLegal -- legal references', () => {
+  beforeEach(captureStdout);
+  afterEach(restoreStdout);
+
+  it('FRE 901(b)(9) is referenced', () => {
+    formatLegal(makeBaseResult());
+    assert.match(stdoutOutput, /901\(b\)\(9\)/);
+  });
+
+  it('eIDAS Art. 41 is referenced', () => {
+    formatLegal(makeBaseResult());
+    assert.match(stdoutOutput, /Article 41|Art\. 41/);
+  });
+
+  it('both legal references are present together', () => {
+    formatLegal(makeBaseResult());
+    assert.match(stdoutOutput, /901\(b\)\(9\)/);
+    assert.match(stdoutOutput, /910\/2014/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatLegal -- Graceful degradation
+// ---------------------------------------------------------------------------
+
+describe('formatLegal -- graceful degradation', () => {
+  beforeEach(captureStdout);
+  afterEach(restoreStdout);
+
+  it('does not crash with no timestamp', () => {
+    assert.doesNotThrow(() => formatLegal(makeNoTimestampResult()));
+  });
+
+  it('does not crash with no qualifiedTimestamp', () => {
+    const result = makeBaseResult(); // no qualifiedTimestamp in capture
+    assert.doesNotThrow(() => formatLegal(result));
+  });
+
+  it('does not crash with null keyResolution', () => {
+    assert.doesNotThrow(() => formatLegal(makeMinimalResult()));
+  });
+
+  it('does not crash with empty capture object', () => {
+    assert.doesNotThrow(() => formatLegal(makeMinimalResult()));
+  });
+
+  it('does not crash with empty checks array', () => {
+    const result = makeBaseResult({ checks: [] });
+    assert.doesNotThrow(() => formatLegal(result));
+  });
+
+  it('still emits all section headers with minimal result', () => {
+    formatLegal(makeMinimalResult());
+    assert.match(stdoutOutput, /1\. SUMMARY/);
+    assert.match(stdoutOutput, /7\. FULL TECHNICAL DETAILS/);
+  });
+
+  it('does not crash with undefined source', () => {
+    const result = makeBaseResult({ source: undefined });
+    assert.doesNotThrow(() => formatLegal(result));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatLegal -- Methodology / reproducibility
+// ---------------------------------------------------------------------------
+
+describe('formatLegal -- methodology section', () => {
+  beforeEach(captureStdout);
+  afterEach(restoreStdout);
+
+  it('trust-root note is present in Section 6 (Reproducibility)', () => {
+    formatLegal(makeBaseResult());
+    assert.match(stdoutOutput, /trust.root/i);
+  });
+
+  it('reproducibility command includes --legal flag', () => {
+    formatLegal(makeBaseResult());
+    assert.match(stdoutOutput, /--legal/);
+  });
+
+  it('reproducibility command includes source filename', () => {
+    formatLegal(makeBaseResult());
+    assert.match(stdoutOutput, /test\.wacz/);
+  });
+
+  it('embedded key reproducibility command uses --trust-embedded', () => {
+    formatLegal(makeEmbeddedResult());
+    assert.match(stdoutOutput, /--trust-embedded/);
+  });
+
+  it('origin key reproducibility command uses --origin with URL', () => {
+    formatLegal(makeOriginResult());
+    assert.match(stdoutOutput, /--origin/);
+    assert.match(stdoutOutput, /keys\.example\.com/);
+  });
+
+  it('cryptographic algorithms are listed', () => {
+    formatLegal(makeBaseResult());
+    assert.match(stdoutOutput, /SHA-256/);
+    assert.match(stdoutOutput, /Ed25519/);
+    assert.match(stdoutOutput, /RFC 3161/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatLegalJson -- Schema validation
+// ---------------------------------------------------------------------------
+
+describe('formatLegalJson -- top-level schema', () => {
+  beforeEach(captureStdout);
+  afterEach(restoreStdout);
+
+  it('outputs valid JSON', () => {
+    formatLegalJson(makeBaseResult());
+    assert.doesNotThrow(() => JSON.parse(stdoutOutput));
+  });
+
+  it('has reportFormat key', () => {
+    formatLegalJson(makeBaseResult());
+    const parsed = JSON.parse(stdoutOutput);
+    assert.ok('reportFormat' in parsed);
+  });
+
+  it('has verified key', () => {
+    formatLegalJson(makeBaseResult());
+    const parsed = JSON.parse(stdoutOutput);
+    assert.ok('verified' in parsed);
+  });
+
+  it('has tool key', () => {
+    formatLegalJson(makeBaseResult());
+    const parsed = JSON.parse(stdoutOutput);
+    assert.ok('tool' in parsed);
+  });
+
+  it('has summary key', () => {
+    formatLegalJson(makeBaseResult());
+    const parsed = JSON.parse(stdoutOutput);
+    assert.ok('summary' in parsed);
+  });
+
+  it('has checks key', () => {
+    formatLegalJson(makeBaseResult());
+    const parsed = JSON.parse(stdoutOutput);
+    assert.ok('checks' in parsed);
+  });
+
+  it('has capture key', () => {
+    formatLegalJson(makeBaseResult());
+    const parsed = JSON.parse(stdoutOutput);
+    assert.ok('capture' in parsed);
+  });
+
+  it('has timestamps key', () => {
+    formatLegalJson(makeBaseResult());
+    const parsed = JSON.parse(stdoutOutput);
+    assert.ok('timestamps' in parsed);
+  });
+
+  it('has keyResolution key', () => {
+    formatLegalJson(makeBaseResult());
+    const parsed = JSON.parse(stdoutOutput);
+    assert.ok('keyResolution' in parsed);
+  });
+
+  it('has legalContext key', () => {
+    formatLegalJson(makeBaseResult());
+    const parsed = JSON.parse(stdoutOutput);
+    assert.ok('legalContext' in parsed);
+  });
+
+  it('has methodology key', () => {
+    formatLegalJson(makeBaseResult());
+    const parsed = JSON.parse(stdoutOutput);
+    assert.ok('methodology' in parsed);
+  });
+
+  it('has verifiedAt key', () => {
+    formatLegalJson(makeBaseResult());
+    const parsed = JSON.parse(stdoutOutput);
+    assert.ok('verifiedAt' in parsed);
+  });
+
+  it('reportFormat value is WRL-LEGAL-1.0', () => {
+    formatLegalJson(makeBaseResult());
+    const parsed = JSON.parse(stdoutOutput);
+    assert.strictEqual(parsed.reportFormat, 'WRL-LEGAL-1.0');
+  });
+
+  it('verified is true for passing result', () => {
+    formatLegalJson(makeBaseResult());
+    const parsed = JSON.parse(stdoutOutput);
+    assert.strictEqual(parsed.verified, true);
+  });
+
+  it('verified is false for failing result', () => {
+    formatLegalJson(makeFailResult());
+    const parsed = JSON.parse(stdoutOutput);
+    assert.strictEqual(parsed.verified, false);
+  });
+
+  it('verifiedAt is a valid ISO 8601 datetime', () => {
+    formatLegalJson(makeBaseResult());
+    const parsed = JSON.parse(stdoutOutput);
+    assert.match(parsed.verifiedAt, /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+    assert.doesNotThrow(() => new Date(parsed.verifiedAt));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatLegalJson -- Check enrichment
+// ---------------------------------------------------------------------------
+
+describe('formatLegalJson -- enriched checks', () => {
+  beforeEach(captureStdout);
+  afterEach(restoreStdout);
+
+  it('each check has an explanation field', () => {
+    formatLegalJson(makeBaseResult());
+    const parsed = JSON.parse(stdoutOutput);
+    for (const check of parsed.checks) {
+      assert.ok('explanation' in check, `Check ${check.name} missing explanation`);
+    }
+  });
+
+  it('each check has a result field', () => {
+    formatLegalJson(makeBaseResult());
+    const parsed = JSON.parse(stdoutOutput);
+    for (const check of parsed.checks) {
+      assert.ok('result' in check, `Check ${check.name} missing result`);
+    }
+  });
+
+  it('each check has a significance field', () => {
+    formatLegalJson(makeBaseResult());
+    const parsed = JSON.parse(stdoutOutput);
+    for (const check of parsed.checks) {
+      assert.ok('significance' in check, `Check ${check.name} missing significance`);
+    }
+  });
+
+  it('explanation is a non-empty string for known checks', () => {
+    formatLegalJson(makeBaseResult());
+    const parsed = JSON.parse(stdoutOutput);
+    const byName = Object.fromEntries(parsed.checks.map(c => [c.name, c]));
+    assert.ok(typeof byName.artifactHashes.explanation === 'string');
+    assert.ok(byName.artifactHashes.explanation.length > 0);
+  });
+
+  it('result field reflects check outcome (pass text for passing check)', () => {
+    formatLegalJson(makeBaseResult());
+    const parsed = JSON.parse(stdoutOutput);
+    const byName = Object.fromEntries(parsed.checks.map(c => [c.name, c]));
+    // Pass checks get the "pass" explanation, not the "fail" explanation
+    assert.ok(typeof byName.signature.result === 'string');
+    assert.ok(byName.signature.result.length > 0);
+  });
+
+  it('checks array preserves all checks from input', () => {
+    formatLegalJson(makeBaseResult());
+    const parsed = JSON.parse(stdoutOutput);
+    assert.strictEqual(parsed.checks.length, 3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatLegalJson -- Timestamp separation
+// ---------------------------------------------------------------------------
+
+describe('formatLegalJson -- timestamps object', () => {
+  beforeEach(captureStdout);
+  afterEach(restoreStdout);
+
+  it('timestamps.standard is present when timestamp check is passed', () => {
+    formatLegalJson(makeWithTimestamps());
+    const parsed = JSON.parse(stdoutOutput);
+    assert.ok(parsed.timestamps.standard, 'timestamps.standard should be present');
+  });
+
+  it('timestamps.qualified is present when qualifiedTimestamp check is passed', () => {
+    formatLegalJson(makeWithTimestamps());
+    const parsed = JSON.parse(stdoutOutput);
+    assert.ok(parsed.timestamps.qualified, 'timestamps.qualified should be present');
+  });
+
+  it('timestamps.standard and timestamps.qualified are separate keys (not merged)', () => {
+    formatLegalJson(makeWithTimestamps());
+    const parsed = JSON.parse(stdoutOutput);
+    assert.ok('standard' in parsed.timestamps);
+    assert.ok('qualified' in parsed.timestamps);
+  });
+
+  it('timestamps.verification is always present', () => {
+    formatLegalJson(makeBaseResult());
+    const parsed = JSON.parse(stdoutOutput);
+    assert.ok(parsed.timestamps.verification, 'timestamps.verification should always be present');
+  });
+
+  it('timestamps.standard absent when no timestamp in capture', () => {
+    formatLegalJson(makeBaseResult()); // no timestamp in capture
+    const parsed = JSON.parse(stdoutOutput);
+    assert.ok(!parsed.timestamps.standard, 'timestamps.standard should be absent');
+  });
+
+  it('timestamps.qualified absent when no qualifiedTimestamp in capture', () => {
+    formatLegalJson(makeBaseResult()); // no qualifiedTimestamp in capture
+    const parsed = JSON.parse(stdoutOutput);
+    assert.ok(!parsed.timestamps.qualified, 'timestamps.qualified should be absent');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatLegalJson -- Legal context
+// ---------------------------------------------------------------------------
+
+describe('formatLegalJson -- legalContext', () => {
+  beforeEach(captureStdout);
+  afterEach(restoreStdout);
+
+  it('legalContext.applicableFrameworks is an array', () => {
+    formatLegalJson(makeBaseResult());
+    const parsed = JSON.parse(stdoutOutput);
+    assert.ok(Array.isArray(parsed.legalContext.applicableFrameworks));
+  });
+
+  it('FRE 901(b)(9) is in applicable frameworks', () => {
+    formatLegalJson(makeBaseResult());
+    const parsed = JSON.parse(stdoutOutput);
+    const refs = parsed.legalContext.applicableFrameworks.map(f => f.reference);
+    assert.ok(refs.some(r => r.includes('901(b)(9)')));
+  });
+
+  it('eIDAS Art. 41 is in applicable frameworks', () => {
+    formatLegalJson(makeBaseResult());
+    const parsed = JSON.parse(stdoutOutput);
+    const refs = parsed.legalContext.applicableFrameworks.map(f => f.reference);
+    assert.ok(refs.some(r => r.includes('41')));
+  });
+
+  it('legalContext.disclaimer is present and non-empty', () => {
+    formatLegalJson(makeBaseResult());
+    const parsed = JSON.parse(stdoutOutput);
+    assert.ok(typeof parsed.legalContext.disclaimer === 'string');
+    assert.ok(parsed.legalContext.disclaimer.length > 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatLegalJson -- Methodology
+// ---------------------------------------------------------------------------
+
+describe('formatLegalJson -- methodology', () => {
+  beforeEach(captureStdout);
+  afterEach(restoreStdout);
+
+  it('methodology.algorithms is a non-empty array', () => {
+    formatLegalJson(makeBaseResult());
+    const parsed = JSON.parse(stdoutOutput);
+    assert.ok(Array.isArray(parsed.methodology.algorithms));
+    assert.ok(parsed.methodology.algorithms.length > 0);
+  });
+
+  it('SHA-256 is listed in algorithms', () => {
+    formatLegalJson(makeBaseResult());
+    const parsed = JSON.parse(stdoutOutput);
+    assert.ok(parsed.methodology.algorithms.some(a => a.name === 'SHA-256'));
+  });
+
+  it('Ed25519 is listed in algorithms', () => {
+    formatLegalJson(makeBaseResult());
+    const parsed = JSON.parse(stdoutOutput);
+    assert.ok(parsed.methodology.algorithms.some(a => a.name === 'Ed25519'));
+  });
+
+  it('methodology.limitations is a non-empty array', () => {
+    formatLegalJson(makeBaseResult());
+    const parsed = JSON.parse(stdoutOutput);
+    assert.ok(Array.isArray(parsed.methodology.limitations));
+    assert.ok(parsed.methodology.limitations.length > 0);
+  });
+
+  it('methodology.cryptoLibrary is a non-empty string', () => {
+    formatLegalJson(makeBaseResult());
+    const parsed = JSON.parse(stdoutOutput);
+    assert.ok(typeof parsed.methodology.cryptoLibrary === 'string');
+    assert.ok(parsed.methodology.cryptoLibrary.length > 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatLegalJson -- Graceful degradation
+// ---------------------------------------------------------------------------
+
+describe('formatLegalJson -- graceful degradation', () => {
+  beforeEach(captureStdout);
+  afterEach(restoreStdout);
+
+  it('does not crash with null keyResolution', () => {
+    assert.doesNotThrow(() => formatLegalJson(makeMinimalResult()));
+  });
+
+  it('outputs valid JSON with minimal result', () => {
+    formatLegalJson(makeMinimalResult());
+    assert.doesNotThrow(() => JSON.parse(stdoutOutput));
+  });
+
+  it('does not crash with empty checks array', () => {
+    const result = makeBaseResult({ checks: [] });
+    assert.doesNotThrow(() => formatLegalJson(result));
+    const parsed = JSON.parse(stdoutOutput);
+    assert.deepStrictEqual(parsed.checks, []);
+  });
+
+  it('capture fields are null (not undefined) when absent', () => {
+    formatLegalJson(makeMinimalResult());
+    const parsed = JSON.parse(stdoutOutput);
+    assert.strictEqual(parsed.capture.bundleHash, null);
+    assert.strictEqual(parsed.capture.signature, null);
+    assert.strictEqual(parsed.capture.signedAt, null);
+  });
+});

--- a/site/content/legal-evidence.md
+++ b/site/content/legal-evidence.md
@@ -79,6 +79,38 @@ The certification PDF is generated deterministically from the capture record. It
 
 The document is designed for use alongside the WACZ bundle, not as a standalone substitute for it. Verification of the WACZ bundle remains the primary cryptographic assurance; the certification document provides the written description of process and system that supports a 902(13) argument.
 
+### Legal verification report
+
+The `--legal` flag on the `@w-r-l/verify` CLI produces a structured plain-text report designed to accompany a capture when submitted as evidence.
+
+```bash
+npx @w-r-l/verify <capture-url> --legal > verification-report.txt
+```
+
+The report is formatted as WRL-LEGAL-1.0 and contains seven sections:
+
+| Section | Contents |
+|---------|----------|
+| Summary | Plain-language pass/fail result and the captured URL |
+| Subject | Captured URL, capture time, and operator identity |
+| Check explanations | Each verification check described in non-technical terms |
+| Chain of custody | Narrative from capture request through signing and timestamping |
+| Legal standards | How the verification properties map to FRE 901(b)(9) and eIDAS Art. 41; does not claim admissibility |
+| Methodology | Description of the automated pipeline and the `@w-r-l/verify` tool |
+| Technical details | All cryptographic values untruncated: bundle hash, Ed25519 signature, RFC 3161 timestamp token, TSA certificate chain |
+
+No ANSI color codes are written -- the output is safe to save as a file or paste into a document. All cryptographic values appear in full; none are shortened.
+
+Standard and qualified timestamps are reported separately when both are present. The report identifies which tier applies to the capture and what that means under FRE and eIDAS.
+
+For a machine-readable version with the same sections as JSON fields, add `--json`:
+
+```bash
+npx @w-r-l/verify <capture-url> --legal --json > verification-report.json
+```
+
+The legal report supplements the WACZ bundle and the certification PDF -- it does not replace either. The WACZ bundle remains the primary cryptographic artifact. The certification PDF (available via `GET /v1/captures/{captureId}/certificate`) provides the operator's written description of the capture process in a form designed to support a Rule 902(13) foundation.
+
 ### Evidence foundation checklist
 
 The table below maps common opposing-counsel challenges to the technical properties WRL provides. This is practical trial-preparation guidance, not a formal analysis of which rule applies in any given case -- that analysis follows from the rule mapping above.

--- a/site/content/verification.md
+++ b/site/content/verification.md
@@ -47,7 +47,21 @@ TSA:           DigiCert Timestamp Authority
 
 Exit code `0` means all checks passed. Exit code `1` means one or more checks failed. Exit code `2` means a usage error (bad arguments, missing file, or network failure fetching the key or bundle).
 
-For machine-readable output, add `--json`. For full CLI options, see the [verify package README](https://github.com/benpeter/web-resource-ledger/tree/main/packages/verify).
+For machine-readable output, add `--json`. For a legal report, add `--legal` (see below). For full CLI options, see the [verify package README](https://github.com/benpeter/web-resource-ledger/tree/main/packages/verify).
+
+### Legal report
+
+Add `--legal` to produce a structured plain-text report formatted for use in legal proceedings or formal documentation:
+
+```bash
+npx @w-r-l/verify https://api.webresourceledger.com/v1/captures/cap_a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6 --legal
+```
+
+The report contains seven sections: a plain-language summary, a subject description, per-check explanations, a chain of custody narrative, applicable legal standards, a methodology description, and full technical details. All cryptographic values are untruncated. No ANSI color codes are written, so the output is safe to redirect to a file or paste into a document.
+
+Add `--json` alongside `--legal` for a machine-readable JSON version with the same seven sections as structured fields.
+
+For the legal context behind the report -- including how WRL captures map to FRE 901(b)(9) and eIDAS Art. 41 -- see [Legal Evidence](/legal-evidence/).
 
 ### REST API (server-side)
 


### PR DESCRIPTION
## Summary

- Add `--legal` flag to `@w-r-l/verify` CLI that produces comprehensive, plain-language verification reports suitable for submission in legal proceedings
- New `format-legal.js` module with 7-section structured report: Summary, Subject of Verification, Verification Checks Performed, Chain of Custody, Applicable Legal Standards, Methodology, Full Technical Details
- `--legal --json` variant produces machine-readable JSON with enriched check explanations, separated timestamps, trust model descriptions, and legal context
- 82 new tests in `format-legal.test.js`, 3 new tests in `cli-args.test.js` (230 total, 0 failures)
- Documentation updates: README, verification.md, legal-evidence.md

## Key design decisions

- Separate module (not extending format.js) — legal output has fundamentally different characteristics (no ANSI, no timestamp merging, untruncated values)
- Factual assertions only — references FRE 901(b)(9) and eIDAS Art. 41 without claiming admissibility
- Timestamps shown separately (standard RFC 3161 vs qualified eIDAS) with legal weight explanation
- Trust model warning leads Section 1 when embedded keys are used
- Reproducibility command shell-quoted and built from result object (not process.argv) for security

## Test plan

- [x] 82 structural tests for formatLegal() and formatLegalJson()
- [x] No-ANSI invariant across all output paths
- [x] Untruncated values in Section 7
- [x] Timestamp separation (not merged)
- [x] Trust model visibility for embedded keys
- [x] Legal references present (FRE 901(b)(9), eIDAS Art. 41)
- [x] Graceful degradation with missing optional fields
- [x] JSON schema validation (all required top-level keys)
- [x] --legal parseArgs tests in cli-args.test.js
- [x] Default output unchanged (existing tests pass)

Resolves #166
