### PR TITLE
feat: add operator admin dashboard

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -315,6 +315,7 @@ Completed items removed from active tracking:
 - ~~R34: API versioning and stability commitment~~ -- DONE (Phase 0065): v1.0.0 version bump (openapi.yaml + package.json), CHANGELOG.md with retroactive history, DEPRECATION-POLICY.md (6-month notice, 30-day emergency), WRL-API-Version response header, CI version-sync enforcement, PR template (Issue #113)
 - ~~R35: MCP directory listings and ecosystem~~ -- DONE (Phase 0066): server.json updated to 2025-12-11 registry schema, glama.json for Glama auto-indexing, PRs submitted to punkpeye/awesome-mcp-servers (Legal) + appcypher/awesome-mcp-servers (Security) + iipc/awesome-web-archiving (Acquisition + Utilities), MCP.so submission, doc bugs fixed (capture_page→capture_url, batch_capture removed, cursor→offset), 6 MCP client integration examples (VS Code, Claude Code, Cursor, Cline, Windsurf, Generic) (Issue #114)
 - ~~R38: CDN for verification traffic~~ -- DONE (Phase 0068): Workers Cache API per-colo caching for verification endpoints, admin cache purge endpoint (URL-based, Free plan compatible), verify subdomain routing, Server-Timing + X-WRL-Cache headers, cache monitoring docs, key rotation runbook (Issue #116)
+- ~~Admin dashboard~~ -- DONE (Phase 0093): Operator dashboard at /admin with tenant list, per-tenant detail (usage history, keys, config), platform overview stats, admin auth gate, 3 API endpoints, 43 new tests (Issue #203)
 
 ---
 

--- a/docs/evolution/0093-admin-dashboard/decisions.md
+++ b/docs/evolution/0093-admin-dashboard/decisions.md
@@ -1,0 +1,92 @@
+# Phase 0093: Admin Dashboard -- Decisions
+
+## D1: Rate limit -- 30 req/60s (not 20)
+
+**Context**: api-design-minion recommended 20/60s, security-minion recommended 30/60s.
+
+**Decision**: 30/60s. The admin key has ~256 bits of entropy -- brute-force is
+not the threat model. The rate limit prevents self-DoS (operator mistake or
+runaway script). 30/60s gives the dashboard enough headroom for parallel
+fetches (overview + tenants) plus manual refreshes during incident triage.
+
+**Rejected**: 20/60s was too conservative for a single-operator dashboard that
+loads 2 endpoints per page view.
+
+## D2: Separate /admin shell (not embedded in /ui)
+
+**Context**: Two options considered: (A) add admin views to the existing /ui
+SPA, gated by a role check; (B) separate /admin endpoint with its own HTML
+shell.
+
+**Decision**: Option B -- separate shell. The admin dashboard has different auth
+(ADMIN_KEY vs tenant API key), different layout (wider container, no sidebar),
+and should not be discoverable by tenant users. The separation also mirrors
+src/ui/ → src/admin/ directory structure cleanly.
+
+**Rejected**: Option A would have required mixing two auth models in the same
+SPA and adding role-aware UI branching.
+
+## D3: sessionStorage for admin key (not cookie, not memory)
+
+**Context**: Where to store the admin key client-side after login.
+
+**Decision**: sessionStorage. Tab-scoped (dies when tab closes), no CSRF risk
+(Bearer token, not cookie), survives hash navigation within the SPA. The
+security-minion confirmed this is appropriate for the threat model (operator
+on their own machine, not a shared kiosk).
+
+**Trade-off**: If the operator opens two admin tabs, they share the same
+sessionStorage in the same origin. Acceptable for single-operator use.
+
+## D4: No standalone getUsageHistory DAL function
+
+**Context**: margo advisory noted that a standalone getUsageHistory function
+would be dead code -- usage history is only ever fetched as part of
+getTenantDetail.
+
+**Decision**: Embed the usage history query in getTenantDetail's db.batch() call.
+One function, one round-trip.
+
+**Rejected**: Standalone function for theoretical future reuse (YAGNI).
+
+## D5: Auth validation via GET /v1/admin/overview (not dedicated ping)
+
+**Context**: The frontend needs to validate the admin key before showing the
+dashboard. Options: (A) dedicated auth-check endpoint, (B) use an existing
+admin endpoint.
+
+**Decision**: Use GET /v1/admin/overview. It returns useful data for the first
+page load anyway, and a 401 response doubles as auth rejection. No new
+endpoint needed.
+
+**Rejected**: Dedicated /v1/admin/ping or /v1/admin/auth endpoint (YAGNI --
+adds an endpoint with no data value).
+
+## D6: Column sort order -- client-side only
+
+**Context**: Should table sorting hit the server or sort in-browser?
+
+**Decision**: Client-side sort. The tenant list is small (tens of tenants, not
+thousands). Sorting in JS avoids additional API complexity (ORDER BY
+parameter, SQL injection surface). The security-minion's column-name allowlist
+recommendation becomes unnecessary.
+
+## D7: totalStorageBytes → currentPeriodStorageBytes (code review fix)
+
+**Context**: code-review-minion identified that `totalStorageBytes` in
+getOverviewStats was period-scoped but named as if all-time.
+
+**Decision**: Rename to `currentPeriodStorageBytes` across DAL, API, frontend,
+and tests. The SQL uses `CASE WHEN period = ?` so it's definitively
+current-period only.
+
+## D8: keyHashPrefix → keyHash.slice(0, 8) (code review fix)
+
+**Context**: admin-detail.js referenced `k.keyHashPrefix` as a fallback for
+unnamed keys, but getTenantDetail returns `keyHash` (full hash), not
+`keyHashPrefix`.
+
+**Decision**: Replace with `k.keyHash.slice(0, 8) + '...'` to show a truncated
+hash as a recognizable identifier. The full hash is already exposed by the
+existing admin key list endpoint, so truncation is a display convenience,
+not a security measure.

--- a/docs/evolution/0093-admin-dashboard/outcome.md
+++ b/docs/evolution/0093-admin-dashboard/outcome.md
@@ -1,0 +1,85 @@
+# Phase 0093: Admin Dashboard -- Outcome
+
+## What was built
+
+An operator-facing admin dashboard at `GET /admin` that replaces manual D1
+queries for tenant and usage visibility. Three API endpoints provide the data;
+a vanilla JS SPA with two views (tenant list + tenant detail) renders it.
+
+### New files
+
+| File | Purpose | Lines |
+|------|---------|-------|
+| `src/admin-dashboard.js` | API handlers for 3 dashboard endpoints | ~210 |
+| `src/admin/admin-shell.js` | HTML shell factory (CSP, inline CSS/JS) | ~125 |
+| `src/admin/admin-auth.js` | Login gate, sessionStorage auth, adminFetch wrapper | ~290 |
+| `src/admin/admin-css.js` | Admin-specific CSS using design system tokens | ~280 |
+| `src/admin/admin-tenants.js` | Tenant list view: stats cards, sortable table, overview | ~375 |
+| `src/admin/admin-detail.js` | Per-tenant detail: usage history, keys, config, usage bar | ~365 |
+| `test/admin-dashboard.test.js` | DAL + API + security tests (43 tests) | ~650 |
+| `test/ui-admin.test.js` | HTML structure and security header tests | ~120 |
+
+### Modified files
+
+| File | Change |
+|------|--------|
+| `src/db.js` | +3 DAL functions: `listTenantsWithUsage`, `getTenantDetail`, `getOverviewStats` |
+| `src/index.js` | +4 routes (3 API + 1 HTML shell), imports |
+| `src/rate-limits.js` | Admin rate limit raised from 5 to 30 req/60s |
+| `src/admin.js` | Comment updated to reflect new rate limit |
+| `wrangler.toml` | ADMIN_RATE_LIMITER limit 5→30 (production + staging) |
+| `wrangler.test.toml` | ADMIN_RATE_LIMITER limit synced to 30 |
+| `test/fixtures.js` | +`seedTenantWithTier` helper, `eidasCaptureCount` param |
+| `openapi.yaml` | +3 endpoint specs, admin tag updated, rate limit docs updated |
+
+### API endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| GET | `/v1/admin/tenants` | List all tenants with current-period usage |
+| GET | `/v1/admin/tenants/:id` | Tenant detail with usage history and keys |
+| GET | `/v1/admin/overview` | Platform-wide aggregate stats |
+| GET | `/admin` | Admin dashboard HTML shell |
+
+### Key metrics
+
+- Tests: 63 files, 1634 passed, 0 failed
+- New tests: 43 (DAL) + ~120 lines UI = comprehensive coverage
+- No new dependencies
+- No schema changes or migrations needed
+
+## Success criteria assessment
+
+| Criterion | Status |
+|-----------|--------|
+| Tenant list with capture counts, tier, usage vs. limits | Done: list view with stat cards, sortable table, quota bars |
+| Data live from D1 | Done: all queries hit env.DB directly, Cache-Control: private, no-store |
+| Admin authentication | Done: ADMIN_KEY Bearer token, sessionStorage login gate |
+| Loads in under 2 seconds | Design-level: db.batch() single round-trip, Promise.all parallel fetch; runtime verification pending production deploy |
+
+## Deviations from plan
+
+1. **totalStorageBytes renamed**: Code review caught that the SQL scoped storage
+   to the current period, but the name implied all-time. Renamed to
+   `currentPeriodStorageBytes` across all layers.
+2. **keyHashPrefix fixed**: Frontend referenced a non-existent `keyHashPrefix`
+   field. Fixed to use `keyHash.slice(0, 8)`.
+3. **quota.captures → quota.capturesPerMonth**: margo caught a frontend bug
+   where the usage progress bar would never render due to wrong field name.
+
+## Surface consistency
+
+| Surface | Action |
+|---------|--------|
+| OpenAPI spec | Updated: 3 new endpoints, admin tag description, rate limit docs (5→30) |
+| Docs site | No update needed: docs don't reference admin rate limit numbers directly |
+| Landing page | No update needed: no admin functionality mentioned |
+| MCP server | No update needed: admin endpoints should not be exposed as MCP tools |
+| Legal pages | No update needed: no new data collection or third-party integrations |
+
+## Backlog changes
+
+- Added to Done section: Admin dashboard (Issue #203, Phase 0093)
+- No new parking lot items: all deferred items (profitability calculations,
+  tenant self-service) were explicitly out of scope from the start and don't
+  need separate tracking

--- a/docs/evolution/0093-admin-dashboard/process.md
+++ b/docs/evolution/0093-admin-dashboard/process.md
@@ -1,0 +1,184 @@
+# Phase 0093: Admin Dashboard -- Process
+
+## TL;DR
+
+Seven specialists planned an admin dashboard to replace manual D1 queries.
+The team argued about rate limits (20 vs 30/60s), standalone vs embedded
+getUsageHistory, and whether to add a dedicated auth-check endpoint. Synthesis
+resolved all three in favor of simplicity. Six execution tasks produced ~2,400
+lines of new code across 8 new files and 8 modified files. Three code reviewers
+found and fixed a field-name bug, a naming inconsistency, and a dead-code
+reference. All 1,634 tests pass. PR #239.
+
+## Phase 1: Meta-Plan
+
+Nefario analyzed the task and identified seven specialists across four domains:
+
+**Primary domains**: data-minion (D1 queries), api-design-minion (REST surface),
+frontend-minion (vanilla JS SPA), security-minion (admin auth model).
+
+**Cross-cutting**: ux-design-minion (visual hierarchy), test-minion (DAL and
+endpoint test strategy), ux-strategy-minion (jobs-to-be-done analysis).
+
+Notable exclusions: oauth-minion (admin uses static key, not OAuth),
+observability-minion (read-only dashboard, existing logging patterns),
+edge-minion (no caching -- admin responses are no-store).
+
+One external skill discovered: ops-runbook (the manual D1 queries this
+dashboard replaces). Treated as reference material, not an execution
+dependency.
+
+## Phase 2: Specialist Planning
+
+All seven specialists ran in parallel. Key arguments:
+
+**data-minion** proposed three DAL functions using LEFT JOINs and correlated
+subqueries. Argued that no new indexes were needed because the existing
+composite PK on usage_counters (tenant_id, period) already covers the query
+patterns. Also proposed a standalone `getUsageHistory(db, tenantId, limit)`
+function for reuse.
+
+**api-design-minion** proposed three endpoints mapping 1:1 to the DAL
+functions. Recommended the client make parallel requests for overview + tenants
+to meet the 2s load target. Suggested 20 req/60s rate limit.
+
+**security-minion** recommended sessionStorage for admin key (tab-scoped, no
+CSRF), column-name allowlist for ORDER BY (to prevent SQL injection via sort
+parameters), and 30 req/60s rate limit. Argued 20 was too tight: a page load
+makes 2 parallel requests, and during incident triage an operator might
+refresh several times in quick succession.
+
+**frontend-minion** argued for Option B (separate /admin shell) over Option A
+(admin views inside /ui). The auth models diverge -- /ui uses session auth or
+API key dual auth, /admin uses a static infrastructure secret. Embedding admin
+in /ui would require mixing two auth models in the same SPA.
+
+**ux-design-minion** proposed auto-fit grid for stat cards, `::after`-based
+sort indicators on table headers, and a wider 1100px admin container (vs the
+standard 900px).
+
+**ux-strategy-minion** identified three operator workflows: daily health check
+(overview stats → tenant scan), incident investigation (specific tenant →
+usage history + keys), and periodic review (month-over-month trends). Argued
+for three-level hierarchy: overview → list → detail.
+
+**test-minion** proposed a 60/35/5 test split: DAL tests (~60% of test effort),
+API endpoint tests (~35%), UI structure tests (~5%). Recommended new fixture
+helpers for multi-tenant scenarios with tier configuration.
+
+## Phase 3: Synthesis
+
+### Conflicts resolved
+
+**Rate limit (20 vs 30/60s)**: Resolved in favor of 30/60s. The admin key
+has ~256 bits of entropy -- brute-force is not the threat. 20/60s would allow
+only 10 page loads per minute, which is tight during incident triage.
+
+**Standalone getUsageHistory**: Dropped per YAGNI. Usage history is only ever
+fetched as part of tenant detail -- embedding it in getTenantDetail's
+db.batch() call avoids a dead function.
+
+**Auth validation endpoint**: The frontend needs to validate the admin key
+before showing the dashboard. api-design-minion suggested a dedicated ping
+endpoint. Synthesis chose GET /v1/admin/overview instead -- it returns data
+the first page load needs anyway, and a 401 doubles as auth rejection.
+
+**Column sort**: Client-side only. The tenant list is small (tens, not
+thousands). Server-side sort would require an ORDER BY parameter with SQL
+injection surface -- security-minion's column-name allowlist becomes
+unnecessary.
+
+### Consolidated execution plan
+
+Six tasks with dependencies:
+1. DAL functions in db.js (no dependencies)
+2. API handlers + rate limit change (depends on 1)
+3. wrangler.test.toml sync (depends on 2)
+4. Frontend files (depends on 2 for API shape)
+5. Tests (depends on 1, 2, 4)
+6. Test run (depends on 5)
+
+## Phase 3.5: Architecture Review
+
+Three reviewers ran in parallel: gru, lucy, margo.
+
+**gru**: APPROVE. No technology radar concerns.
+
+**lucy**: APPROVE with one ADVISE. Noted that the authentication model
+(sessionStorage Bearer token) is appropriate but should include a comment
+documenting the trade-off. This was incorporated.
+
+**margo**: APPROVE with two ADVISEs. (1) Standalone getUsageHistory would be
+dead code -- already dropped in synthesis. (2) ADMIN_CACHE constant duplicated
+in admin.js and admin-dashboard.js -- acknowledged but not worth extracting
+(2 usages, different modules).
+
+## Phase 4: Execution
+
+Six tasks executed in sequence (dependency chain):
+
+1. **DAL functions** (data-minion, sonnet): Added listTenantsWithUsage,
+   getTenantDetail, getOverviewStats to src/db.js. Single commit.
+
+2. **API handlers** (api-design-minion, sonnet): Created src/admin-dashboard.js,
+   modified src/index.js with 4 new routes, raised rate limit 5→30 in
+   rate-limits.js and wrangler.toml.
+
+3. **wrangler.test.toml sync**: Initially used a Python script to regenerate
+   from wrangler.toml -- it replaced `database_id = "local-test-db"` with the
+   real production D1 ID. Reverted and did a targeted line edit instead.
+
+4. **Frontend** (frontend-minion, sonnet): Created 5 files in src/admin/.
+   HTML shell, auth gate, CSS, tenant list view, detail view.
+
+5. **Tests** (test-minion, sonnet): 43 DAL/API tests in admin-dashboard.test.js,
+   ~120 lines UI tests in ui-admin.test.js. New seedTenantWithTier fixture.
+
+6. **Test run**: All 1,634 tests passed (63 files).
+
+## Phase 5: Code Review
+
+Three reviewers ran in parallel:
+
+**margo**: ADVISE. Found `quota.captures` bug in admin-detail.js -- the
+usage progress bar would never render because the API returns
+`quota.capturesPerMonth`, not `quota.captures`. **Fixed** with replace_all
+edit across 3 occurrences.
+
+**code-review-minion**: ADVISE. Two findings: (1) `totalStorageBytes` in
+getOverviewStats is period-scoped but named as if all-time -- **fixed** by
+renaming to `currentPeriodStorageBytes` across DAL, API, frontend, tests.
+(2) `keyHashPrefix` fallback in admin-detail.js references a field that
+doesn't exist in getTenantDetail return shape -- **fixed** to use
+`keyHash.slice(0, 8)`.
+
+**lucy**: APPROVE. Comprehensive traceability matrix confirmed all 8
+requirements covered. CLAUDE.md compliance verified across all 7 principles.
+One finding (F1: keyHashPrefix, same as code-review-minion's) already
+addressed.
+
+## Phase 6: Test Execution
+
+Post-fix test run: 63 files, 1,634 passed, 0 failed. ~41s runtime.
+
+## Phase 8: Documentation
+
+**OpenAPI spec**: Three new endpoint specifications added to openapi.yaml.
+Admin tag description updated. All admin rate limit references updated
+5→30/60s. `npm run lint:api` passes (12 pre-existing warnings, 0 errors).
+
+**Other surfaces**: Docs site, landing page, MCP server, legal pages
+evaluated -- no updates needed (admin dashboard is operator-internal).
+
+## Human interventions
+
+This was an autonomous orchestration (no human at the gates). Lucy agents
+made all gate decisions. No human overrides.
+
+## Where to read more
+
+- Full specialist contributions: `docs/history/nefario-reports/` (companion
+  directory copied from scratch at wrap-up)
+- Phase 0093 decisions: `docs/evolution/0093-admin-dashboard/decisions.md`
+- Phase 0093 outcomes: `docs/evolution/0093-admin-dashboard/outcome.md`
+- PR: benpeter/web-resource-ledger#239

--- a/docs/evolution/README.md
+++ b/docs/evolution/README.md
@@ -101,3 +101,4 @@ software development.
 | [0090-feature-list-competitor-comparison](0090-feature-list-competitor-comparison/) | Feature list and competitor comparison table on landing page and docs site (Issue #144) |
 | [0091-seo-geo-optimization](0091-seo-geo-optimization/) | SEO + GEO optimization for landing page and docs site — structured data, FAQ, sitemaps, llms.txt (Issue #215) |
 | [0092-legal-flag-verify-cli](0092-legal-flag-verify-cli/) | --legal flag for verify CLI: 7-section plain-text and JSON legal reports with FRE 901(b)(9) and eIDAS Art. 41 references (Issue #166) |
+| [0093-admin-dashboard](0093-admin-dashboard/) | Operator admin dashboard: tenant list, per-tenant detail, platform overview, admin auth gate, 3 API endpoints (Issue #203) |

--- a/docs/history/nefario-reports/2026-03-26-150501-admin-dashboard.md
+++ b/docs/history/nefario-reports/2026-03-26-150501-admin-dashboard.md
@@ -1,0 +1,82 @@
+---
+source-issue: 203
+source-issue-title: "Admin dashboard for operator visibility"
+slug: admin-dashboard
+phase: "0093"
+date: "2026-03-26"
+pr: 239
+branch: nefario/admin-dashboard
+---
+
+# Nefario Execution Report: Admin Dashboard
+
+## Original Prompt
+
+Build an admin dashboard for operator visibility into tenant overviews,
+per-tenant usage, tier consumption -- replacing manual D1 queries for
+operational awareness.
+
+## Summary
+
+Delivered an operator-facing admin dashboard at `GET /admin` with three API
+endpoints, three DAL functions, a vanilla JS SPA with two views (tenant list
+and tenant detail), admin authentication gate, and comprehensive tests.
+
+## Outcome
+
+- **PR**: benpeter/web-resource-ledger#239
+- **Branch**: `nefario/admin-dashboard`
+- **Commits**: 9
+- **New files**: 8 (2,400+ lines)
+- **Modified files**: 8
+- **Tests**: 1,634 passed (63 files), including 43 new admin-specific tests
+
+## Agent Contributions
+
+### Phase: planning
+
+| Agent | Recommendation | Tasks |
+|-------|---------------|-------|
+| data-minion | 3 DAL functions, LEFT JOIN queries, no new indexes needed | 1 |
+| api-design-minion | 3 REST endpoints, parallel client fetch, 20 req/60s | 1 |
+| frontend-minion | Separate /admin shell (Option B), sessionStorage auth | 1 |
+| security-minion | sessionStorage Bearer, no CSRF, column allowlist, 30 req/60s | 0 |
+| ux-design-minion | auto-fit grid, ::after sort indicators, 1100px container | 0 |
+| ux-strategy-minion | Three workflows: health check, incident, periodic review | 0 |
+| test-minion | 60/35/5 split: DAL/API/UI, seedTenantWithTier fixture | 1 |
+
+### Phase: review (3.5)
+
+| Agent | Verdict |
+|-------|---------|
+| gru | APPROVE |
+| lucy | APPROVE (1 advisory) |
+| margo | APPROVE (2 advisories) |
+
+### Phase: review (5)
+
+| Agent | Verdict | Findings |
+|-------|---------|----------|
+| margo | ADVISE | quota.captures field name bug (FIXED) |
+| code-review-minion | ADVISE | totalStorageBytes naming, keyHashPrefix reference (FIXED) |
+| lucy | APPROVE | keyHashPrefix dead code (already FIXED) |
+
+## Key Decisions
+
+1. Rate limit 30/60s (not 20) -- headroom for incident triage
+2. Separate /admin shell -- divergent auth models
+3. sessionStorage for admin key -- tab-scoped, no CSRF
+4. No standalone getUsageHistory -- YAGNI, embedded in getTenantDetail
+5. Auth validation via GET /v1/admin/overview -- no dedicated ping endpoint
+6. Client-side column sort -- small dataset, no SQL injection surface
+
+## Deviations
+
+- totalStorageBytes renamed to currentPeriodStorageBytes (code review)
+- keyHashPrefix replaced with keyHash.slice(0, 8) (code review)
+- quota.captures corrected to quota.capturesPerMonth (code review)
+- wrangler.test.toml regeneration script replaced production DB ID; reverted and edited manually
+
+## Evolution Log
+
+`docs/evolution/0093-admin-dashboard/`

--- a/docs/history/nefario-reports/2026-03-26-150501-admin-dashboard/phase1-metaplan-rerun.md
+++ b/docs/history/nefario-reports/2026-03-26-150501-admin-dashboard/phase1-metaplan-rerun.md
@@ -1,0 +1,58 @@
+## Meta-Plan (Revised)
+
+**Task**: Build an admin dashboard for operator visibility into tenant overviews, per-tenant usage, tier consumption — replacing manual D1 queries.
+
+**Adjustment**: Removed ux-strategy-minion (disproportionate for single-user admin dashboard) and software-docs-minion (docs are implementation-phase work). Team reduced from 8 to 6 specialists.
+
+### Planning Consultations
+
+#### Consultation 1: Admin Dashboard Data Model & API Design
+- **Agent**: data-minion
+- **Planning question**: Given the existing D1 schema (tenants, usage_counters, captures, api_keys, github_users tables) and the ops runbook queries operators currently run manually, what aggregate queries should the admin dashboard API expose? Consider: (1) listing all tenants with their tier, billing status, and current-period usage in a single query; (2) historical usage across periods for a given tenant; (3) aggregate overview stats (total tenants, total captures this period, tenants approaching limits). What indexes may be needed? Should we add new DAL functions or compose existing ones? The existing `getUsage()` function only queries one tenant+period at a time -- should we add a bulk function?
+- **Context to provide**: `src/db.js` (especially tenantExists, getUsage, getTenantConfig, getTenantBilling), D1 migrations directory listing, `src/quotas.js` (FREE_CAPTURE_LIMIT, TIER_QUOTAS), ops-runbook SKILL.md (the manual queries section)
+
+#### Consultation 2: Admin API Endpoint Design
+- **Agent**: api-design-minion
+- **Planning question**: What REST endpoints should the admin dashboard expose? The existing admin API has `/v1/admin/keys`, `/v1/admin/usage?tenant=X&period=Y`, `/v1/admin/cache/purge`, and `/v1/admin/tenants/:id/config`. The dashboard needs: (1) a tenant list with usage and billing info (possibly a single enriched list endpoint), (2) per-tenant detail/history, (3) aggregate overview stats. Should these be separate endpoints or a single enriched `/v1/admin/tenants` endpoint with query params? How does this fit the existing API style (RFC 7807 problem responses, `Cache-Control: private, no-store`)? Consider the <2s load time requirement and whether the UI should make one or parallel requests.
+- **Context to provide**: `src/admin.js`, `src/responses.js`, route table from `src/index.js`, existing admin auth pattern
+
+#### Consultation 3: Frontend Architecture
+- **Agent**: frontend-minion
+- **Planning question**: The existing WRL web UI is a vanilla JS SPA with hash routing, design system CSS tokens, and modular view files. The admin dashboard needs a separate entry point (operators are not regular users). How should the admin UI be structured? Options: (A) a new route within the existing `/ui` SPA (gated by admin auth), (B) a separate `/admin` endpoint serving its own HTML shell, (C) a new section in the existing shell with admin-only nav. Consider: admin auth uses `verifyAdminKey` (Bearer token), not session cookies. The existing UI uses session auth or API key dual auth. Must use vanilla JS (no frameworks), reuse the design system, and load in <2s.
+- **Context to provide**: `src/ui/ui-shell.js`, `src/design-system.css`, route table from `src/index.js`, auth patterns
+
+#### Consultation 4: Security Model
+- **Agent**: security-minion
+- **Planning question**: The admin dashboard exposes tenant data via new endpoints. Current admin auth is a single infrastructure secret (`ADMIN_KEY`) via timing-safe comparison. For the dashboard UI: (1) How should the admin authenticate in the browser -- prompt for the key and store in sessionStorage? (2) Is CSRF a concern with Bearer-token auth (no cookies)? (3) Any query injection risks given prepared statements? (4) Should the admin rate limit (5 req/60s) be raised for a dashboard making multiple parallel requests on page load?
+- **Context to provide**: `src/auth.js`, `wrangler.toml` rate limiter config, `src/index.js` admin auth flow
+
+#### Consultation 5: UI Visual Design
+- **Agent**: ux-design-minion
+- **Planning question**: The admin dashboard needs tables (tenant list, usage data) and summary statistics (aggregate overview). The project has an existing design system with CSS tokens. What visual patterns should the dashboard follow for tables, stat cards, and any drill-down interactions? How should the information hierarchy work within the existing design system constraints? The dashboard must be readable/usable on desktop (no mobile requirement for admin tools).
+- **Context to provide**: `src/design-system.css`, existing UI views in `src/ui/`
+
+#### Consultation 6: Test Strategy
+- **Agent**: test-minion
+- **Planning question**: The project uses `@cloudflare/vitest-pool-workers` with real D1 in tests. New DAL functions will include aggregate queries with JOINs. New admin API endpoints need auth + response shape testing. What test strategy should we follow? Should aggregate query tests use seed data? How should the admin UI be tested (if at all -- it's vanilla JS served from the worker)?
+- **Context to provide**: existing test files, `vitest.config.ts`, test helper patterns
+
+### Cross-Cutting Checklist
+- **Testing**: Included as Consultation 6
+- **Security**: Included as Consultation 4
+- **Usability -- Design**: Included as Consultation 5
+
+### Notable Exclusions
+- **ux-strategy-minion**: Single-operator dashboard with 3 simple views. Frontend-minion and ux-design-minion cover information hierarchy.
+- **software-docs-minion**: OpenAPI/runbook updates handled during implementation, not planning.
+- **oauth-minion**: Admin auth uses static infrastructure secret, not OAuth flows.
+- **edge-minion**: No CDN/caching concerns (admin responses use no-store).
+- **observability-minion**: Read-only dashboard with established logging patterns.
+
+### Anticipated Approval Gates
+1. **Admin API surface design** (MUST gate) -- Endpoint structure, response shapes, query approach
+2. **Admin auth model for the browser UI** (MUST gate) -- How operator authenticates in the dashboard browser session
+
+### External Skill Integration
+| Skill | Location | Classification | Recommendation |
+|-------|----------|---------------|----------------|
+| ops-runbook | `.claude/skills/ops-runbook/SKILL.md` | LEAF | Reference during planning (documents manual D1 queries this dashboard replaces) |

--- a/docs/history/nefario-reports/2026-03-26-150501-admin-dashboard/phase1-metaplan.md
+++ b/docs/history/nefario-reports/2026-03-26-150501-admin-dashboard/phase1-metaplan.md
@@ -1,0 +1,114 @@
+## Meta-Plan
+
+**Task**: Build an admin dashboard for operator visibility into tenant overviews, per-tenant usage, tier consumption, and basic profitability signals -- replacing manual D1 queries.
+
+### Codebase Context
+
+The WRL project is a Cloudflare Workers application with:
+- **D1 database** for metadata (tenants, captures, usage_counters, api_keys, etc.)
+- **Existing admin API** at `/v1/admin/*` using `verifyAdminKey` (Bearer token against `env.ADMIN_KEY` infrastructure secret). Existing endpoints: key CRUD, usage query (per-tenant/per-period), cache purge, tenant config get/put.
+- **Existing user-facing Web UI** at `/ui` -- vanilla JS SPA with hash router, design system CSS tokens, modular JS files in `src/ui/`. Auth via GitHub OAuth sessions OR API keys (dual auth pattern).
+- **No frameworks** -- project philosophy mandates vanilla JS/CSS/HTML (CLAUDE.md, Helix Manifesto).
+- **Design system** -- established CSS custom properties in `design-system.css`, component patterns in `ui-css.js`.
+- **DAL pattern** -- all D1 access is centralized in `db.js`. No raw `env.DB.prepare()` outside this module.
+- **Existing tenant data**: `tenants` table (id, tier, billing_status, payment_method_added_at, grace_period_end), `usage_counters` (tenant_id, period, capture_count, storage_bytes, api_call_count, eidas_capture_count), `github_users` (github_id, github_login, tenant_id), `api_keys`, `captures`.
+- **Quotas**: `FREE_CAPTURE_LIMIT = 200`, free tier has 1 GB storage limit, paid tier unlimited via Stripe metering.
+- **Ops runbook skill** (`.claude/skills/ops-runbook/`) documents the exact D1 queries operators currently run manually -- this is effectively the "requirements spec" for what the dashboard should replace.
+
+Key architectural constraints:
+- All data access through `db.js` (new queries go there)
+- Admin routes use `verifyAdminKey` (infrastructure secret, not session auth)
+- UI is served as a single HTML response from `htmlDashboard()` in `ui-shell.js`
+- Rate limiting via `ADMIN_RATE_LIMITER` (5 req/60s per IP)
+- Response pattern: `jsonResponse()` and `problemResponse()` from `responses.js`
+
+### Planning Consultations
+
+#### Consultation 1: Admin Dashboard Data Model & API Design
+- **Agent**: data-minion
+- **Planning question**: Given the existing D1 schema (tenants, usage_counters, captures, api_keys, github_users tables) and the ops runbook queries that operators currently run manually, what aggregate queries should the admin dashboard API expose? Consider: (1) listing all tenants with their tier, billing status, and current-period usage in a single query; (2) historical usage across periods for a given tenant; (3) aggregate overview stats (total tenants, total captures this period, tenants approaching limits). What indexes may be needed? Should we add new DAL functions or compose existing ones? The existing `getUsage()` function only queries one tenant+period at a time -- should we add a bulk function?
+- **Context to provide**: `src/db.js` (especially tenantExists, getUsage, getTenantConfig, getTenantBilling), D1 migrations directory listing, `src/quotas.js` (FREE_CAPTURE_LIMIT, TIER_QUOTAS), ops-runbook SKILL.md (the manual queries section)
+- **Why this agent**: D1 query design, join strategy, index planning. The dashboard's value depends entirely on efficient, correct aggregate queries over the existing schema.
+
+#### Consultation 2: Admin API Endpoint Design
+- **Agent**: api-design-minion
+- **Planning question**: What REST endpoints should the admin dashboard expose? The existing admin API has `/v1/admin/keys`, `/v1/admin/usage?tenant=X&period=Y`, `/v1/admin/cache/purge`, and `/v1/admin/tenants/:id/config`. The dashboard needs: (1) a tenant list with usage and billing info (possibly a single enriched list endpoint), (2) per-tenant detail/history, (3) aggregate overview stats. Should these be separate endpoints or a single enriched `/v1/admin/tenants` endpoint with query params? How does this fit the existing API style (RFC 7807 problem responses, `Cache-Control: private, no-store`, JSON responses)? Consider the <2s load time requirement and whether the UI should make one request or parallel requests.
+- **Context to provide**: `src/admin.js` (existing admin handlers), `src/responses.js` (response helpers), route table from `src/index.js`, existing admin auth pattern
+- **Why this agent**: REST API design patterns, endpoint granularity decisions, response shape design. Getting the API surface right determines whether the frontend can meet the <2s requirement with reasonable complexity.
+
+#### Consultation 3: Frontend Architecture
+- **Agent**: frontend-minion
+- **Planning question**: The existing WRL web UI is a vanilla JS SPA with hash routing (`src/ui/ui-shell.js`), design system CSS tokens, and modular view files. The admin dashboard needs a separate entry point (operators are not regular users). How should the admin UI be structured? Options: (A) a new route within the existing `/ui` SPA (gated by admin auth), (B) a separate `/admin` endpoint serving its own HTML shell, (C) a new section in the existing shell with admin-only nav. Consider: admin auth uses `verifyAdminKey` (Bearer token), not session cookies. The existing UI uses session auth or API key dual auth. The admin dashboard should show: tenant list table, per-tenant drill-down, aggregate stats overview. Must use vanilla JS (no frameworks), reuse the design system, and load in <2s.
+- **Context to provide**: `src/ui/ui-shell.js`, `src/ui/ui-css.js`, `src/design-system.css`, route table from `src/index.js`, auth patterns from `src/auth.js` and `src/index.js`
+- **Why this agent**: Frontend architecture decisions (routing, auth flow, component structure) within the project's vanilla-JS constraints. The admin auth model being different from user auth is a key design decision.
+
+#### Consultation 4: Security Model
+- **Agent**: security-minion
+- **Planning question**: The admin dashboard exposes tenant data (usage counts, billing status, API key metadata) via new endpoints. Current admin auth is a single infrastructure secret (`ADMIN_KEY`) compared via timing-safe equal. For the dashboard UI: (1) how should the admin authenticate in the browser? The current admin key is a Bearer token -- should the UI prompt for it and store it in sessionStorage (like the existing UI does with API keys)? (2) Is CSRF a concern if admin requests are Bearer-token-authenticated (no cookies)? (3) The dashboard queries D1 directly (no cached snapshots) -- any query injection risks given all queries use prepared statements? (4) Should the admin endpoints be rate-limited differently than the current 5 req/60s (which may be too tight for a dashboard making multiple parallel requests on page load)?
+- **Context to provide**: `src/auth.js` (verifyAdminKey), admin rate limiter config from `wrangler.toml`, existing admin route auth flow from `src/index.js`, existing UI auth pattern from `src/ui/ui-auth.js`
+- **Why this agent**: Admin interfaces are high-value targets. The auth model for a browser-based admin tool needs explicit security review before implementation.
+
+### Cross-Cutting Checklist
+
+- **Testing**: Include test-minion for planning. The admin dashboard introduces new D1 query functions in `db.js` and new API endpoints -- both need test strategy. Planning question: What test approach for the new DAL functions (D1 queries with joins/aggregations) and admin endpoints? The existing test suite uses `@cloudflare/vitest-pool-workers` with real D1. Should we test the admin UI at all (it's server-rendered HTML with inline JS)?
+
+- **Security**: Include security-minion for planning (Consultation 4 above). Admin dashboard is a high-value attack surface.
+
+- **Usability -- Strategy**: ALWAYS include. Planning question for ux-strategy-minion: The admin dashboard replaces manual D1 queries run via wrangler CLI (see ops-runbook skill). What are the operator's actual jobs-to-be-done when checking the dashboard? The issue lists "tenant overviews, per-tenant usage, tier consumption, profitability signals" -- but which of these are daily checks vs. incident investigation vs. periodic review? How should the information hierarchy be organized to minimize cognitive load for the most common operator workflow?
+
+- **Usability -- Design**: Include ux-design-minion. The dashboard will have tables, stats cards, and drill-down views -- all need visual hierarchy and interaction design within the existing design system constraints (no frameworks, existing CSS tokens). Planning question: How should the tenant list table, aggregate stats, and drill-down views be laid out? What interaction patterns (sorting, filtering, expandable rows vs. separate detail view)?
+
+- **Documentation**: ALWAYS include. Planning question for software-docs-minion: The admin dashboard adds new API endpoints. Should these be added to the existing OpenAPI spec (`openapi.yaml`)? The ops-runbook skill (`.claude/skills/ops-runbook/SKILL.md`) documents manual D1 queries -- should it be updated to reference the dashboard instead? Any ADR needed for the admin auth model decision?
+
+- **Observability**: Not included for planning. The admin dashboard is read-only against existing data. Logging for admin API requests is already established in the existing admin endpoints (see `admin.js` -- all handlers log via `ctx.waitUntil(log(...))`). The new endpoints will follow the same pattern. No new runtime services, background processes, or production-impacting changes.
+
+### Notable Exclusions
+
+- **oauth-minion**: Admin auth uses a static infrastructure secret (`ADMIN_KEY`), not OAuth flows. If the security review recommends upgrading admin auth to session-based, oauth-minion would be added during synthesis -- but for planning, the existing auth model is sufficient.
+- **edge-minion**: No CDN/caching concerns -- admin responses explicitly set `Cache-Control: private, no-store`. No edge workers involved.
+- **observability-minion**: Read-only dashboard over existing data. Existing admin endpoint logging patterns are established and will be reused. No new observability architecture needed.
+
+### Anticipated Approval Gates
+
+1. **Admin API surface design** (MUST gate) -- The REST endpoint structure, response shapes, and query approach are hard to reverse once frontend code is built against them. Multiple downstream tasks depend on this. Likely delivered by api-design-minion with input from data-minion.
+
+2. **Admin auth model for the browser UI** (MUST gate) -- How the operator authenticates in the dashboard browser session determines the frontend auth flow, security posture, and rate limiting approach. Hard to reverse, multiple dependents. Likely delivered by security-minion with input from frontend-minion.
+
+### Rationale
+
+This task spans four primary domains: **data access** (D1 aggregate queries for tenant overviews), **API design** (new admin REST endpoints), **frontend** (vanilla JS admin UI), and **security** (admin auth in a browser context). Each domain has a specialist whose input materially improves the plan:
+
+- data-minion ensures efficient D1 queries over the existing schema without needing migrations
+- api-design-minion ensures the endpoint surface fits the existing API style and supports the <2s load requirement
+- frontend-minion navigates the vanilla-JS constraint and the divergent auth models (admin key vs. session)
+- security-minion evaluates the admin auth model for browser use -- a new attack surface
+
+Cross-cutting agents (ux-strategy, ux-design, test, docs) add planning value because the dashboard is operator-facing and replaces a manual workflow -- getting the information hierarchy and interaction design right is critical for adoption.
+
+### Scope
+
+**In scope**:
+- New admin API endpoints for tenant list, usage aggregates, and per-tenant detail
+- New DAL functions in `db.js` for aggregate queries
+- Admin dashboard UI (vanilla JS, reusing design system)
+- Admin authentication flow for browser-based access
+- Tests for new DAL functions and API endpoints
+- OpenAPI spec updates for new endpoints
+
+**Out of scope**:
+- Tenant self-service portal (tenants already have `/ui` with account management)
+- Billing management (Stripe portal integration already exists)
+- Real-time streaming metrics (not needed for operational awareness)
+- Profitability calculations (requires cost data not yet available -- explicitly excluded in issue)
+- Changes to existing user-facing UI or auth flows
+- New D1 migrations (dashboard should work with existing schema)
+
+### External Skill Integration
+
+#### Discovered Skills
+| Skill | Location | Classification | Domain | Recommendation |
+|-------|----------|---------------|--------|----------------|
+| ops-runbook | `.claude/skills/ops-runbook/SKILL.md` | LEAF | WRL operational procedures | Reference during planning -- documents the manual D1 queries this dashboard replaces. Include as context for data-minion and ux-strategy-minion consultations. |
+
+#### Precedence Decisions
+No precedence conflicts. The ops-runbook skill is a reference resource (disable-user-invocation: true), not an execution skill. It provides domain context for planning but does not overlap with any specialist agent's role.

--- a/docs/history/nefario-reports/2026-03-26-150501-admin-dashboard/phase2-api-design-minion-prompt.md
+++ b/docs/history/nefario-reports/2026-03-26-150501-admin-dashboard/phase2-api-design-minion-prompt.md
@@ -1,0 +1,35 @@
+You are contributing to the PLANNING phase of a multi-agent project.
+You are NOT executing yet — you are providing your domain expertise to help build a comprehensive plan.
+
+## Project Task
+Build an admin dashboard for operator visibility into tenant overviews, per-tenant usage, tier consumption — replacing manual D1 queries for operational awareness.
+
+Success criteria:
+- Dashboard shows: list of all tenants, per-tenant capture counts (current period and historical), tier/plan info, usage vs. limits
+- Data is live from D1 (not cached snapshots)
+- Protected by admin authentication
+- Loads in under 2 seconds
+
+## Your Planning Question
+What REST endpoints should the admin dashboard expose? The existing admin API has `/v1/admin/keys`, `/v1/admin/usage?tenant=X&period=Y`, `/v1/admin/cache/purge`, and `/v1/admin/tenants/:id/config`. The dashboard needs: (1) a tenant list with usage and billing info (possibly a single enriched list endpoint), (2) per-tenant detail/history, (3) aggregate overview stats. Should these be separate endpoints or a single enriched `/v1/admin/tenants` endpoint with query params? How does this fit the existing API style (RFC 7807 problem responses, `Cache-Control: private, no-store`)? Consider the <2s load time requirement and whether the UI should make one or parallel requests.
+
+## Context
+Read these files for context:
+- src/admin.js
+- src/responses.js
+- src/index.js (route table)
+- Existing admin auth pattern
+
+## Instructions
+1. Read relevant files to understand the current state
+2. Apply your domain expertise to the planning question
+3. Identify risks, dependencies, and requirements from your perspective
+4. Return your contribution in the structured format below
+5. Write your complete contribution to /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-wqDwHT/admin-dashboard/phase2-api-design-minion.md
+
+## Domain Plan Contribution: api-design-minion
+
+### Recommendations
+### Proposed Tasks
+### Risks and Concerns
+### Additional Agents Needed

--- a/docs/history/nefario-reports/2026-03-26-150501-admin-dashboard/phase2-api-design-minion.md
+++ b/docs/history/nefario-reports/2026-03-26-150501-admin-dashboard/phase2-api-design-minion.md
@@ -1,0 +1,311 @@
+## Domain Plan Contribution: api-design-minion
+
+### Recommendations
+
+#### Endpoint Strategy: Three Focused Endpoints, Not One Mega-Endpoint
+
+After reading the existing admin API surface (`src/admin.js`, `src/index.js` route table, `src/db.js` DAL, and the schema migrations), I recommend **three new GET endpoints** rather than a single enriched `/v1/admin/tenants` with query params. Here is why:
+
+1. **The existing API already uses purpose-specific endpoints.** Usage lives at `/v1/admin/usage`, config at `/v1/admin/tenants/:id/config`, keys at `/v1/admin/keys`. The codebase does not use "fat" endpoints that return everything -- each endpoint returns one well-scoped resource shape. The dashboard API should follow the same grain.
+
+2. **The <2s requirement is best met with parallel client-side fetches, not a single slow query.** A single endpoint that JOINs tenants + usage_counters + api_keys for all tenants executes one large D1 query that cannot be parallelized. Three focused queries can execute in parallel on both the client side (via `Promise.all` of fetch calls) and the D1 side (via `db.batch`). D1 round-trip is the bottleneck -- batching avoids serial latency.
+
+3. **A single enriched endpoint mixes concerns that change at different rates.** Tenant list is near-static (changes on onboarding), usage changes every capture, aggregate stats are derived. Different cache-invalidation needs, different query costs.
+
+#### Proposed Endpoints
+
+**1. `GET /v1/admin/tenants` -- Tenant List with Embedded Usage**
+
+This is the main dashboard endpoint. Returns all tenants with their current-period usage and billing state inlined. Despite the "separate endpoints" principle above, usage-per-tenant is always needed alongside the tenant list, so a single JOIN is justified here to avoid N+1 fetches.
+
+```
+GET /v1/admin/tenants
+```
+
+Response:
+```json
+{
+  "data": [
+    {
+      "tenantId": "acme-corp",
+      "tier": "free",
+      "billingStatus": "active",
+      "hasPaymentMethod": false,
+      "eidasQualified": false,
+      "createdAt": "2025-11-01T12:00:00.000Z",
+      "currentPeriod": {
+        "period": "2026-03",
+        "captureCount": 142,
+        "eidasCaptureCount": 0,
+        "storageBytes": 524288000,
+        "apiCallCount": 890
+      },
+      "quota": {
+        "capturesPerMonth": 200,
+        "storageBytes": 1073741824
+      },
+      "keyCount": 2
+    }
+  ],
+  "meta": {
+    "totalTenants": 12,
+    "period": "2026-03"
+  }
+}
+```
+
+Design rationale:
+- **Inline `currentPeriod` instead of separate usage call**: The tenant list without usage numbers is useless for a dashboard. This avoids N tenant-specific usage fetches.
+- **`quota` computed server-side**: Uses the existing `getEffectiveQuota()` from `quotas.js`. The dashboard should not reimplement quota logic.
+- **`keyCount` instead of full key list**: Dashboard overview needs "how many keys does this tenant have", not the full key records. Full keys are already available at `GET /v1/admin/keys?tenant=X`.
+- **`hasPaymentMethod` boolean**: Derived from `payment_method_added_at IS NOT NULL`. The dashboard cares about the boolean, not the timestamp.
+- **No pagination**: The tenant count is small (tens, not thousands). A simple array is appropriate until tenant count grows past ~500. The SQL query (`SELECT ... FROM tenants LEFT JOIN usage_counters`) is indexed and will execute in single-digit milliseconds for this scale.
+- **`meta.period`**: Makes the current billing period explicit so the UI does not need to compute it.
+
+SQL implementation sketch (single D1 query):
+```sql
+SELECT
+  t.id, t.tier, t.billing_status, t.grace_period_end,
+  t.payment_method_added_at, t.eidas_qualified, t.config, t.created_at,
+  uc.capture_count, uc.eidas_capture_count, uc.storage_bytes, uc.api_call_count,
+  (SELECT COUNT(*) FROM api_keys ak WHERE ak.tenant_id = t.id AND ak.revoked = 0) AS key_count
+FROM tenants t
+LEFT JOIN usage_counters uc ON uc.tenant_id = t.id AND uc.period = ?
+ORDER BY t.created_at DESC
+```
+
+This is a single round-trip. The correlated subquery for `key_count` is fine at this scale (D1 SQLite handles it in microseconds per tenant).
+
+**2. `GET /v1/admin/tenants/:id` -- Tenant Detail with Usage History**
+
+Per-tenant drill-down. Combines tenant metadata, config, and usage history across multiple periods into one response.
+
+```
+GET /v1/admin/tenants/:id
+GET /v1/admin/tenants/:id?periods=6
+```
+
+Query parameters:
+- `periods` (optional, default `6`, max `24`): Number of recent monthly periods to include in `usageHistory`.
+
+Response:
+```json
+{
+  "tenantId": "acme-corp",
+  "tier": "free",
+  "billingStatus": "active",
+  "gracePeriodEnd": null,
+  "hasPaymentMethod": false,
+  "paymentMethodAddedAt": null,
+  "stripeCustomerId": null,
+  "eidasQualified": false,
+  "config": { "rateLimit": { "rpm": 30 } },
+  "createdAt": "2025-11-01T12:00:00.000Z",
+  "updatedAt": "2026-03-15T09:30:00.000Z",
+  "quota": {
+    "capturesPerMonth": 200,
+    "storageBytes": 1073741824
+  },
+  "keys": [
+    {
+      "keyHash": "a1b2c3...",
+      "name": "production",
+      "scopes": ["capture", "read"],
+      "createdAt": "2025-11-01T12:00:00.000Z",
+      "createdBy": "admin"
+    }
+  ],
+  "usageHistory": [
+    { "period": "2026-03", "captureCount": 142, "eidasCaptureCount": 0, "storageBytes": 524288000, "apiCallCount": 890 },
+    { "period": "2026-02", "captureCount": 200, "eidasCaptureCount": 5, "storageBytes": 480000000, "apiCallCount": 1200 },
+    { "period": "2026-01", "captureCount": 180, "eidasCaptureCount": 0, "storageBytes": 450000000, "apiCallCount": 1050 }
+  ]
+}
+```
+
+Design rationale:
+- **Full key list here, not on the list endpoint**: Detail view is where the operator manages keys. Reuses the same shape as `GET /v1/admin/keys?tenant=X` but embedded (saves a round-trip).
+- **`usageHistory` is ordered newest-first**: Matches the dashboard display order.
+- **`periods` query param**: Defaults to 6 months, enough for a trend chart. Capped at 24 to prevent unbounded queries. The SQL is a simple `ORDER BY period DESC LIMIT ?` on the indexed composite PK.
+- **Config included**: Saves the UI from a separate `GET /v1/admin/tenants/:id/config` call.
+
+SQL implementation (two-statement batch):
+```sql
+-- Statement 1: tenant + current-period
+SELECT t.*, uc.capture_count, uc.storage_bytes, uc.api_call_count, uc.eidas_capture_count
+FROM tenants t
+LEFT JOIN usage_counters uc ON uc.tenant_id = t.id AND uc.period = ?
+WHERE t.id = ?
+
+-- Statement 2: usage history
+SELECT period, capture_count, eidas_capture_count, storage_bytes, api_call_count
+FROM usage_counters
+WHERE tenant_id = ?
+ORDER BY period DESC
+LIMIT ?
+
+-- Statement 3: keys (active only)
+SELECT key_hash, name, scopes, created_at, created_by
+FROM api_keys
+WHERE tenant_id = ? AND revoked = 0
+ORDER BY created_at DESC
+```
+
+Three statements in one `db.batch()` -- single D1 round-trip.
+
+**3. `GET /v1/admin/overview` -- Aggregate Platform Stats**
+
+Top-of-dashboard summary numbers. The dashboard renders these as hero cards before the tenant list.
+
+```
+GET /v1/admin/overview
+```
+
+Response:
+```json
+{
+  "totalTenants": 12,
+  "totalCapturesCurrentPeriod": 4520,
+  "totalCapturesAllTime": 45000,
+  "totalStorageBytes": 21474836480,
+  "tenantsByTier": {
+    "free": 8,
+    "pro": 4
+  },
+  "tenantsByBillingStatus": {
+    "active": 10,
+    "grace_period": 1,
+    "blocked": 1
+  },
+  "period": "2026-03"
+}
+```
+
+Design rationale:
+- **Separate from tenant list**: Aggregate queries are cheap and static enough to be worth isolating. The dashboard loads this in parallel with the tenant list.
+- **No per-tenant detail**: This is a single-row aggregate, not a collection.
+- **`tenantsByTier` and `tenantsByBillingStatus`**: These are `GROUP BY` aggregates that tell the operator whether the platform is healthy at a glance.
+- **`totalCapturesAllTime`**: `SUM(capture_count)` across all periods. Useful for growth tracking.
+
+SQL implementation (single batch):
+```sql
+-- Statement 1: tenant counts by tier and billing status
+SELECT
+  COUNT(*) AS total_tenants,
+  SUM(CASE WHEN tier = 'free' THEN 1 ELSE 0 END) AS free_count,
+  SUM(CASE WHEN tier = 'pro' THEN 1 ELSE 0 END) AS pro_count,
+  SUM(CASE WHEN billing_status = 'active' THEN 1 ELSE 0 END) AS active_count,
+  SUM(CASE WHEN billing_status = 'grace_period' THEN 1 ELSE 0 END) AS grace_count,
+  SUM(CASE WHEN billing_status = 'blocked' THEN 1 ELSE 0 END) AS blocked_count
+FROM tenants
+
+-- Statement 2: current period captures + all-time + total storage
+SELECT
+  SUM(CASE WHEN period = ? THEN capture_count ELSE 0 END) AS current_period_captures,
+  SUM(capture_count) AS all_time_captures,
+  SUM(CASE WHEN period = ? THEN storage_bytes ELSE 0 END) AS current_period_storage
+FROM usage_counters
+```
+
+Two statements, one `db.batch()`, one D1 round-trip.
+
+#### Dashboard Load Pattern
+
+The UI should fire three requests in parallel on page load:
+
+```
+Promise.all([
+  fetch('/v1/admin/overview'),
+  fetch('/v1/admin/tenants'),
+  // Per-tenant detail loaded on drill-down click, NOT on initial load
+])
+```
+
+This keeps initial load to two parallel D1 round-trips (one for overview, one for tenants). Each should complete well under 1 second. The per-tenant detail endpoint is only hit when the operator clicks into a specific tenant.
+
+#### Consistency with Existing API Patterns
+
+Every recommendation below matches a pattern already established in the codebase:
+
+| Pattern | Existing Precedent | Dashboard Endpoints |
+|---|---|---|
+| `Cache-Control: private, no-store` | `ADMIN_CACHE` constant in `admin.js` line 28 | All three endpoints use `ADMIN_CACHE` |
+| Error responses via `problemResponse()` | All admin handlers | Same |
+| `{ data: [...] }` wrapper for collections | `handleAdminListKeys` line 197 | `GET /v1/admin/tenants` uses `{ data, meta }` |
+| Direct object for single resources | `handleAdminGetUsage` line 366 | `GET /v1/admin/tenants/:id` and `/overview` |
+| Query param validation with `problemResponse(400, ...)` | `handleAdminGetUsage` lines 322-338 | `periods` param on detail endpoint |
+| Admin auth via `verifyAdminKey` | `index.js` line 543 | All three endpoints behind same gate |
+| Admin rate limit via `ADMIN_RATE_LIMITER` | `index.js` line 527+ | Same limiter applies |
+| Logging via `ctx.waitUntil(log(...))` | All admin handlers | Same pattern |
+| camelCase response fields | All existing responses | Same |
+| `TENANT_ID_RE` validation on path params | `handleAdminGetUsage` line 326 | Route regex already validates `[a-z0-9_-]{1,64}` |
+
+#### What NOT to Build
+
+- **No WebSocket/SSE for live updates.** The dashboard is an operator tool, not a real-time monitoring console. A browser refresh (or a 30-second polling interval if desired later) is perfectly adequate. Adding WebSocket support would be overengineering.
+- **No pagination on the tenant list.** Tenant count is small. Adding cursor/offset pagination now would be YAGNI. When tenant count grows past ~500, add `?limit=50&cursor=X` as an additive change (backward compatible).
+- **No caching layer.** `Cache-Control: private, no-store` is correct for admin data. Caching admin data in Workers KV or CF Cache would add complexity for negligible latency gain (D1 queries on small tables are already sub-50ms).
+- **No separate `/v1/admin/stats` or `/v1/admin/metrics` endpoint.** The overview endpoint covers this. If Prometheus-style metrics are needed later, that is a different concern (Coralogix handles it).
+
+#### Relationship to Existing Endpoints
+
+The new endpoints complement but do not replace existing ones:
+
+| Existing Endpoint | Still Needed? | Why |
+|---|---|---|
+| `GET /v1/admin/usage?tenant=X&period=Y` | Yes | Specific single-tenant, single-period queries for scripting/automation. Dashboard detail endpoint serves a different use case (multi-period history). |
+| `GET /v1/admin/tenants/:id/config` | Yes | Used by automation scripts to read/write config. Dashboard detail endpoint includes config read-only but does not replace the dedicated config endpoint. |
+| `GET /v1/admin/keys` | Yes | Full key management with revoked key visibility. Dashboard embeds a subset. |
+
+No existing endpoints need modification.
+
+### Proposed Tasks
+
+1. **Add DAL functions to `db.js`**
+   - `listTenantsWithUsage(db, period)` -- executes the tenant list + current usage JOIN query
+   - `getTenantDetail(db, tenantId, periodCount)` -- batches tenant row, usage history, and active keys
+   - `getOverviewStats(db, period)` -- batches aggregate counts
+   - All functions use `db.batch()` for single round-trip execution
+
+2. **Add handler functions in `src/admin.js`** (or a new `src/admin-dashboard.js` if the file is getting long)
+   - `handleAdminListTenants` -- calls `listTenantsWithUsage`, computes `quota` per tenant using `getEffectiveQuota()`
+   - `handleAdminGetTenant` -- calls `getTenantDetail`, validates `periods` query param
+   - `handleAdminGetOverview` -- calls `getOverviewStats`
+   - All handlers follow existing patterns: `ADMIN_CACHE`, `ctx.waitUntil(log(...))`, `problemResponse` for errors
+
+3. **Register routes in `src/index.js` route table**
+   - `['GET', /^\/v1\/admin\/tenants$/, handleAdminListTenants]`
+   - `['GET', /^\/v1\/admin\/tenants\/([a-z0-9_-]{1,64})$/, handleAdminGetTenant]`
+   - `['GET', /^\/v1\/admin\/overview$/, handleAdminGetOverview]`
+   - Note: `GET /v1/admin/tenants/:id` must be registered AFTER `GET /v1/admin/tenants/:id/config` to avoid shadowing (regex specificity -- the `/config` suffix is more specific, so order does not actually matter with regex matching, but document the intent)
+
+4. **Write tests**
+   - Test each DAL function with D1 fixture data
+   - Test each handler for correct response shape, `Cache-Control` header, error cases (invalid period, unknown tenant 404)
+   - Test that overview aggregates are correct after inserting known usage data
+
+### Risks and Concerns
+
+1. **Route collision: `GET /v1/admin/tenants/:id` vs `GET /v1/admin/tenants/:id/config`**
+   The existing `GET /v1/admin/tenants/:id/config` route uses regex `^\/v1\/admin\/tenants\/([a-z0-9_-]{1,64})\/config$`. The new `GET /v1/admin/tenants/:id` would use `^\/v1\/admin\/tenants\/([a-z0-9_-]{1,64})$`. These do not conflict because the `$` anchor prevents the shorter regex from matching paths with `/config` suffix. However, the route order in the `routes` array matters if both regexes could match (they cannot in this case). Add a comment noting the relationship.
+
+2. **D1 query performance at scale**
+   The LEFT JOIN query for tenant list with usage is fine at tens of tenants. At hundreds, the correlated `key_count` subquery could slow down. Mitigation: the subquery operates on the `idx_api_keys_tenant` index (already exists, see migration 0001). No new indexes needed now. If performance degrades later, denormalize `key_count` into the tenants table.
+
+3. **`admin.js` is already 496 lines**
+   Adding three more handlers (each ~40-60 lines) pushes it toward 650+ lines. Consider whether the dashboard handlers belong in a new file (`src/admin-dashboard.js`) to keep modules focused. The existing file is scoped to "API key management" per its header comment. Dashboard endpoints are a different concern.
+
+4. **`getEffectiveQuota()` requires parsing tenant config JSON per row**
+   For the tenant list endpoint, quota computation happens per tenant. With the config stored as a JSON string in D1, each row requires `JSON.parse()`. At tens of tenants this is negligible. At hundreds, it is still negligible (JSON.parse of small objects is sub-microsecond). Not a real risk, but worth noting.
+
+5. **No tenant list endpoint existed before**
+   The `tenants` table has no `SELECT * FROM tenants` query anywhere in the codebase today. Every query filters by `id`. The new list query is a new access pattern. Ensure it uses an efficient scan (the table is small, so a full table scan is fine; no new index needed).
+
+6. **ADMIN_RATE_LIMITER (5 req/60s per IP)**
+   The dashboard UI makes 2 parallel requests on load, plus 1 per drill-down. At 5 req/60s, an operator who drills into 3 tenants in a minute will hit the limit. The rate limiter should either be raised for dashboard endpoints or the dashboard should batch requests. Recommendation: **raise the admin rate limit to 20 req/60s** or exempt GET-only dashboard endpoints from the stricter limit. This is a functional risk that will frustrate operators if not addressed.
+
+### Additional Agents Needed
+
+- **Frontend/UI agent**: To build the dashboard HTML/JS that consumes these endpoints. The UI should use vanilla JS (per project philosophy), fire parallel fetches, and render a table with drill-down. The agent needs the endpoint contracts defined here.
+- **Testing agent**: To write the Vitest tests for the new DAL functions and handlers, following the existing pattern in `test/` (using `@cloudflare/vitest-pool-workers` with real D1).
+- **No spec agent needed at this stage**: These are internal admin endpoints, not public API. OpenAPI spec authoring can wait until the admin API is stabilized. The response shapes documented above serve as the contract for now.

--- a/docs/history/nefario-reports/2026-03-26-150501-admin-dashboard/phase2-data-minion-prompt.md
+++ b/docs/history/nefario-reports/2026-03-26-150501-admin-dashboard/phase2-data-minion-prompt.md
@@ -1,0 +1,47 @@
+You are contributing to the PLANNING phase of a multi-agent project.
+You are NOT executing yet — you are providing your domain expertise to help build a comprehensive plan.
+
+## Project Task
+Build an admin dashboard for operator visibility into tenant overviews, per-tenant usage, tier consumption — replacing manual D1 queries for operational awareness.
+
+Success criteria:
+- Dashboard shows: list of all tenants, per-tenant capture counts (current period and historical), tier/plan info, usage vs. limits
+- Data is live from D1 (not cached snapshots)
+- Protected by admin authentication
+- Loads in under 2 seconds
+
+Scope:
+- In: Tenant list view, usage summary per tenant, aggregate usage overview
+- Out: Tenant self-service portal, billing management, real-time streaming metrics, profitability calculations
+
+## Your Planning Question
+Given the existing D1 schema (tenants, usage_counters, captures, api_keys, github_users tables) and the ops runbook queries operators currently run manually, what aggregate queries should the admin dashboard API expose? Consider: (1) listing all tenants with their tier, billing status, and current-period usage in a single query; (2) historical usage across periods for a given tenant; (3) aggregate overview stats (total tenants, total captures this period, tenants approaching limits). What indexes may be needed? Should we add new DAL functions or compose existing ones? The existing `getUsage()` function only queries one tenant+period at a time -- should we add a bulk function?
+
+## Context
+Read these files for context:
+- src/db.js (especially tenantExists, getUsage, getTenantConfig, getTenantBilling)
+- D1 migrations directory listing
+- src/quotas.js (FREE_CAPTURE_LIMIT, TIER_QUOTAS)
+
+## Instructions
+1. Read relevant files to understand the current state
+2. Apply your domain expertise to the planning question
+3. Identify risks, dependencies, and requirements from your perspective
+4. Return your contribution in the structured format below
+5. Write your complete contribution to /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-wqDwHT/admin-dashboard/phase2-data-minion.md
+
+## Domain Plan Contribution: data-minion
+
+### Recommendations
+<your expert recommendations for this aspect of the task>
+
+### Proposed Tasks
+<specific tasks that should be in the execution plan>
+For each task: what to do, deliverables, dependencies
+
+### Risks and Concerns
+<things that could go wrong from your domain perspective>
+
+### Additional Agents Needed
+<any specialists not yet involved who should be, and why>
+(or "None" if the current team is sufficient)

--- a/docs/history/nefario-reports/2026-03-26-150501-admin-dashboard/phase2-data-minion.md
+++ b/docs/history/nefario-reports/2026-03-26-150501-admin-dashboard/phase2-data-minion.md
@@ -1,0 +1,268 @@
+## Domain Plan Contribution: data-minion
+
+### Recommendations
+
+#### 1. Three new DAL functions, not raw queries in admin handlers
+
+The existing `getUsage()` queries one tenant+period. The dashboard needs three
+distinct access patterns that should be proper DAL functions in `db.js`, not
+ad-hoc `env.DB.prepare()` calls in route handlers. The project rule is:
+"No raw env.DB.prepare() calls should exist outside this module" (db.js header,
+line 16).
+
+**Function A: `listTenantsWithUsage(db, period)`** -- All tenants with current-period
+usage in a single query.
+
+```sql
+SELECT
+  t.id,
+  t.tier,
+  t.billing_status,
+  t.payment_method_added_at,
+  t.stripe_customer_id,
+  t.eidas_qualified,
+  t.created_at,
+  COALESCE(u.capture_count, 0)       AS capture_count,
+  COALESCE(u.storage_bytes, 0)       AS storage_bytes,
+  COALESCE(u.api_call_count, 0)      AS api_call_count,
+  COALESCE(u.eidas_capture_count, 0) AS eidas_capture_count
+FROM tenants t
+LEFT JOIN usage_counters u
+  ON u.tenant_id = t.id AND u.period = ?
+ORDER BY t.created_at DESC
+```
+
+This is a single D1 round-trip. The `LEFT JOIN` ensures tenants with zero
+usage in the period still appear (with zeroed counters). Binding the period
+parameter lets the frontend pass `computePeriod()` or any historical period.
+
+At current scale (tens of tenants), this is a full scan of a tiny table --
+no index needed. The tenants PK covers the join. The usage_counters composite
+PK `(tenant_id, period)` covers the lookup side.
+
+**Function B: `getUsageHistory(db, tenantId, periods)`** -- Historical usage
+across multiple periods for a single tenant.
+
+```sql
+SELECT period, capture_count, storage_bytes, api_call_count, eidas_capture_count, updated_at
+FROM usage_counters
+WHERE tenant_id = ?
+ORDER BY period DESC
+LIMIT ?
+```
+
+The `periods` parameter caps the result set (default 12 for trailing 12 months).
+No WHERE on specific period values -- just grab the most recent N. The composite
+PK `(tenant_id, period)` already serves this query perfectly: D1/SQLite will
+do an index range scan on `tenant_id = ?` and walk `period` in order. The
+`DESC` direction reverses the scan but requires no additional index because
+SQLite B-trees can be traversed in either direction.
+
+Return shape: array of `{ period, captureCount, storageBytes, apiCallCount, eidasCaptureCount, updatedAt }`.
+
+**Function C: `getAggregateStats(db, period)`** -- Overview stats for the
+dashboard header.
+
+```sql
+SELECT
+  (SELECT COUNT(*) FROM tenants) AS total_tenants,
+  (SELECT COUNT(*) FROM tenants WHERE payment_method_added_at IS NOT NULL) AS paid_tenants,
+  (SELECT COUNT(*) FROM tenants WHERE billing_status != 'active') AS tenants_nonactive_billing,
+  (SELECT COALESCE(SUM(u.capture_count), 0) FROM usage_counters u WHERE u.period = ?) AS total_captures,
+  (SELECT COALESCE(SUM(u.storage_bytes), 0) FROM usage_counters u WHERE u.period = ?) AS total_storage_bytes,
+  (SELECT COALESCE(SUM(u.eidas_capture_count), 0) FROM usage_counters u WHERE u.period = ?) AS total_eidas_captures,
+  (SELECT COUNT(*) FROM api_keys WHERE revoked = 0) AS active_api_keys
+```
+
+This is a single statement with scalar subqueries. Each subquery hits a
+different index (tenants PK, billing_status partial index, usage_counters
+composite PK, api_keys PK). At current data volume this is fast. SQLite
+executes scalar subqueries efficiently.
+
+#### 2. "Tenants approaching limits" requires computation, not a query
+
+The quota system is not purely in SQL. Free tenants get `FREE_CAPTURE_LIMIT`
+(200) unless they have `payment_method_added_at` (then unlimited). Per-tenant
+overrides live in the `config` JSON column (`config.quotas.capturesPerMonth`).
+Paid tenants with a payment method have `Infinity` quota.
+
+This means "approaching limits" must be computed in JS:
+1. `listTenantsWithUsage()` returns all tenants with their current capture count
+   and `payment_method_added_at`/`config` columns.
+2. For each tenant, call `getEffectiveQuota(hasPaymentMethod, config)` from
+   `quotas.js`.
+3. Compare `captureCount` to `quota.capturesPerMonth`.
+4. Flag tenants where `captureCount / quota.capturesPerMonth >= 0.8` (or
+   whatever threshold the dashboard wants).
+
+This is application-layer logic and should live in the admin handler or a
+thin helper, not in the DAL. Do NOT try to push this into SQL -- the quota
+rules live in JS and must stay there as the single source of truth.
+
+#### 3. No new indexes needed
+
+Current indexes that serve the dashboard queries:
+
+| Query | Index used |
+|-------|-----------|
+| `listTenantsWithUsage` | `tenants` PK (full scan, tiny table) + `usage_counters` PK `(tenant_id, period)` for join |
+| `getUsageHistory` | `usage_counters` PK `(tenant_id, period)` -- range scan |
+| `getAggregateStats` | `tenants` PK, `idx_tenants_billing_status` (partial), `usage_counters` PK |
+| Paid tenant count | Sequential scan on `tenants` checking `payment_method_added_at IS NOT NULL` -- fast at current scale |
+
+At tens of tenants and months of usage data, all of these are sub-millisecond
+on D1. Adding indexes would increase write overhead on every capture without
+measurable read benefit. Revisit if tenant count exceeds ~1000.
+
+**One exception to monitor**: if the dashboard queries run frequently and
+`tenants` grows, the `payment_method_added_at IS NOT NULL` scan in
+`getAggregateStats` could benefit from a partial index. But that is premature
+optimization today.
+
+#### 4. Compose existing functions where possible, add new ones for bulk patterns
+
+The existing DAL has the right single-tenant functions (`getUsage`,
+`getTenantConfig`, `getTenantBilling`, `tenantExists`). The dashboard should
+NOT call these in a loop (N+1 query pattern). Instead:
+
+- `listTenantsWithUsage` replaces N calls to `getUsage` + N calls to
+  `getTenantBilling` with one JOIN query.
+- `getUsageHistory` replaces N calls to `getUsage(db, tenantId, period)` with
+  one range query.
+- `getAggregateStats` replaces manual aggregation across multiple queries.
+
+The existing single-tenant functions remain untouched -- they serve their
+current callers (capture flow, quota checks, billing webhooks).
+
+#### 5. Include `config` in the tenant list query if needed for quota calculation
+
+If the dashboard needs to show "usage vs. limits" inline (not just raw counts),
+the `listTenantsWithUsage` query should also SELECT `t.config`. The handler
+then parses each tenant's config JSON and calls `getEffectiveQuota()` to
+compute the limit. This avoids a second round-trip per tenant.
+
+Updated query adds `t.config` to the SELECT list. The `config` column is
+nullable TEXT containing JSON -- small per row.
+
+#### 6. API shape for the three endpoints
+
+Based on the access patterns, the admin dashboard API should expose:
+
+```
+GET /v1/admin/dashboard/tenants?period=YYYY-MM
+  -> { data: [{ id, tier, billingStatus, paymentMethodAddedAt, eidasQualified,
+                createdAt, captureCount, storageBytes, apiCallCount,
+                eidasCaptureCount, effectiveLimit, usagePercent }] }
+
+GET /v1/admin/dashboard/tenants/:tenantId/history?periods=12
+  -> { data: [{ period, captureCount, storageBytes, apiCallCount,
+                eidasCaptureCount }] }
+
+GET /v1/admin/dashboard/stats?period=YYYY-MM
+  -> { totalTenants, paidTenants, tenantsNonactiveBilling, totalCaptures,
+       totalStorageBytes, totalEidasCaptures, activeApiKeys }
+```
+
+All three use existing `verifyAdminKey` auth and the `admin` rate limiter.
+Cache-Control: `private, no-store` (consistent with other admin endpoints).
+
+#### 7. D1 batch for dashboard page load
+
+When the dashboard first loads, the frontend needs both the tenant list AND
+aggregate stats. These two queries are independent and can run via
+`db.batch()` in a single D1 round-trip:
+
+```js
+const [tenantsResult, statsResult] = await db.batch([
+  tenantListStatement,
+  aggregateStatsStatement,
+]);
+```
+
+This keeps the initial page load to one D1 call. The history endpoint is
+on-demand (user clicks a tenant), so it runs separately.
+
+Alternatively, the frontend can fetch `/dashboard/tenants` and
+`/dashboard/stats` in parallel as two HTTP requests. The D1 batch approach
+is only relevant if there is a single API endpoint that returns both. Given
+the success criterion of "<2 seconds load time", either approach works -- D1
+latency for these queries will be <50ms each.
+
+### Proposed Tasks
+
+1. **Add `listTenantsWithUsage(db, period)` to `src/db.js`**
+   - LEFT JOIN tenants + usage_counters for given period
+   - Return array of tenant objects with zeroed defaults for missing usage
+   - Include `config` column for downstream quota calculation
+   - Unit test: verify tenants with no usage row appear with zero counts
+
+2. **Add `getUsageHistory(db, tenantId, limit)` to `src/db.js`**
+   - Range scan on usage_counters PK for one tenant, ordered by period DESC
+   - Default limit 12 (trailing year)
+   - Unit test: verify ordering, limit, and empty history
+
+3. **Add `getAggregateStats(db, period)` to `src/db.js`**
+   - Single statement with scalar subqueries
+   - Unit test: verify counts with mixed tenant states (paid/free/grace/blocked)
+
+4. **Build admin handler for tenant list endpoint**
+   - Call `listTenantsWithUsage`, then compute `effectiveLimit` and
+     `usagePercent` per tenant using `getEffectiveQuota()`
+   - Accept optional `period` query param (default: `computePeriod()`)
+
+5. **Build admin handler for tenant history endpoint**
+   - Validate tenantId from path, call `getUsageHistory`
+   - Accept optional `periods` query param (default: 12)
+
+6. **Build admin handler for aggregate stats endpoint**
+   - Call `getAggregateStats`, accept optional `period` query param
+
+7. **Register routes in `src/index.js`**
+   - Three new GET routes under `/v1/admin/dashboard/`
+   - All use existing `verifyAdminKey` + admin rate limiter
+
+### Risks and Concerns
+
+**R1: Config JSON parsing in bulk.**
+`listTenantsWithUsage` returns the `config` column as raw JSON text for every
+tenant. The handler must parse each one to call `getEffectiveQuota()`. At
+current scale (tens of tenants) this is negligible. At hundreds of tenants,
+the JSON parsing cost is still trivial (<1ms total). Not a real risk but worth
+noting for documentation.
+
+**R2: D1 read latency from Worker.**
+D1 is co-located with the Worker, but under load, D1 has documented P99
+latencies of ~30ms per query. The batch approach (one round-trip for
+tenants+stats) keeps worst-case at ~30ms, well within the 2-second target.
+The history endpoint adds one more round-trip on user click. No risk here.
+
+**R3: No migration needed.**
+All three queries work against the existing schema with existing indexes.
+No new migration file is required. This is a pure application-layer change.
+
+**R4: Unbounded tenant list.**
+The `listTenantsWithUsage` query returns ALL tenants. If the tenant count
+grows to thousands, this query result becomes large. At that point, add
+pagination (`LIMIT/OFFSET` or cursor-based). For now, with tens of tenants,
+returning all in one response is correct and simple. Do not add pagination
+prematurely -- YAGNI.
+
+**R5: Period parameter validation.**
+All three endpoints accept a `period` query param. Validate it against the
+`/^\d{4}-\d{2}$/` regex (same as `handleAdminGetUsage` already does). Reject
+invalid formats with 400. Default to `computePeriod()`.
+
+### Additional Agents Needed
+
+- **api-design-minion**: Should validate the endpoint URL structure
+  (`/v1/admin/dashboard/*` vs. extending existing `/v1/admin/*`), response
+  envelope consistency with existing admin endpoints, and whether the three
+  endpoints should be consolidated into fewer.
+- **security-minion**: Should confirm that the existing `verifyAdminKey` +
+  admin rate limiter is sufficient for these new endpoints, and that no
+  tenant data leakage is possible through the bulk tenant list (all data is
+  already available to admin-key holders via individual queries, so this
+  should be fine).
+- **test-minion**: Should plan tests for the three new DAL functions and
+  the three new admin handlers. The DAL tests should use the real D1 test
+  pool (not mocks), consistent with the project's testing philosophy.

--- a/docs/history/nefario-reports/2026-03-26-150501-admin-dashboard/phase2-frontend-minion-prompt.md
+++ b/docs/history/nefario-reports/2026-03-26-150501-admin-dashboard/phase2-frontend-minion-prompt.md
@@ -1,0 +1,35 @@
+You are contributing to the PLANNING phase of a multi-agent project.
+You are NOT executing yet — you are providing your domain expertise to help build a comprehensive plan.
+
+## Project Task
+Build an admin dashboard for operator visibility into tenant overviews, per-tenant usage, tier consumption — replacing manual D1 queries for operational awareness.
+
+Success criteria:
+- Dashboard shows: list of all tenants, per-tenant capture counts (current period and historical), tier/plan info, usage vs. limits
+- Data is live from D1 (not cached snapshots)
+- Protected by admin authentication
+- Loads in under 2 seconds
+
+## Your Planning Question
+The existing WRL web UI is a vanilla JS SPA with hash routing, design system CSS tokens, and modular view files. The admin dashboard needs a separate entry point (operators are not regular users). How should the admin UI be structured? Options: (A) a new route within the existing `/ui` SPA (gated by admin auth), (B) a separate `/admin` endpoint serving its own HTML shell, (C) a new section in the existing shell with admin-only nav. Consider: admin auth uses `verifyAdminKey` (Bearer token), not session cookies. The existing UI uses session auth or API key dual auth. Must use vanilla JS (no frameworks), reuse the design system, and load in <2s.
+
+## Context
+Read these files for context:
+- src/ui/ui-shell.js (existing UI shell)
+- src/design-system.css (design system tokens)
+- src/index.js (route table)
+- Auth patterns in src/auth.js
+
+## Instructions
+1. Read relevant files to understand the current state
+2. Apply your domain expertise to the planning question
+3. Identify risks, dependencies, and requirements from your perspective
+4. Return your contribution in the structured format below
+5. Write your complete contribution to /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-wqDwHT/admin-dashboard/phase2-frontend-minion.md
+
+## Domain Plan Contribution: frontend-minion
+
+### Recommendations
+### Proposed Tasks
+### Risks and Concerns
+### Additional Agents Needed

--- a/docs/history/nefario-reports/2026-03-26-150501-admin-dashboard/phase2-frontend-minion.md
+++ b/docs/history/nefario-reports/2026-03-26-150501-admin-dashboard/phase2-frontend-minion.md
@@ -1,0 +1,113 @@
+## Domain Plan Contribution: frontend-minion
+
+### Recommendations
+
+**Option B: Separate `/admin` endpoint serving its own HTML shell.**
+
+This is the clear winner. Here is the rationale:
+
+1. **Auth model incompatibility rules out Options A and C.** The existing `/ui` SPA uses dual auth (session cookies via GitHub OAuth OR `sessionStorage` API key). Admin auth uses `verifyAdminKey` -- a Bearer token against an infrastructure secret, with no session, no cookies, no GitHub identity. Mixing these into the same boot flow (`bootApp()` in `ui-auth.js`) would require forking the auth logic into a conditional mess. A separate shell keeps both auth flows clean and unmixed.
+
+2. **Security isolation.** The admin dashboard exposes cross-tenant data (all tenants, all usage, all keys). The tenant UI exposes single-tenant data. Serving them from the same HTML payload means a XSS in the tenant UI could theoretically reach admin DOM. A separate `/admin` endpoint with its own CSP and its own auth gate eliminates that surface entirely.
+
+3. **Bundle size and load time.** The existing `/ui` shell already concatenates 14 JS modules inline. Adding admin views (tenant list, per-tenant detail, usage charts) would push the bundle larger for all users, not just admins. A separate shell loads only admin code for admin users -- trivially meeting the <2s target since the admin code is small and there are no heavy dependencies.
+
+4. **Operational separation.** The admin dashboard is for operators, not end users. Different deployment cadence, different error handling expectations. If admin code breaks, tenant UI keeps working and vice versa.
+
+5. **Full design system reuse.** The design system CSS (`design-system.css`) is already a standalone export (`DESIGN_SYSTEM_CSS`). The admin shell imports it identically to the tenant shell. Tables, badges, cards, alerts, data grids -- everything the admin dashboard needs is already in the design system. Zero duplication.
+
+**Architecture:**
+
+```
+src/admin/
+  admin-shell.js     -- htmlAdminDashboard(), analogous to ui-shell.js
+  admin-css.js       -- admin-specific CSS (layout, admin-only components)
+  admin-auth.js      -- admin Bearer token auth gate (prompt, store in sessionStorage, validate against /v1/admin/usage?tenant=default)
+  admin-tenants.js   -- tenant list view (table with id, tier, eidas flag, current period captures)
+  admin-detail.js    -- per-tenant detail view (usage history, keys, config)
+```
+
+**Route registration in `index.js`:**
+
+```js
+['GET', /^\/admin$/, handleAdminDashboard],
+```
+
+The handler calls `htmlAdminDashboard()` -- same pattern as `handleDashboard()` calling `htmlDashboard()`. Admin auth happens client-side (the admin key is stored in `sessionStorage` and sent as Bearer on every API call). The `/admin` route itself is unauthenticated (it serves a static HTML shell), just like `/ui` is. This matches the existing architecture: the shell is public, the API calls are authenticated.
+
+**Hash routing within admin:**
+
+```
+#/tenants        -- tenant list (default)
+#/tenants/:id    -- per-tenant detail (usage, keys, config)
+```
+
+Two routes. That is all. YAGNI -- start with exactly what replaces the manual D1 queries.
+
+**Admin auth flow:**
+
+1. Admin loads `/admin` -- shell renders auth gate (input for admin key)
+2. Admin enters key, client stores it in `sessionStorage` under `wrl_admin_key`
+3. Client validates by calling `GET /v1/admin/usage?tenant=default&period=2026-03` with `Authorization: Bearer <key>`
+4. On 200: render admin shell with nav. On 401: show error, clear key.
+5. All subsequent `apiFetch` calls attach the Bearer token from `sessionStorage`.
+6. No cookies, no CSRF, no session endpoint -- pure Bearer token auth.
+
+**New backend endpoints needed:**
+
+The admin dashboard needs one endpoint that does not exist yet:
+
+- `GET /v1/admin/tenants` -- list all tenants with their tier, eidas_qualified flag, created_at. This is the backbone of the tenant list view. Without it, the dashboard would need to hardcode tenant IDs or make the operator type them.
+
+The existing endpoints cover the rest:
+- `GET /v1/admin/usage?tenant=X&period=Y` -- per-tenant usage (already exists)
+- `GET /v1/admin/keys?tenant=X` -- per-tenant API keys (already exists via `listApiKeyRecords`)
+- `GET /v1/admin/tenants/:id/config` -- per-tenant config (already exists)
+
+**Data fetching pattern:**
+
+Live D1 queries on every view render. No caching layer, no polling. The admin refreshes the page when they want fresh data. For the tenant list, fetch `/v1/admin/tenants` once on view mount. For per-tenant detail, fetch usage + keys + config in parallel on view mount. This is simple, matches the "no cached snapshots" requirement, and avoids stale data.
+
+Optionally: a manual "Refresh" button on each view that re-fetches. No auto-refresh interval -- the admin clicks when they want.
+
+### Proposed Tasks
+
+1. **[backend] Add `GET /v1/admin/tenants` endpoint** -- returns `{ tenants: [{ id, tier, eidasQualified, createdAt }] }`. Uses admin auth. Query: `SELECT id, tier, eidas_qualified, created_at FROM tenants ORDER BY created_at ASC`. Add `listTenants()` to `db.js`. Register route in `index.js`.
+
+2. **[backend] Add usage summary to tenant list response** -- optionally join current-period usage counters into the tenant list so the overview table can show capture counts without N+1 requests. Alternative: the frontend can batch-fetch usage per tenant, but a single query is cleaner. Proposed: `GET /v1/admin/tenants?include=usage` adds `currentPeriod: { captureCount, storageBytes, apiCallCount, eidasCaptureCount, period }` to each tenant.
+
+3. **[frontend] Create `src/admin/admin-shell.js`** -- HTML shell function `htmlAdminDashboard()` that mirrors `ui-shell.js` structure: inline design system CSS + admin CSS + admin JS modules. Returns a `Response` with appropriate CSP headers. Title: "WRL Admin".
+
+4. **[frontend] Create `src/admin/admin-auth.js`** -- auth gate for admin key. Input field, submit handler, `sessionStorage` persistence, validation against a real admin endpoint. `adminApiFetch()` wrapper that always attaches Bearer token.
+
+5. **[frontend] Create `src/admin/admin-css.js`** -- admin-specific styles. Reuse design system tokens exclusively. Admin layout (sidebar or top nav with "Tenants" link), table enhancements for the tenant overview.
+
+6. **[frontend] Create `src/admin/admin-tenants.js`** -- tenant list view. Table with columns: Tenant ID, Tier (badge), eIDAS (badge), Captures (current period), Storage, Created. Each row links to `#/tenants/:id`. Empty state if no tenants.
+
+7. **[frontend] Create `src/admin/admin-detail.js`** -- per-tenant detail view. Sections: overview (tier, eidas, created), current period usage (data grid), historical usage (last 6 months table), API keys (table with name, scopes, created, revoked status), tenant config (JSON display). Back link to `#/tenants`.
+
+8. **[frontend] Register `/admin` route in `index.js`** -- add `handleAdminDashboard` handler, import `htmlAdminDashboard`. One line in the routes array, one import, one handler function.
+
+9. **[frontend] Accessibility pass** -- ensure admin views meet WCAG 2.2 AA: table headers use `<th scope="col">`, data tables have captions, badges have sufficient color contrast, focus management on view transitions, skip-to-content link, `aria-current="page"` on active nav.
+
+### Risks and Concerns
+
+1. **Missing `GET /v1/admin/tenants` endpoint.** This is the critical dependency. The frontend cannot render a tenant list without it. The existing admin API operates on individual tenants (usage, config, keys) but has no list-all operation. This must ship before or alongside the frontend.
+
+2. **N+1 usage queries.** If the tenant list endpoint does not include usage data, the frontend must call `GET /v1/admin/usage?tenant=X` for each tenant to populate the overview table. With 10 tenants, that is 11 requests on page load. With 100 tenants, it is untenable. The backend should provide a batch or joined response. Recommendation: `GET /v1/admin/tenants?include=usage` joins `usage_counters` for the current period.
+
+3. **Historical usage requires multiple requests.** To show a 6-month usage history for a tenant, the frontend needs to call the usage endpoint 6 times (once per period) or the backend needs a new endpoint that returns multiple periods. Recommendation: add `GET /v1/admin/usage?tenant=X&periods=6` (or similar) that returns an array of period rows. Alternatively, add a range parameter: `&from=2025-10&to=2026-03`. This is a backend concern but directly impacts frontend feasibility.
+
+4. **Admin key exposure in browser.** The admin key sits in `sessionStorage`. This is the same pattern the tenant UI uses for API keys. The risk profile is identical and already accepted. However, note that `sessionStorage` is cleared on tab close, so the admin must re-enter the key each session. This is acceptable security behavior for an infrastructure secret.
+
+5. **No tier limits data.** The dashboard should show "usage vs. limits" per the success criteria, but the tier system only has `free` and `pro` as values in the database. The actual limits (captures per period, storage cap) are defined in application code, not in D1. The frontend needs to either: (a) hardcode tier limits in the admin JS, which couples frontend to backend policy, or (b) the backend exposes tier limits via the tenant config endpoint. Recommendation: the backend should return `limits` alongside `config` in the tenant detail, so the frontend can display a usage bar/percentage without hardcoding thresholds.
+
+6. **<2s load time is trivially met.** The admin shell is a single inlined HTML document with no external resources, no images, no fonts. The design system CSS is ~5 KB, admin CSS will be ~2 KB, admin JS will be ~8-10 KB. Total payload under 20 KB. Even with D1 query latency (~50-100ms per query), the complete render should happen in well under 1 second. The real latency risk is the N+1 usage query problem in risk #2 -- solve that and the budget is easily met.
+
+7. **CSP strictness.** The admin shell uses `'unsafe-inline'` for scripts and styles (same as the tenant UI). This is the tradeoff of the inline-everything architecture. It is an accepted pattern in this project. The admin shell should copy the exact CSP from the tenant shell.
+
+### Additional Agents Needed
+
+- **api-design-minion**: Design the `GET /v1/admin/tenants` endpoint (response shape, pagination if needed, `?include=usage` join behavior). Also design the multi-period usage query for historical data. These are new API surfaces that need proper design before implementation.
+
+- **security-minion**: Review the admin key-in-sessionStorage pattern for the admin dashboard specifically. The admin key has broader privileges than a tenant API key (cross-tenant access). Confirm that the existing threat model covers this, or identify if additional controls are needed (e.g., shorter session lifetime, IP-binding, or a separate admin-session mechanism).

--- a/docs/history/nefario-reports/2026-03-26-150501-admin-dashboard/phase2-security-minion-prompt.md
+++ b/docs/history/nefario-reports/2026-03-26-150501-admin-dashboard/phase2-security-minion-prompt.md
@@ -1,0 +1,30 @@
+You are contributing to the PLANNING phase of a multi-agent project.
+You are NOT executing yet — you are providing your domain expertise to help build a comprehensive plan.
+
+## Project Task
+Build an admin dashboard for operator visibility into tenant overviews, per-tenant usage, tier consumption — replacing manual D1 queries for operational awareness.
+
+Protected by admin authentication. Data is live from D1.
+
+## Your Planning Question
+The admin dashboard exposes tenant data via new endpoints. Current admin auth is a single infrastructure secret (`ADMIN_KEY`) via timing-safe comparison. For the dashboard UI: (1) How should the admin authenticate in the browser -- prompt for the key and store in sessionStorage? (2) Is CSRF a concern with Bearer-token auth (no cookies)? (3) Any query injection risks given prepared statements? (4) Should the admin rate limit (5 req/60s) be raised for a dashboard making multiple parallel requests on page load?
+
+## Context
+Read these files for context:
+- src/auth.js
+- wrangler.toml (rate limiter config)
+- src/index.js (admin auth flow)
+
+## Instructions
+1. Read relevant files to understand the current state
+2. Apply your domain expertise to the planning question
+3. Identify risks, dependencies, and requirements from your perspective
+4. Return your contribution in the structured format below
+5. Write your complete contribution to /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-wqDwHT/admin-dashboard/phase2-security-minion.md
+
+## Domain Plan Contribution: security-minion
+
+### Recommendations
+### Proposed Tasks
+### Risks and Concerns
+### Additional Agents Needed

--- a/docs/history/nefario-reports/2026-03-26-150501-admin-dashboard/phase2-security-minion.md
+++ b/docs/history/nefario-reports/2026-03-26-150501-admin-dashboard/phase2-security-minion.md
@@ -1,0 +1,139 @@
+## Domain Plan Contribution: security-minion
+
+### Recommendations
+
+#### 1. Admin Authentication in the Browser: Prompt + sessionStorage
+
+**Recommendation: Prompt for the ADMIN_KEY and store it in sessionStorage.** This is the correct approach for this context. Justification:
+
+- The admin dashboard is a same-origin UI served from the same Worker (`/ui/admin` or similar, alongside the existing `/ui` tenant dashboard). There is no cross-origin trust boundary to worry about.
+- `sessionStorage` is scoped to the tab and clears when the tab closes. This limits the exposure window compared to `localStorage` (which persists indefinitely and survives browser restarts).
+- The key is sent as a `Bearer` token in the `Authorization` header on every API call, exactly matching the existing `verifyAdminKey` flow. No new auth mechanism needed.
+- **Do NOT use cookies.** The existing admin auth is Bearer-token based. Adding cookies introduces CSRF attack surface and complicates the auth model for zero benefit.
+
+**Implementation details:**
+
+- On page load, check `sessionStorage.getItem('wrl_admin_key')`. If absent, render a login form with a single password input.
+- On form submit, make a lightweight probe request (e.g., `GET /v1/admin/keys?limit=0` or a new `GET /v1/admin/ping`) with the entered key as `Authorization: Bearer <key>`. If 200, store in `sessionStorage`. If 401, show error. Do NOT store the key before validation.
+- The probe request counts against the ADMIN_RATE_LIMITER (5/60s per IP). This is acceptable because login attempts are infrequent. But see rate limit recommendation below.
+- Provide a visible "Logout" button that calls `sessionStorage.removeItem('wrl_admin_key')` and reloads.
+
+**Security constraints on the login form:**
+
+- **No autocomplete**: set `autocomplete="off"` on the input field. The admin key is an infrastructure secret, not a user password -- browser password managers should not cache it.
+- **Paste-friendly**: Do not disable paste. Operators will paste from 1Password.
+- **No key echo**: Use `<input type="password">` so the key is masked.
+- **CSP**: The existing CSP (`default-src 'none'; script-src 'unsafe-inline'; connect-src 'self'`) is already correct for a same-origin SPA. No changes needed. `connect-src 'self'` restricts fetch calls to the same origin, preventing exfiltration of the key via script injection.
+
+#### 2. CSRF: Not a Concern with Bearer-Token Auth (No Cookies)
+
+**Correct -- CSRF is not a concern here.** CSRF attacks exploit the browser's automatic inclusion of cookies on cross-origin requests. Since the admin dashboard sends the key via the `Authorization` header (which browsers never attach automatically), a malicious third-party page cannot forge admin requests.
+
+The existing tenant dashboard (`/ui`) uses session cookies (`__Host-wrl_session`) and therefore correctly requires the `X-WRL-CSRF` header for mutations. The admin dashboard does NOT use cookies and MUST NOT use the `X-WRL-CSRF` mechanism -- it would be cargo-culting security for a threat that does not exist in Bearer-token auth.
+
+**One caveat**: If a future change adds cookie-based admin sessions, CSRF protection must be added simultaneously. Document this invariant in the code.
+
+#### 3. SQL Injection: Mitigated by Prepared Statements, but Verify New Queries
+
+**The existing D1 access pattern is sound.** All queries in `db.js` use `db.prepare(...).bind(...)` -- parameterized queries that prevent SQL injection regardless of input content. The DAL comment at the top of `db.js` ("All DB access is centralised here. No raw env.DB.prepare() calls should exist outside this module") is the correct architectural constraint.
+
+**For the new dashboard endpoints, the risk is bypassing this pattern.** Specific guidance:
+
+- **All new queries MUST go through `db.js`.** No inline `env.DB.prepare()` calls in dashboard handler code. This is already the project convention -- enforce it in review.
+- **Query parameters for dashboard views** (tenant filter, date ranges, sort order, pagination) must be validated before reaching `db.js`. The existing patterns are good models:
+  - `TENANT_ID_RE` for tenant ID validation (`/^[a-z0-9_-]{1,64}$/`)
+  - Period validation (`/^\d{4}-\d{2}$/`)
+  - Integer validation for `limit`/`offset`
+- **ORDER BY and column names cannot be parameterized** in prepared statements. If the dashboard allows sorting by column, use an allowlist (e.g., `const SORT_COLUMNS = new Set(['captureCount', 'storageBytes', 'createdAt'])`) and reject anything not in the set. Never interpolate user input into `ORDER BY` clauses.
+- **Aggregation queries** (e.g., `SELECT tenant_id, SUM(captures) ... GROUP BY tenant_id`) are fine with prepared statements as long as the `WHERE` clause parameters are bound.
+
+#### 4. Rate Limit: Raise to 30/60s for Admin Dashboard
+
+**The current 5 req/60s limit is too restrictive for a dashboard.** A single page load showing tenant overview + per-tenant usage + key list could easily make 3-5 parallel requests. Navigating between views would exhaust the limit within 60 seconds.
+
+**Recommendation: Raise `ADMIN_RATE_LIMITER` to 30 req/60s.** Rationale:
+
+- The admin key is an infrastructure secret known only to the operator. Brute-force is not the primary threat model -- the key has ~256 bits of entropy (`wrl_live_` prefix + 32 random bytes base64url-encoded).
+- The `AUTH_RATE_LIMITER` (10/60s) protects against brute-force on the OAuth login flow, which faces a genuinely adversarial internet. The admin endpoints face a different threat profile (known IPs, infrastructure secret).
+- 30/60s provides comfortable headroom for dashboard navigation (5-6 views with 4-5 requests each) without enabling abuse.
+- The rate limit is per-IP, so a compromised key used from a different IP would get its own 30/60s budget. This is acceptable because a compromised admin key is a critical incident regardless of rate limiting.
+
+**Changes required:**
+
+1. `wrangler.toml`: Change `ADMIN_RATE_LIMITER` `simple.limit` from `5` to `30` (both production and staging).
+2. `src/rate-limits.js`: Change `admin` limit from `5` to `30`.
+3. Document the change rationale in the evolution log.
+
+**Alternative considered and rejected**: A separate `ADMIN_DASHBOARD_RATE_LIMITER` binding with a higher limit. This adds operational complexity (new binding to manage) for no meaningful security benefit. A single limiter at 30/60s is sufficient.
+
+#### 5. Additional Security Requirements for the Admin Dashboard
+
+**A. Information Disclosure via Admin Endpoints**
+
+The new dashboard endpoints will expose tenant data (usage, configuration, capture counts). This is authorized for admin users but the responses must be hardened:
+
+- **Cache-Control: `private, no-store`** on all admin responses. The existing `ADMIN_CACHE` constant in `admin.js` already does this -- reuse it for all new endpoints.
+- **No CORS headers** on admin endpoints. Admin endpoints are same-origin only. Never add `Access-Control-Allow-Origin` to admin responses. Verify no wildcard CORS leaks into the admin path.
+- **X-Frame-Options: DENY** is already set globally in `index.js` line 701. Verify it applies to the admin dashboard HTML page as well.
+
+**B. Admin Dashboard HTML Page Security**
+
+- Serve the admin dashboard from a separate route (e.g., `GET /admin`) with its own CSP, distinct from the tenant dashboard at `/ui`.
+- **CSP** should match the existing pattern: `default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src 'self'; connect-src 'self'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'`.
+- The admin page must NOT be cacheable: `Cache-Control: no-store`.
+
+**C. Logging**
+
+All admin dashboard API calls must be logged at severity 3 (info) with:
+- `event: 'admin.<action>'`
+- `authMethod: 'admin_key'`
+- `cip` (hashed client IP)
+- `responseStatus`
+
+The existing admin handlers already do this consistently. New dashboard-specific endpoints must follow the same pattern. Failed requests (auth failures, validation errors) must also be logged at severity 4-5. This is critical for security monitoring -- the admin key is a high-value target.
+
+**D. No Tenant Data in URL Paths**
+
+If the dashboard uses client-side routing (e.g., `/admin#tenant/acme`), that is fine because fragment identifiers are not sent to the server. If it uses server-side routes (e.g., `/admin/tenants/acme`), ensure tenant IDs in URL paths are validated with `TENANT_ID_RE` before use.
+
+**E. Output Encoding**
+
+The dashboard renders tenant data (tenant IDs, key names, usage numbers) in HTML. Even though tenant IDs are constrained by `TENANT_ID_RE` and key names by `NAME_RE`, always use `textContent` (not `innerHTML`) when rendering data from API responses. This prevents stored XSS if a validation regex is ever relaxed. The existing tenant dashboard in `/ui` already follows this pattern.
+
+### Proposed Tasks
+
+1. **[Auth] Implement admin key prompt + sessionStorage flow** -- Password input form, probe-on-submit, store on success, logout button. Use existing `verifyAdminKey` path. No new auth mechanism.
+
+2. **[Rate Limit] Raise ADMIN_RATE_LIMITER from 5/60s to 30/60s** -- Update `wrangler.toml` (production + staging) and `src/rate-limits.js`. One-line change each.
+
+3. **[API] Add new admin dashboard endpoints behind verifyAdminKey** -- Tenant list, per-tenant detail, tier consumption. All queries through `db.js`. All responses with `Cache-Control: private, no-store`. All requests logged.
+
+4. **[API] Add ORDER BY allowlist validation in db.js** -- If dashboard supports sortable columns, the DAL must enforce a column allowlist. Never interpolate sort parameters.
+
+5. **[UI] Serve admin dashboard HTML from separate route with correct CSP** -- `GET /admin` returns HTML shell with strict CSP. Same pattern as existing `/ui` but separate page.
+
+6. **[Security Review] Verify no CORS headers leak onto admin endpoints** -- Explicit check during implementation that admin paths never get `Access-Control-Allow-Origin` in the response.
+
+### Risks and Concerns
+
+**RISK 1 (Medium): Admin key in browser memory**
+- The ADMIN_KEY will live in `sessionStorage` and in the JavaScript heap for the lifetime of the tab. A browser extension, XSS in another same-origin page, or browser devtools access could extract it.
+- **Mitigation**: CSP with `connect-src 'self'` prevents exfiltration via network. `frame-ancestors 'none'` prevents clickjacking. The key is masked in the input. sessionStorage clears on tab close. This is an accepted residual risk for an operator-only tool.
+- **Future consideration**: If the admin user base grows beyond a single operator, switch to GitHub OAuth with an admin role (the OAuth infrastructure already exists for tenant auth). This is out of scope for MVP.
+
+**RISK 2 (Low): Rate limit increase enables faster brute-force**
+- Raising from 5/60s to 30/60s means an attacker can try 30 keys per minute per IP instead of 5.
+- **Mitigation**: At 256 bits of entropy, brute-force is not a viable attack regardless of rate. The rate limit exists primarily to prevent accidental self-DoS, not brute-force. 30/60s remains conservative.
+
+**RISK 3 (Low): Dashboard data aggregation reveals business intelligence**
+- Aggregated usage views (total captures across all tenants, tier distribution) are more valuable to an attacker than individual endpoint responses. A compromised admin key accessing the dashboard gives a fuller picture than calling individual endpoints.
+- **Mitigation**: This is inherent to any dashboard. The admin key is already the keys to the kingdom. Logging all admin requests to Coralogix (already in place) enables detection of unauthorized access patterns.
+
+**RISK 4 (Informational): No key rotation mechanism**
+- If the admin key is compromised, rotation requires `wrangler secret put ADMIN_KEY` and then updating the key in 1Password. There is no in-band rotation via the API.
+- **Mitigation**: This is the current operational model and is acceptable for a single-operator system. Document the rotation procedure in the evolution log.
+
+### Additional Agents Needed
+
+- **iac-minion**: To update `wrangler.toml` rate limiter values (production + staging) and verify the binding changes deploy correctly.
+- **test-minion**: To write tests for (a) admin auth flow rejects invalid keys and returns 401, (b) rate limit behavior at new threshold, (c) new dashboard endpoints enforce admin auth, (d) no CORS headers on admin responses.

--- a/docs/history/nefario-reports/2026-03-26-150501-admin-dashboard/phase2-test-minion-prompt.md
+++ b/docs/history/nefario-reports/2026-03-26-150501-admin-dashboard/phase2-test-minion-prompt.md
@@ -1,0 +1,33 @@
+You are contributing to the PLANNING phase of a multi-agent project.
+You are NOT executing yet — you are providing your domain expertise to help build a comprehensive plan.
+
+## Project Task
+Build an admin dashboard for operator visibility into tenant overviews, per-tenant usage, tier consumption — replacing manual D1 queries for operational awareness.
+
+Success criteria:
+- Data is live from D1 (not cached snapshots)
+- Protected by admin authentication
+- Loads in under 2 seconds
+
+## Your Planning Question
+The project uses `@cloudflare/vitest-pool-workers` with real D1 in tests. New DAL functions will include aggregate queries with JOINs. New admin API endpoints need auth + response shape testing. What test strategy should we follow? Should aggregate query tests use seed data? How should the admin UI be tested (if at all -- it's vanilla JS served from the worker)?
+
+## Context
+Read these files for context:
+- Existing test files (test/ directory)
+- vitest.config.ts
+- Test helper patterns
+
+## Instructions
+1. Read relevant files to understand the current state
+2. Apply your domain expertise to the planning question
+3. Identify risks, dependencies, and requirements from your perspective
+4. Return your contribution in the structured format below
+5. Write your complete contribution to /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-wqDwHT/admin-dashboard/phase2-test-minion.md
+
+## Domain Plan Contribution: test-minion
+
+### Recommendations
+### Proposed Tasks
+### Risks and Concerns
+### Additional Agents Needed

--- a/docs/history/nefario-reports/2026-03-26-150501-admin-dashboard/phase2-test-minion.md
+++ b/docs/history/nefario-reports/2026-03-26-150501-admin-dashboard/phase2-test-minion.md
@@ -1,0 +1,177 @@
+# Domain Plan Contribution: test-minion
+
+## Recommendations
+
+### 1. Follow Established Integration Test Patterns -- Do Not Invent New Ones
+
+The codebase has a mature, consistent testing approach built around `@cloudflare/vitest-pool-workers` with real D1. The admin dashboard tests must follow the same conventions exactly:
+
+- **SELF.fetch()** for all HTTP endpoint tests (see `admin-keys.test.js`, `admin-usage.test.js`)
+- **env.DB** for direct DAL function tests (see `db.test.js`)
+- **cleanDb() in beforeEach** for test isolation (every existing test file does this)
+- **IP counter per test file** to avoid admin rate limiter collisions (5 req/60s per IP)
+- **Seed functions in fixtures.js** for test data setup (seedApiKey, seedCapture, seedUsageCounter, seedGithubUser, etc.)
+
+No new test infrastructure is needed. The existing `test/fixtures.js` already has the building blocks.
+
+### 2. Test Strategy: Three Layers
+
+**Layer 1: DAL Function Unit Tests (~60% of new tests)**
+
+New aggregate query functions (tenant overview, cross-tenant stats, tier breakdown) should be tested directly against `env.DB` in `test/db.test.js` or a new `test/admin-dal.test.js` file. These tests:
+
+- Call the DAL function directly with `env.DB`
+- Seed specific data scenarios via `seedCapture`, `seedUsageCounter`, `seedApiKey`, etc.
+- Assert return shape, aggregation correctness, edge cases (empty tenants, zero usage)
+- Are fast (no HTTP overhead) and test the SQL logic in isolation
+
+This is where aggregate query correctness matters most. Seed data **must** be used -- you cannot test a `SUM()` or `COUNT()` with `GROUP BY` on an empty database. But each test seeds its own data (factory pattern via existing `seed*` helpers), not a shared fixture file.
+
+**Layer 2: Admin API Endpoint Tests (~35% of new tests)**
+
+New endpoints (e.g., `GET /v1/admin/tenants`, `GET /v1/admin/tenants/:id/usage`) should follow the exact pattern from `admin-keys.test.js` and `admin-usage.test.js`:
+
+- Auth tests: 401 without header, 401 with wrong key, 200 with correct ADMIN_KEY
+- Validation tests: 400 for invalid params
+- Response shape tests: exact field list, Content-Type, Cache-Control headers
+- Security: legacy CAPTURE_API_KEY and tenant keys must not work on admin routes
+- Rate limiting: each `describe` block uses `nextIp()` to get a unique IP
+
+These tests exercise the full request path (routing, auth middleware, handler, DAL, response serialization) through SELF.fetch(). They catch integration issues that DAL-only tests miss: param parsing, error response format (RFC 9457), header correctness.
+
+**Layer 3: Admin UI Tests (~5% of new tests)**
+
+The existing UI test pattern is lightweight and appropriate: test the **exported JS string constants**, not a real DOM. See `ui-dashboard.test.js` and `ui-settings-usage.test.js` for the established approach:
+
+- Assert that the HTML shell contains expected structural elements (`<div id="admin-app">` or similar)
+- Assert security invariants: no `innerHTML` assignments with variable data (XSS guard)
+- Assert no external resource loads (`<script src=`, `<link rel="stylesheet" href=`)
+- Extract and test pure-logic helper functions (formatters, percentage calculations) using the same evaluation technique in `ui-settings-usage.test.js`
+- Test response headers (CSP, Cache-Control, Content-Type) on the route
+
+**Do NOT** attempt browser-level E2E tests for the admin UI. The project has no Playwright/browser test infrastructure, and spinning one up for an internal admin dashboard violates YAGNI. The vanilla JS UI is rendered server-side as a string constant -- string-level assertions are sufficient and match the existing pattern.
+
+### 3. Seed Data Strategy for Aggregate Queries
+
+Each test function seeds its own data. No shared fixture files. No pre-populated "test database." This is the pattern the entire test suite follows and it works:
+
+```js
+// Example: testing a "tenant overview" aggregate function
+it('returns correct capture counts across multiple tenants', async () => {
+  await seedCapture(env.DB, 'cap_' + 'a'.repeat(32), { tenantId: 'tenant-a', status: 'complete' });
+  await seedCapture(env.DB, 'cap_' + 'b'.repeat(32), { tenantId: 'tenant-a', status: 'failed' });
+  await seedCapture(env.DB, 'cap_' + 'c'.repeat(32), { tenantId: 'tenant-b', status: 'complete' });
+  await seedUsageCounter(env.DB, { tenantId: 'tenant-a', captureCount: 5 });
+  await seedUsageCounter(env.DB, { tenantId: 'tenant-b', captureCount: 2 });
+
+  const overview = await getAdminTenantOverview(env.DB);
+  expect(overview).toHaveLength(2);
+  // ... assertions on aggregated fields
+});
+```
+
+For aggregate queries with JOINs (e.g., tenant + usage_counters + captures + api_keys), seed all relevant tables. The existing `cleanDb()` function already handles teardown in FK-safe order, and `beforeEach` ensures a clean slate.
+
+**Key seed data scenarios to cover:**
+
+- Empty database (no tenants) -- should return empty array, not error
+- Tenant with zero usage data -- should return zeros, not null/undefined
+- Multiple tenants with varying data volumes -- verify aggregation is per-tenant
+- Tenants across different tiers (free, pro) -- verify tier grouping/filtering
+- Tenants with and without billing (stripe_customer_id null vs set)
+- Usage data across multiple periods -- verify period filtering on aggregates
+- Revoked vs active API keys -- verify count correctness based on filter
+
+### 4. New Fixture Helpers Needed
+
+The existing `fixtures.js` will need one or two new helpers. Keep them minimal:
+
+- **`seedTenantWithTier(db, tenantId, tier)`** -- seeds a tenant row with a specific tier value. Currently `seedApiKey` and `seedCapture` create tenants via `INSERT OR IGNORE INTO tenants (id)` which only sets the `id` column. For admin dashboard tests, we need tenants with `tier`, `billing_status`, and `stripe_customer_id` populated.
+
+No other new helpers are likely needed. Existing `seedCapture`, `seedUsageCounter`, `seedApiKey`, `seedGithubUser` cover the test data needs.
+
+### 5. Response Shape Testing is Non-Negotiable
+
+Every new admin endpoint must have a test that asserts **exactly** which fields appear in the response body. See the existing pattern:
+
+```js
+it('response body has exactly the expected fields', async () => {
+  const res = await get('?tenant=default');
+  const body = await res.json();
+  expect(Object.keys(body).sort()).toEqual(
+    ['apiCallCount', 'captureCount', 'period', 'storageBytes', 'tenantId', 'updatedAt'].sort(),
+  );
+});
+```
+
+This catches field name typos, accidental data leakage, and response contract drift. It is especially important for the admin dashboard because the vanilla JS frontend will parse these exact field names.
+
+### 6. Do Not Run Tests Casually
+
+Per CLAUDE.md and CLAUDE.local.md, `npm test` spins up a full workerd runtime consuming ~8 GB. Tests should only be run when code changes need verification. Never run two test instances in parallel. CSS-only or copy-only UI changes do not warrant a test run.
+
+## Proposed Tasks
+
+### T1: Add `seedTenantWithTier` helper to `test/fixtures.js`
+- Create a helper that seeds a tenant with tier, billing_status, stripe_customer_id, payment_method_added_at
+- Add it to the existing exports
+- Estimated: ~20 lines of code
+
+### T2: Write DAL tests for new aggregate query functions
+- Create `test/admin-dal.test.js` (or extend `test/db.test.js`)
+- Test tenant list query (all tenants with their tier, capture count, usage summary)
+- Test per-tenant detail query (full usage breakdown with JOINs)
+- Test edge cases: empty database, zero-usage tenants, multi-period data
+- Test tier filtering if the API supports it
+- Each test seeds its own data, cleans up via `cleanDb()` in `beforeEach`
+- Follow the exact naming and structure patterns from `db.test.js`
+
+### T3: Write integration tests for new admin API endpoints
+- Create `test/admin-dashboard.test.js` (or similar)
+- Test auth (401 without/wrong key, 200 with ADMIN_KEY)
+- Test param validation (400 for invalid tenant IDs, periods)
+- Test response shape (exact field lists, Content-Type, Cache-Control headers)
+- Test data correctness (seeded data appears in responses)
+- Test security: tenant keys and CAPTURE_API_KEY rejected on admin routes
+- Use `nextIp()` pattern with a unique IP range (e.g., starting at 150)
+
+### T4: Write admin UI unit tests
+- Create `test/ui-admin.test.js`
+- Test HTML shell structure (expected DOM ids, no external resources)
+- Test security invariants (innerHTML assignments only use empty string)
+- Test CSP and response headers on the admin UI route
+- Extract and test any pure-logic formatter functions (if the UI includes byte formatting, percentage calculations, date formatting)
+- Follow patterns from `ui-dashboard.test.js` and `ui-settings-usage.test.js` exactly
+
+### T5: Verify no regression in existing tests
+- After all new code is written, run `npm test` once to confirm no regressions
+- Verify the admin rate limiter IP range does not collide with existing test files
+- Check that `cleanDb()` covers any new tables (unlikely since we are using existing tables)
+
+## Risks and Concerns
+
+### Risk 1: Admin Rate Limiter Collisions
+The admin rate limiter is 5 req/60s per IP. Every existing admin test file uses a `nextIp()` counter starting at a different base (admin-keys starts at 10, admin-usage starts at 100, account-usage starts at 200). **The new test file must use a non-overlapping IP range.** I recommend starting at 150 for the new admin dashboard tests. Document the range in the file header comment, matching the convention in existing admin test files.
+
+### Risk 2: Aggregate Query Performance on D1
+Aggregate queries with JOINs across `tenants`, `captures`, `usage_counters`, and `api_keys` will be live D1 queries. The "loads in under 2 seconds" success criterion means these queries must be efficient. Tests should assert on correctness, but the implementation should be reviewed for index usage. If the dashboard needs to aggregate across all tenants, consider:
+- Whether existing indexes support the query plan
+- Whether a new covering index is needed for the dashboard query
+- Whether the query should limit/paginate results
+
+Tests will not catch performance issues with small seed data, so this is an implementation concern, not a testing concern. But the test plan should flag it.
+
+### Risk 3: Test Memory Budget
+The test suite already consumes ~8 GB via workerd. Adding a new test file with many seed data scenarios will not significantly increase memory (D1 is in-memory SQLite, and we are talking about dozens of rows). However, **do not create a separate test file that runs in a different worker instance** -- all admin tests should share the same worker, which they do by default with vitest-pool-workers.
+
+### Risk 4: Response Shape Drift Between API and UI
+The admin dashboard UI (vanilla JS) will parse JSON responses from the admin API. If the API response shape changes, the UI breaks silently. The response shape tests (T3) catch API-side drift, but there is no mechanism to catch UI-side drift (the UI parses field names as strings in JS). Consider adding a comment in the admin UI JS that references the test file where the response contract is asserted, so future developers know to update both places.
+
+### Risk 5: isolatedStorage is Disabled
+The vitest config sets `isolatedStorage: false` due to R2 SQLite WAL issues. This means all tests in all files share the same D1 database instance across the test run. The `cleanDb()` in `beforeEach` is the only isolation mechanism. If a test fails to clean up (e.g., throws before `beforeEach` runs on the next test), subsequent tests may see stale data. This is an existing risk, not a new one, but aggregate queries are more sensitive to stale data than single-record queries.
+
+## Additional Agents Needed
+
+None beyond what is presumably already involved in the plan. The test strategy integrates with whatever DAL functions and API endpoints the implementation agent builds. No specialized tooling, infrastructure, or external dependencies are required.
+
+The test approach is entirely within the existing testing stack: vitest + @cloudflare/vitest-pool-workers + real D1. No new test frameworks, no browser automation, no additional CI configuration needed.

--- a/docs/history/nefario-reports/2026-03-26-150501-admin-dashboard/phase2-ux-design-minion-prompt.md
+++ b/docs/history/nefario-reports/2026-03-26-150501-admin-dashboard/phase2-ux-design-minion-prompt.md
@@ -1,0 +1,31 @@
+You are contributing to the PLANNING phase of a multi-agent project.
+You are NOT executing yet — you are providing your domain expertise to help build a comprehensive plan.
+
+## Project Task
+Build an admin dashboard for operator visibility into tenant overviews, per-tenant usage, tier consumption — replacing manual D1 queries for operational awareness.
+
+Success criteria:
+- Dashboard shows: list of all tenants, per-tenant capture counts (current period and historical), tier/plan info, usage vs. limits
+- Loads in under 2 seconds
+
+## Your Planning Question
+The admin dashboard needs tables (tenant list, usage data) and summary statistics (aggregate overview). The project has an existing design system with CSS tokens. What visual patterns should the dashboard follow for tables, stat cards, and any drill-down interactions? How should the information hierarchy work within the existing design system constraints? The dashboard must be readable/usable on desktop (no mobile requirement for admin tools).
+
+## Context
+Read these files for context:
+- src/design-system.css (design system tokens)
+- src/ui/ (existing UI views)
+
+## Instructions
+1. Read relevant files to understand the current state
+2. Apply your domain expertise to the planning question
+3. Identify risks, dependencies, and requirements from your perspective
+4. Return your contribution in the structured format below
+5. Write your complete contribution to /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-wqDwHT/admin-dashboard/phase2-ux-design-minion.md
+
+## Domain Plan Contribution: ux-design-minion
+
+### Recommendations
+### Proposed Tasks
+### Risks and Concerns
+### Additional Agents Needed

--- a/docs/history/nefario-reports/2026-03-26-150501-admin-dashboard/phase2-ux-design-minion.md
+++ b/docs/history/nefario-reports/2026-03-26-150501-admin-dashboard/phase2-ux-design-minion.md
@@ -1,0 +1,215 @@
+## Domain Plan Contribution: ux-design-minion
+
+### Recommendations
+
+#### 1. Information Hierarchy: Three-Level Drill-Down
+
+The admin dashboard should present information at three levels of granularity, using progressive disclosure to avoid cognitive overload:
+
+**Level 1 -- Aggregate Overview (landing state)**
+A row of 3-4 stat cards at the top, providing at-a-glance operational awareness. These follow the exact pattern already established by `billing-stats-row` / `billing-stat` in the billing view:
+
+- **Total tenants** (count)
+- **Active tenants this period** (tenants with captureCount > 0)
+- **Total captures this period** (sum across all tenants)
+- **Total storage** (sum of storageBytes, formatted as human-readable)
+
+Use the existing `billing-stat-value` (--text-xl, --weight-bold) for the number and `billing-stat-label` (--text-xs, --color-text-muted) for the descriptor. This is a proven pattern in the codebase -- reuse, don't reinvent.
+
+**Level 2 -- Tenant Table (primary content)**
+Below the stats, a sortable table of all tenants. This is the core view the operator will spend time in.
+
+**Level 3 -- Tenant Detail (drill-down)**
+Clicking a tenant row navigates to a per-tenant detail view showing full usage history, key listing, and configuration. This uses the existing hash-router pattern (`#/admin/tenants/:tenantId`).
+
+#### 2. Tenant Table Design
+
+Use the existing `.table` component from `design-system.css` as the foundation. The table should:
+
+**Columns:**
+| Column | Content | Alignment | Notes |
+|--------|---------|-----------|-------|
+| Tenant ID | `text-mono` | left | Primary identifier, clickable link to detail view |
+| Status | Badge | left | Active / Inactive badge using existing `.badge` variants |
+| Captures (period) | Number | right | Current period capture count, `font-variant-numeric: tabular-nums` |
+| Storage | Formatted bytes | right | Human-readable (KB/MB/GB) |
+| API Keys | Count | right | Number of active (non-revoked) keys |
+| Created | Relative date | right | "3 days ago" or "Mar 15, 2026" |
+
+**Visual treatment:**
+- Use existing `.table th` styling (surface-muted background, uppercase xs text, letter-spacing)
+- Use existing `.table td` styling (space-3 padding, border-subtle bottom borders)
+- Add `cursor: pointer` on rows to indicate clickability
+- Hover state: `background: var(--color-surface-muted)` -- same hover pattern as `.capture-item`
+- Focus-visible: `outline: 2px solid var(--color-primary); outline-offset: -2px` -- same as `.capture-item`
+- Numeric columns should use `font-variant-numeric: tabular-nums` for alignment (already used in `.usage-metric-value`)
+
+**Sorting interaction:**
+- Column headers become buttons with a sort indicator (ascending/descending arrow using text characters, not icons)
+- Active sort column uses `--weight-bold` instead of `--weight-medium`
+- Default sort: Captures (period), descending -- the operator most likely wants to see high-usage tenants first
+- Sort is client-side since tenant counts will be small (hundreds, not thousands)
+
+**Empty state:**
+If no tenants exist, show a centered message using the existing `.capture-empty` pattern: `"No tenants found."` in `--color-text-muted`.
+
+#### 3. Stat Cards Pattern
+
+Reuse the `billing-stats-row` grid pattern exactly. For 4 stats, change `grid-template-columns` to `repeat(4, 1fr)`. Each card uses:
+
+```
+.admin-stats-row {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: var(--space-4);
+  margin-bottom: var(--space-6);
+}
+```
+
+Each stat cell uses the same structure as `buildStatCell` in `ui-billing.js`:
+- `.admin-stat` container (text-align: center)
+- `.admin-stat-value` (--text-xl, --weight-bold, --color-text)
+- `.admin-stat-label` (--text-xs, --color-text-muted, margin-top: --space-1)
+
+No card borders or backgrounds on individual stat cells. The stats are visually grouped by their grid proximity, not by card containers. This matches the billing view's approach.
+
+#### 4. View Container Width
+
+The current `.view-container` is `max-width: 860px`. For a data-dense admin table with 6 columns, this is tight but workable if:
+- Tenant ID is truncated with ellipsis at ~12ch for long IDs (most IDs are short like `acme`, `demo`)
+- Storage and date columns are compact
+- The table itself gets `width: 100%` within the container
+
+Do NOT increase the view container max-width globally. If the admin view needs more room, scope it:
+
+```css
+.view-container--admin {
+  max-width: 1100px;
+}
+```
+
+This keeps the narrow, focused layout for tenant-facing views while giving the operator more room. Apply this class only when the admin route is active.
+
+#### 5. Tenant Detail View (Drill-Down)
+
+When clicking a tenant row, navigate to `#/admin/tenants/:tenantId`. This view shows:
+
+**A. Back navigation** -- Reuse the `buildBackLink()` pattern from `ui-detail.js`: a simple text link "Back to tenants" at the top.
+
+**B. Tenant header** -- Tenant ID displayed as an h1 using the existing `.captures-heading` style (--text-2xl, --weight-bold). Below it, a badge showing status.
+
+**C. Current period usage card** -- A `.settings-section.card` containing:
+- Period heading (using `formatPeriod` pattern from billing)
+- Usage metrics using the existing `.usage-metric` / `.usage-bar` pattern:
+  - Captures: count vs. free tier limit (200), shown as a progress bar
+  - Storage: bytes used
+  - API calls: count
+  - eIDAS captures: count (if > 0)
+
+**D. Usage history section** -- A compact table showing period-over-period data:
+| Period | Captures | Storage | API Calls | eIDAS |
+|--------|----------|---------|-----------|-------|
+| 2026-03 | 1,247 | 45 MB | 3,891 | 12 |
+| 2026-02 | 982 | 38 MB | 2,654 | 8 |
+
+Use the existing `.billing-tier-table` styling (smaller --text-sm font, compact padding).
+
+**E. API Keys section** -- Reuse the `.settings-key-list` / `.settings-key-row` pattern from the settings view. Show key name, scopes (as badges), creation date, and last-used date. Read-only for now -- the admin dashboard is for visibility, not management.
+
+#### 6. Loading State
+
+Use the existing `view-placeholder` pattern: a text message "Loading tenant data..." in `--color-text-muted`. The billing view uses this exact approach (`#billing-loading`). No skeleton screens needed -- the admin dashboard loads a single aggregate query that should return in under 500ms from D1.
+
+If the API call takes longer than expected, the operator sees the placeholder text. No spinner needed for the initial load; the 2-second budget is generous for a D1 query.
+
+#### 7. Error State
+
+Follow the existing pattern from billing:
+- API failure: `.alert.alert--error` with `role="alert"` saying "Could not load tenant data. Please try refreshing."
+- Network failure: Same alert pattern with "Connection failed. Check your network and try again."
+- No retry button needed for the admin view since the operator can just refresh the browser.
+
+#### 8. Refresh Mechanism
+
+Add a refresh button using the existing `.usage-refresh-btn` pattern (the circular arrow button from the billing view). Place it in a `.usage-footer` row below the stats and above the table. This lets the operator manually refresh without a full page reload.
+
+Do NOT auto-refresh or poll. The admin dashboard is pulled up on demand for operational checks, not left open as a monitoring dashboard. Auto-refresh would add unnecessary complexity and API load.
+
+#### 9. Accessibility Specifications
+
+**Heading hierarchy:**
+- h1: "Admin Dashboard" (or "Tenants" if we want to match the existing nav pattern of view-name as h1)
+- h2: Section headings ("Overview", "Tenants") using `.settings-section-heading` pattern (uppercase, xs, muted)
+- In detail view: h1 is the tenant ID, h2s are section headings
+
+**Table accessibility:**
+- Use semantic `<table>` with `<thead>`, `<tbody>`, `<th scope="col">`
+- Add `aria-label="Tenant list"` on the table
+- Sortable column headers: `<button>` inside `<th>`, with `aria-sort="ascending"` / `aria-sort="descending"` / no `aria-sort` (unsorted)
+- Row click targets: make each tenant row an `<a>` element (not a `<tr>` with click handler). The existing capture list uses `<a class="capture-item">` with grid layout -- follow this pattern
+
+**Focus management:**
+- On navigation to admin view, focus the h1 (using `tabIndex=-1` + `.focus()`, same as captures heading)
+- On navigation to tenant detail, focus the h1 (same pattern)
+- Tab order follows visual order: stats (not focusable, they're just display), refresh button, sort column headers, table rows (as links)
+
+**Screen reader announcements:**
+- Add an `aria-live="polite"` region (sr-only) for announcing sort changes: "Sorted by captures, descending"
+- After refresh: "Tenant data refreshed" announcement via the live region
+
+#### 10. CSS Organization
+
+All admin-specific CSS should be added to `ui-css.js` in a new clearly delimited section:
+
+```
+/* ---------------------------------------------------------------------------
+   Admin dashboard
+--------------------------------------------------------------------------- */
+```
+
+New classes should be prefixed with `admin-` to avoid collision with existing component classes. Reuse design system tokens exclusively -- no hardcoded hex values, consistent with the existing codebase rule.
+
+New CSS additions needed (estimated):
+- `.view-container--admin` -- wider max-width override
+- `.admin-stats-row` -- 4-column stat grid (mirrors billing-stats-row)
+- `.admin-stat`, `.admin-stat-value`, `.admin-stat-label` -- stat cell (mirrors billing-stat)
+- `.admin-table-wrap` -- overflow-x: auto wrapper for the table
+- `.admin-table` -- extends `.table` with row hover, pointer cursor
+- `.admin-table th button` -- sortable header button styling
+- `.admin-tenant-link` -- tenant ID cell styling (mono, accent color)
+
+Total: ~60-80 lines of CSS. No new design tokens needed -- the existing token set covers everything.
+
+### Proposed Tasks
+
+1. **Design the stat card row** -- Define the 4 aggregate stats, their labels, and data sources. Verify the stat-cell pattern from billing view can be reused without modification. Output: confirmed component spec.
+
+2. **Design the tenant table** -- Finalize column set, alignment, sort defaults, and truncation rules. Define hover/focus/active states. Output: table spec with all states documented.
+
+3. **Design the tenant detail view** -- Define the layout, sections, and data displayed for a single tenant drill-down. Specify which existing component patterns to reuse. Output: detail view spec.
+
+4. **Specify CSS additions** -- Write the actual CSS rules needed, using only existing design tokens. Include the wider container variant, admin stat grid, table hover states, and sort button styling. Output: CSS block ready for insertion into `ui-css.js`.
+
+5. **Specify accessibility requirements** -- Document heading hierarchy, table ARIA attributes, focus management, and live region announcements. Output: accessibility spec for implementation handoff.
+
+### Risks and Concerns
+
+1. **View container width tension.** The admin table needs more horizontal room than the 860px tenant-facing views. A scoped `.view-container--admin` at 1100px is the cleanest approach, but requires the shell to conditionally apply the class based on the active route. If this is too much plumbing, the table can work at 860px with more aggressive column truncation, but readability suffers. The implementer should decide based on routing complexity.
+
+2. **Table as links vs. rows with click handlers.** The existing capture list uses `<a>` elements styled as grid rows -- this is the correct accessible pattern (keyboard navigable, right-click context menu works, browser history works). The admin tenant table must follow this same pattern, NOT use `<tr onclick>`. This means the table is technically a list of links styled to look like a table, OR each row's primary column is a link. Recommendation: make the tenant ID cell a link; keep the row as a plain `<tr>`. This avoids the semantic awkwardness of `<a>` inside `<table>` while keeping the drill-down clearly actionable.
+
+3. **No mobile requirement is stated, but the admin dashboard still needs to not break below 860px.** The CSS should not actively optimize for mobile (no stacked columns, no hidden columns), but it must not overflow or become unusable if someone opens it on a smaller window. A simple `overflow-x: auto` on the table wrapper handles this gracefully.
+
+4. **Data volume.** The plan assumes tenant counts in the low hundreds. If tenant count grows to thousands, the table will need server-side pagination and search. This is not needed for MVP -- build the simple version, add pagination later if needed. The 2-second load target is easily met with D1 for hundreds of rows.
+
+5. **No dark mode.** The existing design system has no dark mode tokens or `prefers-color-scheme` handling. The admin dashboard should not introduce dark mode -- stay consistent with the rest of the product.
+
+6. **Stat card count sensitivity.** The 4-stat grid becomes cramped if stat values are long (e.g., "1,247,893 captures"). Use `font-variant-numeric: tabular-nums` and keep labels short. If values exceed 7 digits, abbreviate (1.2M).
+
+### Additional Agents Needed
+
+- **frontend-minion**: To implement the admin view JS module (`ui-admin.js`), the CSS additions in `ui-css.js`, and the hash router extension. The implementation should follow the exact DOM-building pattern from `ui-billing.js` and `ui-detail.js` (createElement, classList, appendChild -- no innerHTML with interpolated data).
+
+- **data-minion**: To define the admin API endpoint(s) that aggregate tenant and usage data. The admin dashboard needs a single endpoint that returns all tenants with their current-period usage in one response, avoiding N+1 queries. This likely means a new query joining `tenants` with `usage_counters` on `period = currentPeriod`.
+
+- **security-minion**: To verify that the admin dashboard route and its API endpoints are properly gated behind admin authentication (ADMIN_KEY). The dashboard must not be accessible to regular tenant sessions. This is a critical access control boundary -- admin sees all tenants' data.

--- a/docs/history/nefario-reports/2026-03-26-150501-admin-dashboard/phase3-synthesis-prompt.md
+++ b/docs/history/nefario-reports/2026-03-26-150501-admin-dashboard/phase3-synthesis-prompt.md
@@ -1,0 +1,55 @@
+MODE: SYNTHESIS
+
+You are synthesizing specialist planning contributions into a final execution plan.
+
+## Original Task
+Build an admin dashboard for operator visibility into tenant overviews, per-tenant usage, tier consumption — replacing manual D1 queries for operational awareness.
+
+Success criteria:
+- Dashboard shows: list of all tenants, per-tenant capture counts (current period and historical), tier/plan info, usage vs. limits
+- Data is live from D1 (not cached snapshots)
+- Protected by admin authentication
+- Loads in under 2 seconds
+
+Scope:
+- In: Tenant list view, usage summary per tenant, aggregate usage overview
+- Out: Tenant self-service portal, billing management, real-time streaming metrics, profitability calculations
+
+## Specialist Contributions
+
+Read the following scratch files for full specialist contributions:
+- /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-wqDwHT/admin-dashboard/phase2-data-minion.md
+- /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-wqDwHT/admin-dashboard/phase2-api-design-minion.md
+- /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-wqDwHT/admin-dashboard/phase2-frontend-minion.md
+- /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-wqDwHT/admin-dashboard/phase2-security-minion.md
+- /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-wqDwHT/admin-dashboard/phase2-ux-design-minion.md
+- /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-wqDwHT/admin-dashboard/phase2-test-minion.md
+
+## Key consensus across specialists:
+- data-minion: Three new DAL functions (listTenantsWithUsage, getUsageHistory, getAggregateStats) using LEFT JOINs and scalar subqueries; no new indexes or migrations needed; "approaching limits" computed in JS app layer
+- api-design-minion: Three endpoints (GET /v1/admin/tenants, GET /v1/admin/tenants/:id, GET /v1/admin/overview) each mapping to single db.batch() call; parallel client load for tenants+overview; full consistency with existing patterns
+- frontend-minion: Option B — separate /admin endpoint with its own HTML shell (admin-shell.js), mirroring existing ui-shell.js pattern; sessionStorage Bearer token auth; vanilla JS with design system CSS
+- security-minion: sessionStorage for admin key (tab-scoped), Bearer token auth (no CSRF concern), column-name allowlist for ORDER BY, raise rate limit to 30/60s
+- ux-design-minion: Reuse existing design system primitives; three-level hierarchy (aggregate stats → tenant table → detail drill-down); wider 1100px container for admin; semantic HTML table with aria-sort; manual refresh only
+- test-minion: Three test layers — DAL tests (~60%), API endpoint tests (~35%), UI tests (~5%); new seedTenantWithTier fixture helper; IP counter range at 150+
+
+## Conflict to resolve:
+- Rate limit: api-design-minion recommends 20/60s, security-minion recommends 30/60s. Resolve this.
+
+## External Skills Context
+One external skill detected: ops-runbook (LEAF, reference only — documents manual D1 queries this dashboard replaces). No execution integration needed.
+
+## Instructions
+1. Review all specialist contributions (read the full files)
+2. Resolve the rate limit conflict between api-design-minion and security-minion
+3. Create the final execution plan in structured format with:
+   - Task list with dependencies, agent assignments, model selection (sonnet for execution), and complete self-contained prompts
+   - Approval gates where needed (the meta-plan identified 2: API surface design and admin auth model)
+   - Consider consolidating gates if appropriate for this scope
+4. Ensure every task has a complete, self-contained prompt that an agent can execute independently
+5. Key constraints from CLAUDE.md:
+   - Vanilla JS only (no frameworks)
+   - YAGNI/KISS philosophy
+   - Fail loudly, degrade intentionally
+   - <300ms uncached response time target
+6. Write your complete delegation plan to /var/folders/3k/bfjvvz9s6dvdn_hvlhvr8lc00000gn/T//nefario-scratch-wqDwHT/admin-dashboard/phase3-synthesis.md

--- a/docs/history/nefario-reports/2026-03-26-150501-admin-dashboard/phase3-synthesis.md
+++ b/docs/history/nefario-reports/2026-03-26-150501-admin-dashboard/phase3-synthesis.md
@@ -1,0 +1,842 @@
+## Delegation Plan
+
+**Team name**: admin-dashboard
+**Description**: Build an admin dashboard for operator visibility into tenant overviews, per-tenant usage, and tier consumption -- replacing manual D1 queries with a live `/admin` UI.
+
+### Conflict Resolution: Rate Limit
+
+api-design-minion recommended 20/60s; security-minion recommended 30/60s. Resolved in favor of **30/60s** (security-minion's position). Rationale: the admin key has approximately 256 bits of entropy, making brute-force non-viable regardless of rate. The rate limit exists to prevent accidental self-DoS, not to resist enumeration. 30/60s gives comfortable headroom for a dashboard session (initial 2-request parallel load + multiple drill-downs + refreshes) without reaching limits during normal operation. A lower value would frustrate the operator within a single minute of exploration. The blast radius is limited -- this only affects requests authenticated with the admin infrastructure secret.
+
+---
+
+### Task 1: Add DAL functions to `src/db.js`
+
+- **Agent**: data-minion
+- **Delegation type**: standard
+- **Model**: sonnet
+- **Mode**: default
+- **Blocked by**: none
+- **Approval gate**: no
+- **Prompt**: |
+
+    ## Task: Add four admin dashboard DAL functions to `src/db.js`
+
+    You are adding four new data access layer functions to the existing `src/db.js` module for an admin dashboard. These functions provide read-only aggregate views of tenant and usage data. No schema changes or migrations are needed -- all queries work against existing tables and indexes.
+
+    ### Context
+
+    The existing DAL in `src/db.js` follows strict conventions:
+    - All DB access is centralized in this module (no raw `env.DB.prepare()` elsewhere)
+    - Functions use `db.prepare(...).bind(...)` for parameterized queries
+    - Functions return plain JS objects with camelCase keys (transformed from snake_case DB columns)
+    - `db.batch()` is used when multiple statements need to execute in a single round-trip
+    - The `computePeriod()` function (already exported from `db.js`) returns the current `YYYY-MM` period string
+
+    The relevant tables are:
+    - `tenants` -- columns: `id`, `tier`, `billing_status`, `grace_period_end`, `payment_method_added_at`, `stripe_customer_id`, `eidas_qualified`, `config`, `created_at`, `updated_at`
+    - `usage_counters` -- columns: `tenant_id`, `period`, `capture_count`, `storage_bytes`, `api_call_count`, `eidas_capture_count`, `updated_at`. Composite PK: `(tenant_id, period)`
+    - `api_keys` -- columns: `key_hash`, `tenant_id`, `scopes`, `name`, `created_at`, `created_by`, `revoked`, `revoked_at`
+
+    ### Functions to add
+
+    **1. `listTenantsWithUsage(db, period)`**
+
+    Returns all tenants with their current-period usage in a single query.
+
+    ```sql
+    SELECT
+      t.id,
+      t.tier,
+      t.billing_status,
+      t.payment_method_added_at,
+      t.eidas_qualified,
+      t.config,
+      t.created_at,
+      COALESCE(u.capture_count, 0) AS capture_count,
+      COALESCE(u.storage_bytes, 0) AS storage_bytes,
+      COALESCE(u.api_call_count, 0) AS api_call_count,
+      COALESCE(u.eidas_capture_count, 0) AS eidas_capture_count,
+      (SELECT COUNT(*) FROM api_keys ak WHERE ak.tenant_id = t.id AND ak.revoked = 0) AS key_count
+    FROM tenants t
+    LEFT JOIN usage_counters u
+      ON u.tenant_id = t.id AND u.period = ?
+    ORDER BY t.created_at DESC
+    ```
+
+    Return shape: array of objects with camelCase keys. Include `config` as raw string (the handler will parse it). Include `keyCount` as a number.
+
+    **2. `getUsageHistory(db, tenantId, limit = 12)`**
+
+    Returns historical usage for a single tenant across multiple periods.
+
+    ```sql
+    SELECT period, capture_count, storage_bytes, api_call_count, eidas_capture_count, updated_at
+    FROM usage_counters
+    WHERE tenant_id = ?
+    ORDER BY period DESC
+    LIMIT ?
+    ```
+
+    Return shape: array of `{ period, captureCount, storageBytes, apiCallCount, eidasCaptureCount, updatedAt }`.
+
+    **3. `getTenantDetail(db, tenantId, periodLimit = 6)`**
+
+    Returns comprehensive tenant data in a single `db.batch()` call (one D1 round-trip). Three statements:
+
+    ```sql
+    -- Statement 1: tenant row
+    SELECT * FROM tenants WHERE id = ?
+
+    -- Statement 2: usage history
+    SELECT period, capture_count, storage_bytes, api_call_count, eidas_capture_count, updated_at
+    FROM usage_counters WHERE tenant_id = ? ORDER BY period DESC LIMIT ?
+
+    -- Statement 3: active keys
+    SELECT key_hash, name, scopes, created_at, created_by
+    FROM api_keys WHERE tenant_id = ? AND revoked = 0 ORDER BY created_at DESC
+    ```
+
+    Return shape: `{ tenant: {...}, usageHistory: [...], keys: [...] }` or `null` if tenant not found. Transform keys to camelCase. Parse `scopes` from JSON string to array.
+
+    **4. `getOverviewStats(db, period)`**
+
+    Returns platform-wide aggregate statistics.
+
+    ```sql
+    -- Statement 1: tenant breakdown
+    SELECT
+      COUNT(*) AS total_tenants,
+      SUM(CASE WHEN tier = 'free' THEN 1 ELSE 0 END) AS free_count,
+      SUM(CASE WHEN tier = 'pro' THEN 1 ELSE 0 END) AS pro_count,
+      SUM(CASE WHEN billing_status = 'active' THEN 1 ELSE 0 END) AS active_count,
+      SUM(CASE WHEN billing_status = 'grace_period' THEN 1 ELSE 0 END) AS grace_count,
+      SUM(CASE WHEN billing_status = 'blocked' THEN 1 ELSE 0 END) AS blocked_count,
+      (SELECT COUNT(*) FROM api_keys WHERE revoked = 0) AS active_api_keys
+    FROM tenants
+
+    -- Statement 2: usage aggregates
+    SELECT
+      SUM(CASE WHEN period = ? THEN capture_count ELSE 0 END) AS current_captures,
+      SUM(capture_count) AS all_time_captures,
+      SUM(CASE WHEN period = ? THEN storage_bytes ELSE 0 END) AS current_storage,
+      SUM(CASE WHEN period = ? THEN eidas_capture_count ELSE 0 END) AS current_eidas_captures
+    FROM usage_counters
+    ```
+
+    Use `db.batch()` for single round-trip. Return shape: `{ totalTenants, tenantsByTier: {free, pro}, tenantsByBillingStatus: {active, gracePeriod, blocked}, totalCapturesCurrentPeriod, totalCapturesAllTime, totalStorageBytes, totalEidasCaptures, activeApiKeys }`.
+
+    ### Implementation rules
+
+    - Export all four functions
+    - Follow the exact coding style of existing functions (JSDoc comments, parameter validation patterns)
+    - Use `COALESCE` for LEFT JOINs to ensure zeroed defaults
+    - No new indexes needed (existing PKs and indexes are sufficient at current scale)
+    - Do NOT use `db.exec()` -- always use `db.prepare().bind().all()` or `db.batch()`
+
+    ### What NOT to do
+
+    - Do NOT modify existing DAL functions
+    - Do NOT add any new tables or migrations
+    - Do NOT compute "approaching limits" logic in the DAL -- that is application-layer logic using `getEffectiveQuota()` from `quotas.js`
+    - Do NOT add pagination -- YAGNI at current scale
+
+    ### Files to modify
+
+    - `src/db.js` -- add the four functions at the end, before any closing comments
+
+    ### Success criteria
+
+    - All four functions exported from `src/db.js`
+    - Parameterized queries (no string interpolation)
+    - camelCase return keys
+    - `db.batch()` used where multiple statements needed
+    - Existing functions and exports unchanged
+
+- **Deliverables**: Four new exported functions in `src/db.js`: `listTenantsWithUsage`, `getUsageHistory`, `getTenantDetail`, `getOverviewStats`
+- **Success criteria**: Functions exported, use parameterized queries, return camelCase objects, batch where possible
+
+---
+
+### Task 2: Add admin dashboard API endpoints and raise rate limit
+
+- **Agent**: api-design-minion
+- **Delegation type**: standard
+- **Model**: sonnet
+- **Mode**: default
+- **Blocked by**: Task 1
+- **Approval gate**: yes
+- **Gate reason**: The API surface (three endpoints with response shapes) is hard to reverse once the frontend depends on it, and both the frontend task (Task 3) and test task (Task 4) depend on these contracts.
+- **Gate rationale**: |
+    Chosen: Three focused GET endpoints (`/v1/admin/tenants`, `/v1/admin/tenants/:id`, `/v1/admin/overview`), each returning purpose-specific response shapes. Tenant list includes embedded usage (via JOIN) to avoid N+1. Detail includes usage history + keys in one response (via db.batch). Overview returns aggregated platform stats.
+    Over: (1) Single mega-endpoint returning everything -- rejected because it mixes concerns that change at different rates and prevents parallel client-side fetches. (2) Reusing existing per-tenant endpoints (`GET /v1/admin/usage`) with a loop -- rejected because it creates N+1 queries.
+    Why: Three endpoints match the existing API pattern (purpose-specific, one resource per endpoint), enable parallel fetching on dashboard load, and each maps cleanly to a single DAL function or db.batch call.
+- **Prompt**: |
+
+    ## Task: Add admin dashboard API endpoints and raise rate limit
+
+    You are adding three new admin API endpoints for an operator dashboard and raising the admin rate limit from 5/60s to 30/60s. The endpoints are read-only views of tenant and usage data, protected by the existing `verifyAdminKey` auth gate.
+
+    ### Context
+
+    The existing admin API in `src/admin.js` handles key management (create, list, revoke) and usage queries. All admin endpoints:
+    - Use `verifyAdminKey` auth (Bearer token against `ADMIN_KEY` secret)
+    - Are rate-limited by `ADMIN_RATE_LIMITER` (currently 5/60s, you will raise to 30/60s)
+    - Return `Cache-Control: private, no-store` via the `ADMIN_CACHE` constant
+    - Use `problemResponse()` for errors (RFC 9457 format)
+    - Log all requests via `ctx.waitUntil(log(...))`
+    - Return camelCase JSON field names
+
+    `src/admin.js` is currently 495 lines focused on key management. The dashboard handlers are a different concern, so create a new file `src/admin-dashboard.js`.
+
+    The route table in `src/index.js` uses regex patterns with capture groups. Admin auth and rate limiting are handled centrally in the fetch handler (lines 527-549) for all `/v1/admin/*` routes, so the new endpoints automatically get auth + rate limiting.
+
+    ### Part 1: Create `src/admin-dashboard.js` with three handler functions
+
+    **Handler 1: `handleAdminListTenants(request, env, ctx)`**
+
+    Endpoint: `GET /v1/admin/tenants`
+
+    Implementation:
+    1. Import `listTenantsWithUsage` from `./db.js` and `getEffectiveQuota` from `./quotas.js`
+    2. Extract optional `period` query param; default to `computePeriod()`; validate with `/^\d{4}-\d{2}$/`
+    3. Call `listTenantsWithUsage(env.DB, period)`
+    4. For each tenant, parse `config` JSON and compute quota via `getEffectiveQuota(hasPaymentMethod, parsedConfig)`
+    5. Log the request via `ctx.waitUntil(log(env, 3, 'admin', { event: 'admin.list_tenants', ... }))`
+
+    Response shape:
+    ```json
+    {
+      "data": [
+        {
+          "tenantId": "acme-corp",
+          "tier": "free",
+          "billingStatus": "active",
+          "hasPaymentMethod": false,
+          "eidasQualified": false,
+          "createdAt": "2025-11-01T12:00:00.000Z",
+          "currentPeriod": {
+            "period": "2026-03",
+            "captureCount": 142,
+            "eidasCaptureCount": 0,
+            "storageBytes": 524288000,
+            "apiCallCount": 890
+          },
+          "quota": {
+            "capturesPerMonth": 200,
+            "storageBytes": 1073741824
+          },
+          "keyCount": 2
+        }
+      ],
+      "meta": {
+        "totalTenants": 12,
+        "period": "2026-03"
+      }
+    }
+    ```
+
+    - `hasPaymentMethod` is a boolean derived from `payment_method_added_at IS NOT NULL`
+    - `quota` is computed server-side by `getEffectiveQuota()`
+    - Do NOT include raw `config` or `payment_method_added_at` timestamp in the response
+    - Headers: `ADMIN_CACHE` (`Cache-Control: private, no-store`)
+
+    **Handler 2: `handleAdminGetTenant(request, env, ctx, match)`**
+
+    Endpoint: `GET /v1/admin/tenants/:id`
+
+    The `match` parameter contains regex capture groups. `match[1]` is the tenant ID (already validated by route regex `[a-z0-9_-]{1,64}`).
+
+    Implementation:
+    1. Import `getTenantDetail` from `./db.js`
+    2. Extract tenant ID from `match[1]`
+    3. Extract optional `periods` query param (default 6, max 24, validate as positive integer)
+    4. Call `getTenantDetail(env.DB, tenantId, periods)`
+    5. If result is null, return `problemResponse(404, 'Tenant not found')`
+    6. Compute quota via `getEffectiveQuota()`
+    7. Log the request
+
+    Response shape:
+    ```json
+    {
+      "tenantId": "acme-corp",
+      "tier": "free",
+      "billingStatus": "active",
+      "gracePeriodEnd": null,
+      "hasPaymentMethod": false,
+      "paymentMethodAddedAt": null,
+      "stripeCustomerId": null,
+      "eidasQualified": false,
+      "config": {},
+      "createdAt": "2025-11-01T12:00:00.000Z",
+      "updatedAt": "2026-03-15T09:30:00.000Z",
+      "quota": {
+        "capturesPerMonth": 200,
+        "storageBytes": 1073741824
+      },
+      "keys": [
+        {
+          "keyHash": "a1b2c3...",
+          "name": "production",
+          "scopes": ["capture", "read"],
+          "createdAt": "2025-11-01T12:00:00.000Z",
+          "createdBy": "admin"
+        }
+      ],
+      "usageHistory": [
+        { "period": "2026-03", "captureCount": 142, "eidasCaptureCount": 0, "storageBytes": 524288000, "apiCallCount": 890 }
+      ]
+    }
+    ```
+
+    - `config` is the parsed JSON object (or `{}` if null)
+    - Headers: `ADMIN_CACHE`
+
+    **Handler 3: `handleAdminGetOverview(request, env, ctx)`**
+
+    Endpoint: `GET /v1/admin/overview`
+
+    Implementation:
+    1. Import `getOverviewStats` from `./db.js`
+    2. Extract optional `period` query param; default to `computePeriod()`; validate
+    3. Call `getOverviewStats(env.DB, period)`
+    4. Log the request
+
+    Response shape:
+    ```json
+    {
+      "totalTenants": 12,
+      "totalCapturesCurrentPeriod": 4520,
+      "totalCapturesAllTime": 45000,
+      "totalStorageBytes": 21474836480,
+      "totalEidasCaptures": 120,
+      "tenantsByTier": { "free": 8, "pro": 4 },
+      "tenantsByBillingStatus": { "active": 10, "gracePeriod": 1, "blocked": 1 },
+      "activeApiKeys": 24,
+      "period": "2026-03"
+    }
+    ```
+
+    - Headers: `ADMIN_CACHE`
+
+    ### Part 2: Register routes in `src/index.js`
+
+    Add three new routes to the `routes` array, after the existing admin routes:
+
+    ```js
+    ['GET',    /^\/v1\/admin\/tenants$/, handleAdminListTenants],
+    ['GET',    /^\/v1\/admin\/tenants\/([a-z0-9_-]{1,64})$/, handleAdminGetTenant],
+    ['GET',    /^\/v1\/admin\/overview$/, handleAdminGetOverview],
+    ```
+
+    Add the import at the top of `index.js`:
+    ```js
+    import { handleAdminListTenants, handleAdminGetTenant, handleAdminGetOverview } from './admin-dashboard.js';
+    ```
+
+    **Route ordering note**: Place `GET /v1/admin/tenants/:id` AFTER the existing `GET /v1/admin/tenants/:id/config` route (line 85-86). The `$` anchor on the new route prevents collision, but keeping the more specific route first is good practice. Add a comment noting the relationship.
+
+    ### Part 3: Raise admin rate limit from 5/60s to 30/60s
+
+    **`src/rate-limits.js`**: Change `admin: { limit: 5, period: 60 }` to `admin: { limit: 30, period: 60 }`.
+
+    **`wrangler.toml`**: Change `simple = { limit = 5, period = 60 }` to `simple = { limit = 30, period = 60 }` in BOTH the production `ADMIN_RATE_LIMITER` binding (around line 48) AND the staging `ADMIN_RATE_LIMITER` binding (around line 258).
+
+    Update the comment in `src/admin.js` header (line 10) that says "5 req/60s per IP" to "30 req/60s per IP".
+
+    ### What NOT to do
+
+    - Do NOT modify existing admin handlers in `src/admin.js` (except the rate limit comment)
+    - Do NOT add WebSocket/SSE support
+    - Do NOT add pagination
+    - Do NOT add a caching layer
+    - Do NOT add CORS headers on admin endpoints
+    - Do NOT add ORDER BY parameters that accept user input (the tenant list always sorts by `created_at DESC`)
+
+    ### Files to create
+
+    - `src/admin-dashboard.js`
+
+    ### Files to modify
+
+    - `src/index.js` -- add import + three routes
+    - `src/rate-limits.js` -- raise admin limit
+    - `wrangler.toml` -- raise binding limit (production + staging)
+    - `src/admin.js` -- update rate limit comment in header
+
+    ### Success criteria
+
+    - Three new GET endpoints accessible with admin key auth
+    - All responses use `ADMIN_CACHE` headers
+    - All requests logged
+    - Period param validated
+    - Tenant detail returns 404 for unknown tenant
+    - Rate limit raised in both code and wrangler config
+    - No CORS headers on admin responses
+    - Existing admin endpoints unaffected
+
+- **Deliverables**: `src/admin-dashboard.js` with three handlers; route registration in `src/index.js`; rate limit raised to 30/60s
+- **Success criteria**: Endpoints return correct response shapes, proper auth gate, logging, error handling, rate limit change applied in both code and wrangler config
+
+---
+
+### Task 3: Build admin dashboard frontend
+
+- **Agent**: frontend-minion
+- **Delegation type**: standard
+- **Model**: sonnet
+- **Mode**: default
+- **Blocked by**: Task 2
+- **Approval gate**: no
+- **Prompt**: |
+
+    ## Task: Build the admin dashboard frontend
+
+    You are building a standalone admin dashboard served from `GET /admin` that lets operators view tenant data, usage, and platform overview. The dashboard is a separate HTML shell from the existing tenant UI at `/ui`, with its own auth flow (admin key in sessionStorage).
+
+    ### Architecture
+
+    Follow the exact same pattern as the existing tenant UI:
+    - `src/ui/ui-shell.js` inlines all CSS + JS into a single HTML response
+    - Each view is a separate JS module file exporting a string constant
+    - DOM is built with `createElement`/`appendChild` -- never use `innerHTML` with variable data (XSS prevention)
+    - Design system CSS (`src/design-system.js` exports `DESIGN_SYSTEM_CSS`) provides all tokens and component styles
+    - Hash routing for view navigation
+
+    ### Files to create
+
+    **1. `src/admin/admin-shell.js`**
+
+    Export `htmlAdminDashboard()` function that returns a `Response` with:
+    - HTML document with inline CSS (design system + admin CSS) and inline JS (auth + views)
+    - Title: "WRL Admin"
+    - CSP header: `default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src 'self'; connect-src 'self'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'`
+    - `Cache-Control: no-store`
+    - `X-Frame-Options: DENY`
+    - `<div id="admin-app"></div>` as mount point
+    - `<noscript>` message
+
+    **2. `src/admin/admin-auth.js`**
+
+    Export `ADMIN_AUTH_JS` string constant containing the auth gate code:
+    - On load: check `sessionStorage.getItem('wrl_admin_key')`
+    - If absent: render a login form with `<input type="password" autocomplete="off">` and a submit button
+    - On submit: validate by calling `GET /v1/admin/overview` with `Authorization: Bearer <key>`. Use the overview endpoint because it is a single lightweight GET that confirms admin access.
+    - On 200: store key in `sessionStorage`, render the admin shell (nav + content area)
+    - On 401: show error alert using `.alert.alert--error` pattern, clear input
+    - Paste-friendly -- do NOT disable paste
+    - Provide a "Logout" button that calls `sessionStorage.removeItem('wrl_admin_key')` and reloads
+
+    Helper function `adminFetch(path)` that wraps `fetch()` with `Authorization: Bearer` header from sessionStorage.
+
+    **3. `src/admin/admin-css.js`**
+
+    Export `ADMIN_CSS` string constant. Only admin-specific CSS additions -- the design system covers everything else. Use design system CSS custom properties exclusively (no hardcoded colors, sizes, or fonts).
+
+    Key classes needed:
+    - `.view-container--admin` -- `max-width: 1100px` (wider than the 860px tenant views, scoped to admin)
+    - `.admin-stats-row` -- `display: grid; grid-template-columns: repeat(4, 1fr); gap: var(--space-4); margin-bottom: var(--space-6);`
+    - `.admin-stat`, `.admin-stat-value`, `.admin-stat-label` -- mirrors the billing-stat pattern (centered text, bold value, muted label)
+    - `.admin-table-wrap` -- `overflow-x: auto` for responsive table handling
+    - `.admin-table tr` -- `cursor: pointer` on data rows, hover background `var(--color-surface-muted)`
+    - `.admin-table th button` -- sortable header button styling (inherits font, no border, pointer cursor)
+    - `.admin-tenant-link` -- tenant ID cell using `font-family: var(--font-mono); color: var(--color-primary)`
+    - `.admin-refresh-btn` -- refresh button styling matching existing `.usage-refresh-btn` pattern
+
+    Estimated approximately 60-80 lines of CSS.
+
+    **4. `src/admin/admin-tenants.js`**
+
+    Export `ADMIN_TENANTS_JS` string constant -- the tenant list view.
+
+    On mount:
+    1. Call `adminFetch('/v1/admin/overview')` and `adminFetch('/v1/admin/tenants')` in parallel via `Promise.all`
+    2. Show loading placeholder ("Loading tenant data..." in muted text)
+    3. On success, render:
+
+    **Level 1: Stat cards** (reuse billing stat-cell pattern)
+    - Total Tenants (from overview)
+    - Active This Period (tenants with captureCount > 0, computed client-side from tenant list)
+    - Total Captures (from overview `totalCapturesCurrentPeriod`)
+    - Total Storage (from overview `totalStorageBytes`, formatted human-readable)
+
+    **Level 2: Tenant table** (semantic HTML `<table>`)
+    - Columns: Tenant ID (link to detail), Tier (badge), Captures (period), Storage, Keys, Created
+    - Tenant ID column: `<a href="#/tenants/${id}">` with `.admin-tenant-link` class
+    - Tier column: use existing `.badge` component
+    - Numeric columns: right-aligned, `font-variant-numeric: tabular-nums`
+    - Created column: human-readable date format
+    - Default sort: captures descending (client-side sort)
+    - Sortable columns: click `<th>` buttons to toggle sort. Use `aria-sort` attribute on active column.
+    - Empty state: "No tenants found." in muted text
+    - `<th scope="col">` on all headers
+    - `aria-label="Tenant list"` on the `<table>`
+
+    **Refresh button**: Below stats, above table. On click, re-fetches both endpoints.
+
+    **Error handling**: On API failure, show `.alert.alert--error` with `role="alert"`: "Could not load tenant data. Please try refreshing."
+
+    **5. `src/admin/admin-detail.js`**
+
+    Export `ADMIN_DETAIL_JS` string constant -- per-tenant detail view.
+
+    Route: `#/tenants/:tenantId` (extract tenant ID from hash)
+
+    On mount:
+    1. Call `adminFetch('/v1/admin/tenants/${tenantId}?periods=12')`
+    2. Show loading placeholder
+
+    On success, render:
+
+    **Back link**: "Back to tenants" linking to `#/tenants` (reuse `buildBackLink()` pattern from `ui-detail.js`)
+
+    **Tenant header**: h1 with tenant ID, badge showing tier
+
+    **Current period usage**: Card section (`.settings-section.card` pattern) with:
+    - Capture count vs. quota limit (progress bar using `.usage-bar` pattern if quota is finite)
+    - Storage bytes (formatted)
+    - API call count
+    - eIDAS capture count (only if > 0)
+
+    **Usage history table**: Compact table showing period-over-period data:
+    | Period | Captures | Storage | API Calls | eIDAS |
+    Use `.billing-tier-table` styling (compact, --text-sm)
+
+    **API Keys section**: Table showing active keys with name, scopes (as badges), created date. Read-only display only.
+
+    **Tenant config section**: Show config as formatted JSON in a `<pre>` with `<code>`. Only if config is non-empty.
+
+    **Error handling**: Same pattern as tenant list.
+
+    ### Route handling
+
+    Add a hash router within the admin shell:
+    ```
+    #/tenants       -> tenant list (default)
+    #/tenants/:id   -> tenant detail
+    ```
+
+    On empty hash or `#/`, redirect to `#/tenants`. Listen to `hashchange` event.
+
+    ### Register the `/admin` route
+
+    In `src/index.js`:
+    1. Import: `import { htmlAdminDashboard } from './admin/admin-shell.js';`
+    2. Add to routes array: `['GET', /^\/admin$/, handleAdminDashboard],`
+    3. Add handler function (same pattern as `handleDashboard`):
+    ```js
+    function handleAdminDashboard() {
+      return htmlAdminDashboard();
+    }
+    ```
+
+    Note: The `/admin` route is NOT under `/v1/admin/` so it does NOT go through admin auth/rate-limit in the fetch handler. This is correct -- the HTML shell is served unauthenticated (just like `/ui`). Auth happens client-side before API calls.
+
+    ### Accessibility requirements
+
+    - Heading hierarchy: h1 = page/view title, h2 = section headings
+    - Semantic table: `<table>`, `<thead>`, `<tbody>`, `<th scope="col">`
+    - Sortable columns: `<button>` inside `<th>`, `aria-sort="ascending"` / `aria-sort="descending"`
+    - `aria-live="polite"` region (visually hidden) for announcing sort changes and refresh completion
+    - Focus management: on view navigation, focus the h1 via `tabIndex=-1` + `.focus()`
+    - Error alerts: `role="alert"` on error messages
+    - Login form: proper `<label>` for the password input
+
+    ### Formatting helpers
+
+    Implement these as plain functions in the tenants module:
+    - `formatBytes(bytes)` -- human-readable bytes (KB, MB, GB)
+    - `formatDate(isoString)` -- "Mar 15, 2026" format
+    - `formatNumber(n)` -- locale-formatted number with commas/dots
+
+    ### What NOT to do
+
+    - Do NOT use any framework (React, Vue, etc.) or build tool
+    - Do NOT use `innerHTML` with variable data -- always `textContent` or `createElement`
+    - Do NOT add auto-refresh or polling
+    - Do NOT add dark mode
+    - Do NOT load external resources (fonts, scripts, stylesheets)
+    - Do NOT add mobile-specific responsive design (just ensure `overflow-x: auto` on tables so nothing breaks)
+    - Do NOT add tenant management features (create, delete, edit) -- this dashboard is read-only visibility
+
+    ### Files to create
+
+    - `src/admin/admin-shell.js`
+    - `src/admin/admin-auth.js`
+    - `src/admin/admin-css.js`
+    - `src/admin/admin-tenants.js`
+    - `src/admin/admin-detail.js`
+
+    ### Files to modify
+
+    - `src/index.js` -- add import, route, handler function
+
+    ### Success criteria
+
+    - `GET /admin` returns a valid HTML document with inline CSS + JS
+    - Admin key prompt appears on first visit
+    - After entering valid key, tenant list renders with stat cards
+    - Tenant drill-down shows usage history, keys, config
+    - All data from live API calls (no cached snapshots)
+    - No external resource loads
+    - Page loads in under 2 seconds (inline-everything architecture makes this trivial)
+    - Tables are accessible with proper ARIA attributes
+    - `textContent` used for all data rendering (no XSS vectors)
+
+- **Deliverables**: `src/admin/` directory with 5 JS modules; route registration in `src/index.js`
+- **Success criteria**: Dashboard renders from `/admin`, admin auth gate works, tenant list and detail views functional, accessible markup, no external resource loads
+
+---
+
+### Task 4: Write tests for admin dashboard
+
+- **Agent**: test-minion
+- **Delegation type**: standard
+- **Model**: sonnet
+- **Mode**: default
+- **Blocked by**: Task 1, Task 2, Task 3
+- **Approval gate**: no
+- **Prompt**: |
+
+    ## Task: Write tests for the admin dashboard DAL, API, and UI
+
+    You are writing tests for the new admin dashboard functionality. Follow the exact conventions of the existing test suite -- `@cloudflare/vitest-pool-workers` with real D1, `SELF.fetch()` for HTTP tests, `cleanDb()` in `beforeEach`.
+
+    ### Context: Testing conventions in this project
+
+    - **No mocks for D1**: Tests use the real D1 binding (`env.DB`) via vitest-pool-workers
+    - **`cleanDb(db)` in `beforeEach`**: Every test file imports this from `test/fixtures.js`
+    - **`nextIp()` pattern**: Each test file maintains its own IP counter to avoid rate limiter collisions. Existing ranges: admin-keys starts at 10, admin-usage at 100, account-usage at 200. **Use IP range starting at 150** for these tests.
+    - **`SELF.fetch()`**: For HTTP endpoint tests, construct requests with `new Request()` and call `SELF.fetch(req)`. Set `CF-Connecting-IP` header for rate limiting.
+    - **Response shape assertions**: Assert exact field lists with `Object.keys(body).sort()`.
+    - **Seed data**: Each test seeds its own data using helpers from `fixtures.js`. No shared fixtures.
+    - **Admin auth**: Use `TEST_ADMIN_KEY` from `fixtures.js` for the `Authorization: Bearer` header.
+
+    ### Test file 1: `test/admin-dashboard.test.js`
+
+    This is the main test file covering both DAL functions and API endpoints.
+
+    **Rate limit IP counter**: Start at 150, increment per describe block.
+
+    **New fixture helper needed**: Add `seedTenantWithTier(db, tenantId, overrides)` to `test/fixtures.js`. This helper seeds a tenant row with customizable columns:
+
+    ```js
+    export async function seedTenantWithTier(db, tenantId, {
+      tier = 'free',
+      billingStatus = 'active',
+      stripeCustomerId = null,
+      paymentMethodAddedAt = null,
+      eidasQualified = 0,
+      config = null,
+      createdAt = new Date().toISOString(),
+    } = {}) {
+      await db.prepare(
+        `INSERT OR REPLACE INTO tenants
+           (id, tier, billing_status, stripe_customer_id, payment_method_added_at, eidas_qualified, config, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+      ).bind(tenantId, tier, billingStatus, stripeCustomerId, paymentMethodAddedAt, eidasQualified,
+             config ? JSON.stringify(config) : null, createdAt).run();
+    }
+    ```
+
+    **DAL function tests** (test with `env.DB` directly):
+
+    `listTenantsWithUsage`:
+    - Empty database returns empty array
+    - Tenant with no usage row returns zeroed counters
+    - Multiple tenants with mixed usage data
+    - Tenants ordered by created_at DESC
+    - keyCount reflects only active (non-revoked) keys
+
+    `getUsageHistory`:
+    - Returns periods in DESC order
+    - Respects limit parameter
+    - Empty history returns empty array
+    - Tenant with no usage data returns empty array
+
+    `getTenantDetail`:
+    - Returns null for nonexistent tenant
+    - Includes tenant metadata, usage history, and active keys
+    - Keys array excludes revoked keys
+    - Periods param caps history results
+
+    `getOverviewStats`:
+    - Empty database returns zeroed stats
+    - Correctly counts tenants by tier
+    - Correctly counts tenants by billing status
+    - Aggregates captures across all tenants for current period
+    - All-time captures includes all periods
+    - Active API keys excludes revoked keys
+
+    **API endpoint tests** (use `SELF.fetch()`):
+
+    `GET /v1/admin/tenants`:
+    - 401 without Authorization header
+    - 401 with wrong key
+    - 200 with valid admin key
+    - Response has correct field structure (`data` array, `meta` object)
+    - Each tenant object has expected fields (tenantId, tier, billingStatus, hasPaymentMethod, eidasQualified, createdAt, currentPeriod, quota, keyCount)
+    - `quota` is computed correctly (free tier = 200 captures, paid = Infinity)
+    - Invalid `period` param returns 400
+    - Cache-Control header is `private, no-store`
+    - Content-Type is `application/json`
+
+    `GET /v1/admin/tenants/:id`:
+    - 401 without auth
+    - 404 for nonexistent tenant
+    - 200 returns full tenant detail with usageHistory and keys arrays
+    - `periods` param defaults to 6, caps at 24
+    - Invalid `periods` param returns 400
+    - Keys array shows name, scopes, createdAt, createdBy (no raw key)
+    - Cache-Control: `private, no-store`
+
+    `GET /v1/admin/overview`:
+    - 401 without auth
+    - 200 returns aggregate stats with expected fields
+    - `tenantsByTier` and `tenantsByBillingStatus` reflect seeded data
+    - Cache-Control: `private, no-store`
+
+    **Security tests**:
+    - Tenant API key (TEST_TENANT_KEY) rejected on admin endpoints
+    - No CORS headers (`Access-Control-Allow-Origin`) on admin responses
+
+    ### Test file 2: `test/ui-admin.test.js`
+
+    Lightweight UI tests following the pattern from `ui-dashboard.test.js`:
+
+    - `GET /admin` returns 200 with `text/html` content type
+    - Response contains `<div id="admin-app">`
+    - Response contains `Cache-Control: no-store`
+    - CSP header includes `frame-ancestors 'none'`
+    - X-Frame-Options: DENY is present
+    - No external script/stylesheet loads (`<script src=`, `<link rel="stylesheet" href=`)
+    - HTML does not contain `innerHTML` assignments with template literals (search the response body string)
+
+    ### Fixture modification
+
+    Add `seedTenantWithTier` to `test/fixtures.js` and export it.
+
+    ### What NOT to do
+
+    - Do NOT create browser/E2E tests (no Playwright)
+    - Do NOT run tests casually -- only run when code changes need verification
+    - Do NOT create a separate test worker instance
+    - Do NOT use mocks for D1 queries
+
+    ### Files to create
+
+    - `test/admin-dashboard.test.js`
+    - `test/ui-admin.test.js`
+
+    ### Files to modify
+
+    - `test/fixtures.js` -- add `seedTenantWithTier` helper
+
+    ### Success criteria
+
+    - All DAL function tests cover empty, single, and multi-tenant scenarios
+    - All API endpoint tests verify auth, response shape, headers, and error cases
+    - UI tests verify HTML structure and security headers
+    - IP counter range (150+) does not overlap with existing test files
+    - Tests pass with `npm test`
+
+- **Deliverables**: `test/admin-dashboard.test.js`, `test/ui-admin.test.js`, `seedTenantWithTier` in `test/fixtures.js`
+- **Success criteria**: All tests pass, cover auth/shape/headers/edge cases, no IP counter collisions
+
+---
+
+### Cross-Cutting Coverage
+
+- **Testing**: Task 4 covers all three layers (DAL, API, UI) with real D1 integration tests. Phase 6 post-execution will run the full suite.
+- **Security**: Addressed inline across Tasks 2 and 3. Admin auth via existing `verifyAdminKey`. sessionStorage for client-side key (tab-scoped, clears on close). No CORS on admin endpoints. CSP on HTML shell. `textContent` for data rendering (no innerHTML with variables). ORDER BY is hardcoded (no user-controlled sort columns in SQL). Rate limit raised to 30/60s with documented rationale. Phase 5 code review will audit.
+- **Usability -- Strategy**: The three-level hierarchy (overview stats -> tenant table -> tenant detail) directly replaces manual D1 queries with a structured workflow. Manual refresh only -- no auto-polling complexity. Journey is: enter admin key -> see overview -> drill into tenant. Phase 3.5 review by ux-strategy-minion will evaluate.
+- **Usability -- Design**: ux-design-minion's specifications are incorporated directly into Task 3's prompt: stat card grid, table design, accessible sortable headers, wider admin container, existing design system component reuse. Phase 3.5 will review.
+- **Documentation**: Phase 8 post-execution will assess documentation needs. The evolution log (prompt.md, decisions.md, outcome.md) will be created as part of the orchestration process per CLAUDE.md requirements.
+- **Observability**: All admin endpoints log requests via `ctx.waitUntil(log(...))`, consistent with existing admin handlers. No new observability infrastructure needed -- admin dashboard is a low-frequency operator tool, not a production service requiring dedicated metrics. Excluded from Phase 3.5 review.
+
+### Architecture Review Agents
+
+- **Mandatory** (5): security-minion, test-minion, ux-strategy-minion, lucy, margo
+- **Discretionary picks**:
+  - ux-design-minion: Plan includes Task 3 producing user-facing UI (admin dashboard views, tables, stat cards, detail views).
+    Review focus: Visual hierarchy correctness, component reuse verification, accessibility of table/sort interaction patterns.
+- **Not selected**:
+  - accessibility-minion: ux-design-minion covers accessibility review for this scope (admin-only internal tool, single operator). The accessibility specs are already detailed in Task 3's prompt.
+  - sitespeed-minion: Admin dashboard is an inline-everything single-page app with no external resources. Total payload under 20 KB. Performance budget is trivially met -- no Lighthouse audit adds value here.
+  - observability-minion: No new runtime services. Admin endpoints follow existing logging patterns. No coordinated observability strategy needed.
+  - user-docs-minion: Internal operator tool. No end-user documentation impact.
+
+### Decisions
+
+- **Rate limit value**
+  Chosen: 30 req/60s (security-minion's recommendation)
+  Over: 20 req/60s (api-design-minion's recommendation)
+  Why: Admin key has approximately 256 bits of entropy making brute-force non-viable. Rate limit is for self-DoS prevention, not security. 30/60s gives comfortable headroom for normal dashboard operation (2 parallel requests per page load + drill-downs + refreshes).
+
+- **Dashboard handlers in separate file**
+  Chosen: New `src/admin-dashboard.js` file
+  Over: Adding handlers to existing `src/admin.js` (api-design-minion noted it is already 495 lines)
+  Why: Different concern (dashboard read-only views vs. key management mutations). Keeps modules focused and under reasonable line counts.
+
+- **API endpoint structure**
+  Chosen: Three focused endpoints (`/v1/admin/tenants`, `/v1/admin/tenants/:id`, `/v1/admin/overview`)
+  Over: Single enriched endpoint returning everything; using existing per-tenant endpoints in a loop
+  Why: Matches existing API pattern (purpose-specific endpoints). Enables parallel client-side fetches. Each maps to a clean DAL function or db.batch call.
+
+- **Auth validation probe endpoint**
+  Chosen: Validate admin key by calling `GET /v1/admin/overview`
+  Over: Creating a dedicated `GET /v1/admin/ping` endpoint (security-minion suggested `GET /v1/admin/keys?limit=0` or a ping endpoint)
+  Why: Overview endpoint is lightweight, already needs to be called, and confirms both auth and data access. A dedicated ping endpoint would be YAGNI.
+
+### Risks and Mitigations
+
+1. **Route collision between `GET /v1/admin/tenants/:id` and `GET /v1/admin/tenants/:id/config`** -- Mitigated by regex anchoring (`$` on the new route). Existing config route has `/config` suffix that prevents match. Route ordering documented in code comments.
+
+2. **Unbounded tenant list at scale** -- At current scale (tens of tenants), returning all tenants is correct. If tenant count grows past approximately 500, add pagination as an additive change. Not building it now (YAGNI).
+
+3. **Admin key in browser sessionStorage** -- Accepted residual risk for an operator-only tool. CSP prevents exfiltration. sessionStorage clears on tab close. If admin user base grows beyond single operator, switch to GitHub OAuth with admin role (infrastructure already exists).
+
+4. **`admin.js` at 495 lines** -- Mitigated by creating new `admin-dashboard.js` rather than adding to existing file.
+
+5. **Config JSON parsing per tenant in list endpoint** -- Negligible at current scale (tens of tenants, small config objects). Noted for future monitoring if tenant count grows.
+
+### Execution Order
+
+```
+Batch 1:
+  Task 1: DAL functions (data-minion)
+
+GATE: Task 2 approval (API surface review)
+
+Batch 2 (sequential after Task 1):
+  Task 2: API endpoints + rate limit (api-design-minion)
+
+Batch 3 (sequential after Task 2):
+  Task 3: Frontend (frontend-minion)
+
+Batch 4 (sequential after Tasks 1, 2, 3):
+  Task 4: Tests (test-minion)
+
+Post-execution:
+  Phase 5: Code review (code-review-minion, lucy, margo)
+  Phase 6: Test execution (npm test)
+  Phase 8: Documentation assessment
+```
+
+### External Skills
+
+No external skills are used in the plan.
+
+### Verification Steps
+
+1. `npm test` passes with all new and existing tests
+2. Deploy to staging and verify:
+   - `GET /admin` renders login form
+   - After entering admin key, tenant list loads with stat cards
+   - Drill-down shows tenant detail with usage history and keys
+   - `GET /v1/admin/tenants`, `GET /v1/admin/tenants/:id`, `GET /v1/admin/overview` return correct JSON
+   - Rate limit allows 30 requests per minute
+3. Verify security:
+   - Admin endpoints reject tenant API keys
+   - No CORS headers on admin responses
+   - CSP headers on `/admin` HTML response
+   - Admin key not visible in network responses

--- a/docs/history/nefario-reports/2026-03-26-150501-admin-dashboard/phase3.5-gru.md
+++ b/docs/history/nefario-reports/2026-03-26-150501-admin-dashboard/phase3.5-gru.md
@@ -1,0 +1,33 @@
+## Gru Technology Review — Admin Dashboard
+
+**Verdict: APPROVE**
+
+---
+
+### Technology Choices
+
+**Vanilla JS dashboard (no framework)** -- correct call. This is a single-operator internal tool with two views and no reactive state requirements beyond a hash router. A framework would add build tooling, dependency surface, and bundle size with zero functional return. The existing inline-everything architecture (proven by the tenant UI at `/ui`) handles this scope cleanly. The `createElement`/`appendChild` pattern for XSS prevention is the right constraint to enforce.
+
+**D1 aggregate queries** -- appropriate for current scale. The four DAL functions use `db.batch()` to collapse multi-statement operations into single round-trips, which is the correct D1 optimization pattern. `COALESCE` for LEFT JOIN defaults and `$` regex anchoring on routes are handled correctly. The "no pagination at current scale" YAGNI call is sound -- adding it as an additive change when tenant count warrants is the right posture.
+
+**sessionStorage auth model** -- accepted residual risk, correctly characterized. sessionStorage is tab-scoped and clears on close, limiting exposure window. The CSP (`default-src 'none'; connect-src 'self'`) prevents key exfiltration via injected scripts. The fallback path (GitHub OAuth with admin role, noted as existing infrastructure) is the right escalation when the user base grows. This is an operator-only tool accessed from a trusted machine -- not a public-facing auth surface. Risk classification in the plan is accurate.
+
+**Rate limit at 30/60s** -- the entropy argument is correct. With ~256 bits in the admin key, brute-force is non-viable regardless of rate limit. 30/60s as a self-DoS floor is defensible; 5/60s would friction normal dashboard operation.
+
+---
+
+### Build vs. Wait
+
+Build now. The underlying capability (D1 queries, admin API, Cloudflare Workers) is fully adopted-ring infrastructure. No speculative dependencies. The operator is currently using manual D1 queries for visibility -- this replaces a real operational pain point with a proven pattern (same architecture as the existing tenant UI). Waiting has clear opportunity cost and no technology maturity benefit.
+
+---
+
+### Strategic Alignment
+
+The inline-everything, no-external-resources architecture is consistent with the Helix Manifesto principles (KISS, lean, no framework by default) and the project's technology preferences. The three-endpoint API surface maps cleanly to the operator's mental model (overview -> tenant list -> tenant detail). No new infrastructure or dependencies are introduced.
+
+One forward-looking note for the backlog: the plan correctly calls out sessionStorage -> GitHub OAuth as the upgrade path if the admin user base grows. That transition should be pre-planned against the existing OAuth infrastructure so it is not a scramble -- but it is not a blocker for this build.
+
+---
+
+No concerns within my domain. Proceed to execution.

--- a/docs/history/nefario-reports/2026-03-26-150501-admin-dashboard/phase3.5-lucy.md
+++ b/docs/history/nefario-reports/2026-03-26-150501-admin-dashboard/phase3.5-lucy.md
@@ -1,0 +1,91 @@
+# Lucy Review: Admin Dashboard Delegation Plan
+
+## Verdict: ADVISE
+
+The plan is well-aligned with user intent, follows CLAUDE.md conventions, and contains no significant drift. Two minor issues warrant adjustment before execution.
+
+---
+
+## Requirement Traceability
+
+| User Requirement | Plan Element | Status |
+|---|---|---|
+| Tenant list view | Task 1 (`listTenantsWithUsage`), Task 2 (`GET /v1/admin/tenants`), Task 3 (tenant table view) | COVERED |
+| Per-tenant usage (current + historical) | Task 1 (`getUsageHistory`, `getTenantDetail`), Task 2 (`GET /v1/admin/tenants/:id`), Task 3 (detail view) | COVERED |
+| Tier/plan info | Task 1 (tenant tier in queries), Task 3 (tier badge in UI) | COVERED |
+| Usage vs. limits | Task 2 (quota computed via `getEffectiveQuota`), Task 3 (progress bar in detail view) | COVERED |
+| Aggregate usage overview | Task 1 (`getOverviewStats`), Task 2 (`GET /v1/admin/overview`), Task 3 (stat cards) | COVERED |
+| Live from D1 (not cached) | Task 2 (`Cache-Control: private, no-store`), Task 3 (manual refresh, no caching) | COVERED |
+| Admin auth | Task 3 (admin key login via sessionStorage) | COVERED |
+| Loads in under 2s | Task 3 (inline-everything architecture) | COVERED |
+| Replace manual D1 queries | All tasks collectively | COVERED |
+| Out: profitability calculations | Not in plan | CORRECTLY EXCLUDED |
+| Out: billing management | Not in plan | CORRECTLY EXCLUDED |
+| Out: tenant self-service | Not in plan | CORRECTLY EXCLUDED |
+| Out: real-time streaming | Not in plan | CORRECTLY EXCLUDED |
+
+No orphaned requirements. No unaddressed requirements.
+
+---
+
+## Findings
+
+### 1. [CONVENTION] File naming inconsistency: `src/admin/` vs existing `src/ui/` prefix pattern
+
+**CHANGE**: Task 3 creates files in `src/admin/` with `admin-` prefixed names (`admin-shell.js`, `admin-auth.js`, `admin-css.js`, `admin-tenants.js`, `admin-detail.js`).
+
+**OBSERVATION**: The existing UI uses `src/ui/` with `ui-` prefixed names (`ui-shell.js`, `ui-auth.js`, `ui-css.js`, `ui-detail.js`). The plan correctly mirrors the directory separation pattern by creating `src/admin/`. The `admin-` prefix within `src/admin/` is consistent with the `ui-` prefix within `src/ui/` convention. No action needed -- noting for completeness that this is correctly modeled.
+
+**Severity**: None. Pattern is consistent.
+
+### 2. [SCOPE] Client-side sortable columns in Task 3
+
+**CHANGE**: Task 3 specifies sortable table columns with `aria-sort` attributes, sort toggle buttons in `<th>`, and an `aria-live` region for announcing sort changes.
+
+**WHY THIS IS BORDERLINE**: The user asked for a dashboard that replaces manual D1 queries. Sortable columns are a reasonable UX improvement for a table view, but the plan specifies a non-trivial interaction pattern (toggle buttons, ARIA live announcements, sort state management) that goes slightly beyond "show me the data." At current scale (tens of tenants), sorting a short list has marginal value.
+
+**RECOMMENDATION**: Acceptable to keep -- it is proportional complexity for a table view and follows accessibility best practices. But if it causes implementation difficulty, it can be dropped to a simple static sort without harm to the stated requirements.
+
+**Severity**: Minor. No action required.
+
+### 3. [COMPLIANCE] Evolution log creation not explicitly tasked
+
+**CHANGE**: The plan's "Documentation" cross-cutting note says "Phase 8 post-execution will assess documentation needs" and mentions evolution log files will be created "as part of the orchestration process per CLAUDE.md requirements."
+
+**WHY THIS MATTERS**: CLAUDE.md rule 1 states "Before starting a phase: create the directory and write `prompt.md` with the exact prompt or task description." This is a pre-execution obligation, not a post-execution documentation assessment. The plan defers this to Phase 8 instead of ensuring it happens before Task 1 begins. The calling orchestration session is responsible for creating the evolution log directory and `prompt.md` before delegating Task 1.
+
+**RECOMMENDATION**: The orchestration runner (nefario) must create the evolution log directory (e.g., `docs/evolution/NNNN-admin-dashboard/`) and write `prompt.md` before dispatching Task 1. This is not a task for a minion -- it is a nefario obligation per CLAUDE.md. Verify that nefario's own workflow handles this. If it does, this finding is informational. If it does not, flag as a gap.
+
+**Severity**: Medium. CLAUDE.md compliance issue if not handled by the orchestration framework.
+
+### 4. [CONVENTION] `periods` query param validation gap in Task 2
+
+**CHANGE**: Task 2 specifies the `GET /v1/admin/tenants/:id` endpoint accepts a `periods` query param with "default 6, max 24, validate as positive integer."
+
+**OBSERVATION**: The plan does not specify what happens if `periods` is 0, negative, or exceeds 24. The test spec (Task 4) includes "Invalid `periods` param returns 400" which implies validation exists, but the handler spec does not state the error response for out-of-range values vs. non-numeric values. The implementation agent should handle both cases.
+
+**RECOMMENDATION**: No plan change needed. The implementation agent will follow the existing `problemResponse(400, ...)` pattern. Noting so the approval gate reviewer checks this.
+
+**Severity**: Minor. Informational.
+
+---
+
+## CLAUDE.md Compliance Summary
+
+| Directive | Status |
+|---|---|
+| YAGNI | PASS -- no pagination, no auto-refresh, no dark mode, no frameworks. Explicit YAGNI callouts throughout. |
+| KISS | PASS -- three focused endpoints, each mapping to one DAL function. Inline-everything frontend. |
+| Lean and Mean | PASS -- no new dependencies. Vanilla JS. Estimated ~60-80 lines admin CSS. |
+| Fail loudly | PASS -- error handling specified with `.alert.alert--error` UI pattern and `problemResponse()` API pattern. |
+| Vanilla JS/CSS/HTML | PASS -- explicitly prohibited frameworks, build tools, external resources. |
+| Latency (<300ms) | PASS -- DAL uses batch queries and JOINs to minimize round-trips. |
+| Evolution log | ADVISE -- see Finding 3. Pre-execution obligation must be met by orchestration runner. |
+| Process documentation | NOTED -- `process.md` is post-PR, correctly deferred. |
+| Backlog update | NOTED -- correctly mentioned in cross-cutting "Documentation" section. |
+
+## Scope Assessment
+
+The plan contains four tasks. The user's request implies three functional areas (data layer, API, UI) plus testing. Four tasks map directly to these areas. No task inflation detected. No technology expansion beyond what the project already uses. No abstraction layers added. No adjacent features smuggled in.
+
+The plan is proportional to the problem.

--- a/docs/history/nefario-reports/2026-03-26-150501-admin-dashboard/phase3.5-margo.md
+++ b/docs/history/nefario-reports/2026-03-26-150501-admin-dashboard/phase3.5-margo.md
@@ -1,0 +1,43 @@
+## Margo Review: Admin Dashboard Delegation Plan
+
+**Verdict: APPROVE**
+
+This plan is well-disciplined. It builds exactly what the success criteria demand with minimal accidental complexity. The "What NOT to do" sections throughout demonstrate active YAGNI enforcement. Specific positives worth noting:
+
+- No pagination (correct at tens-of-tenants scale)
+- No auto-refresh/polling
+- No caching layer
+- No frameworks -- follows the existing inline-everything pattern
+- No new dependencies
+- No schema migrations
+- Auth validation reuses `GET /v1/admin/overview` instead of inventing a `/ping` endpoint
+- Formatting helpers are plain functions, not a utility library
+
+### Minor advisories (non-blocking)
+
+**1. `getUsageHistory` DAL function may be dead code (Task 1)**
+
+`listTenantsWithUsage` embeds current-period usage via JOIN. `getTenantDetail` includes usage history via `db.batch()`. Where is `getUsageHistory` called independently? It is not referenced in any handler prompt. If no handler calls it, it is dead code on arrival. The test task (Task 4) tests it in isolation, but that does not justify its existence.
+
+Recommendation: Drop `getUsageHistory` unless a handler needs it. If a future need arises, it is a three-line function to add later.
+
+**2. Five frontend files is proportional but watch the boundary (Task 3)**
+
+Five modules (`admin-shell.js`, `admin-auth.js`, `admin-css.js`, `admin-tenants.js`, `admin-detail.js`) mirrors the existing `src/ui/` pattern (14 files for a much larger UI surface). This is fine. The plan correctly keeps formatting helpers as plain functions inside the tenants module rather than extracting a shared utils file. Keep it that way.
+
+**3. Task count is proportional**
+
+Four tasks for three layers (DAL, API, frontend) plus tests. No inflation. The sequential execution order is justified by real data dependencies (API depends on DAL; frontend depends on API response shapes; tests depend on all three).
+
+### Complexity budget tally
+
+| Addition | Cost |
+|----------|------|
+| New file: `src/admin-dashboard.js` | 0 (same service, same runtime) |
+| New directory: `src/admin/` (5 files) | 0 (follows established pattern) |
+| New test files (2) | 0 (testing infrastructure) |
+| New dependency | 0 (none added) |
+| New abstraction layer | 0 (none added) |
+| **Total** | **0 budget spend** |
+
+This plan adds features to an existing service using established patterns. No new technologies, services, dependencies, or abstraction layers. The complexity cost is proportional to the problem.

--- a/docs/history/nefario-reports/2026-03-26-150501-admin-dashboard/phase3.5-security-minion.md
+++ b/docs/history/nefario-reports/2026-03-26-150501-admin-dashboard/phase3.5-security-minion.md
@@ -1,0 +1,39 @@
+ADVISE
+
+The plan is structurally sound. The core security controls -- parameterized queries, `textContent` for rendering, `ADMIN_CACHE` headers, hardcoded ORDER BY, `verifyAdminKey` gate on all `/v1/admin/*` routes, no CORS on admin endpoints, CSP on the HTML shell -- are all correct. The concerns below are real but none block execution.
+
+---
+
+- [security]: The `/admin` route is served unauthenticated with no rate limiting, enabling an attacker to enumerate the admin login page and hammer the credential-validation endpoint (`GET /v1/admin/overview`) from the browser.
+  SCOPE: `src/index.js` route registration; `src/admin/admin-auth.js` `adminFetch` helper
+  CHANGE: Add client-side rate limiting in `ADMIN_AUTH_JS`: after 3 consecutive 401 responses on the login form, disable the submit button for 30 seconds and display a lockout message. This is purely frontend (the server rate limit already exists at 30/60s for `/v1/admin/*`), but it closes the UX loop and makes brute-force obvious to the operator.
+  WHY: The admin key has high entropy so brute force is non-viable at scale, but without any client-side throttle the login form will silently hammer the validation endpoint until the server rate limit kicks in. An operator would have no feedback that something is wrong.
+  TASK: Task 3
+
+- [security]: `sessionStorage` is cleared on tab close but is readable by any same-origin JavaScript -- if the `/admin` CSP is ever loosened or a future XSS vector opens on the same origin, the admin key is trivially exfiltrated.
+  SCOPE: `src/admin/admin-auth.js` -- `sessionStorage.getItem('wrl_admin_key')`
+  CHANGE: The plan is acceptable for an internal operator tool, but document the deliberate tradeoff explicitly in a comment in `admin-auth.js`: "Admin key stored in sessionStorage (tab-scoped, cleared on close). This is intentional for a single-operator internal tool. Never deploy this pattern where the admin UI shares an origin with untrusted user-generated content." No code change required if this is acknowledged.
+  WHY: `sessionStorage` is the right call here (cookies would require CSRF handling, IndexedDB is overkill for a single-operator tool), but the choice should be intentional and documented rather than implicit.
+  TASK: Task 3
+
+- [security]: The detail view renders tenant `config` as formatted JSON in a `<pre><code>` block -- the plan says "formatted JSON in a `<pre>` with `<code>`" but does not explicitly specify whether this uses `textContent` or `JSON.stringify` assigned to `innerHTML`.
+  SCOPE: `src/admin/admin-detail.js` -- Tenant config section
+  CHANGE: The implementation instruction must be explicit: use `element.textContent = JSON.stringify(parsedConfig, null, 2)` -- not `element.innerHTML`. The "What NOT to do" in Task 3 already prohibits `innerHTML` with variable data, but `<pre>` blocks are commonly the exception where developers reach for `innerHTML`. Add an explicit note: "Config `<pre>` must use `textContent`, not `innerHTML`."
+  WHY: Tenant config values are operator-supplied strings (e.g., custom quota overrides). An attacker who controls a tenant could inject `<script>` tags via a malicious config field if `innerHTML` is used on the pre element.
+  TASK: Task 3
+
+- [security]: The `periods` query param on `GET /v1/admin/tenants/:id` is validated as "positive integer, max 24" but the plan does not specify what happens on non-integer or negative values -- whether the handler returns 400 or silently falls back to the default.
+  SCOPE: `src/admin-dashboard.js` -- `handleAdminGetTenant` param parsing
+  CHANGE: Specify the validation behavior explicitly in Task 2's prompt: "If `periods` is present but not a valid positive integer (1-24), return `problemResponse(400, 'Invalid periods parameter')`. Do not silently coerce." Fail loudly per the project's engineering philosophy.
+  WHY: Silent coercion masks client bugs and misconfigurations. The existing engineering philosophy mandates failing loudly.
+  TASK: Task 2
+
+- [security]: The `stripeCustomerId` field is included in the `GET /v1/admin/tenants/:id` response shape verbatim. Stripe customer IDs are not secret (they are not payment credentials), but they are PII-adjacent identifiers that identify the operator's billing relationship.
+  SCOPE: `src/admin-dashboard.js` -- `handleAdminGetTenant` response shape (line ~270 of synthesis)
+  CHANGE: This is acceptable for an admin-only endpoint (the operator already has full access to the Stripe dashboard). No change required. Flag for awareness: if the response shape is ever reused on a non-admin endpoint, `stripeCustomerId` must be stripped.
+  WHY: Informational only -- no action needed now.
+  TASK: Task 2
+
+---
+
+Summary: One concrete code addition recommended (client-side login throttle, Task 3), one explicit comment required (sessionStorage tradeoff, Task 3), one wording sharpening required (config pre textContent, Task 3), one validation behavior clarification required (periods param, Task 2). No blocking issues.

--- a/docs/history/nefario-reports/2026-03-26-150501-admin-dashboard/phase3.5-test-minion.md
+++ b/docs/history/nefario-reports/2026-03-26-150501-admin-dashboard/phase3.5-test-minion.md
@@ -1,0 +1,69 @@
+## Verdict: ADVISE
+
+The test plan is structurally sound — real D1, `SELF.fetch()`, per-test seeding, `cleanDb` in `beforeEach`, response shape assertions. No fundamental blocking issues. Four specific gaps worth fixing before implementation begins.
+
+---
+
+### Issue 1: IP counter collision risk (medium)
+
+The plan assigns `192.0.2.150` to the new test file. The existing landscape on `192.0.2.x`:
+
+- `admin-keys.test.js`: starts at 10, uses 31 IPs → reaches 41
+- `webhook-crud.test.js`: starts at 20, uses 12 IPs → reaches 32
+- `schedule-crud.test.js`: starts at 100, uses 8 IPs → reaches 108
+- `admin-usage.test.js`: starts at 100, uses 7 IPs → reaches 107
+- `admin-cache-purge.test.js`: starts at 200 → could reach 250+
+
+With 5 DAL describe blocks (each using a fresh IP per test) plus 3 API describe blocks with 8–10 tests each, the new file will consume 35–50 IPs, reaching `192.0.2.185–200` — directly into `admin-cache-purge`'s starting point. Collision risk is real.
+
+**Fix**: Start at 150 and cap explicitly at 190, OR use a different subnet prefix (e.g., `10.0.1.x` which no other admin file uses). The plan should specify the subnet, not just the counter value. Implementation agent must count IPs needed before committing to a range.
+
+---
+
+### Issue 2: `eidas_capture_count` not seedable via existing fixtures (medium)
+
+The `getOverviewStats` test plan includes "Aggregates eIDAS captures for current period" and the `listTenantsWithUsage` tests include multi-tenant scenarios where `eidasCaptureCount` should be assertable. However:
+
+- The existing `seedUsageCounter` helper has no `eidas_capture_count` parameter — it seeds the column as 0 always.
+- The new `seedTenantWithTier` helper seeds only the tenant row, not usage counters.
+
+Any assertion on non-zero `eidasCaptureCount` in DAL or API tests will silently pass with zeroed values unless `seedUsageCounter` is extended. The test plan omits this fixture modification.
+
+**Fix**: The Task 4 prompt should instruct the implementation agent to also update `seedUsageCounter` to accept an optional `eidasCaptureCount` parameter (default 0). Without this, eIDAS path coverage is false — the tests will pass but never exercise non-zero eIDAS values.
+
+---
+
+### Issue 3: `periods` boundary value missing from API test list (low)
+
+The plan specifies `periods` param defaults to 6 and caps at 24, with "invalid `periods` param returns 400". The test list covers `periods=25` returning 400, but does not include a test for exactly `periods=24` returning 200. Boundary-adjacent values are where off-by-one errors hide.
+
+**Fix**: Add one test: `periods=24` returns 200 with at most 24 history entries.
+
+---
+
+### Issue 4: `getTenantDetail` — missing test for `periodLimit` interaction with actual row count (low)
+
+The plan tests "Periods param caps history results" but the scenario isn't specified clearly: does it test with more rows than the limit (confirming truncation), or just assert the default? If the tenant only has 3 usage rows and `periodLimit=6`, the result will be 3 — which looks correct regardless of whether the LIMIT clause works. The test should seed more rows than the limit to confirm actual truncation.
+
+**Fix**: The "Periods param caps history results" test should explicitly seed N > limit rows and assert `result.usageHistory.length === limit`.
+
+---
+
+### Coverage assessment
+
+The test plan covers the right layers in the right proportions:
+- All four DAL functions tested with empty, single, and multi-entity cases
+- All three API endpoints tested for auth, shape, headers, and error paths
+- Security tests (tenant key rejection, no CORS headers) are present
+- UI tests are appropriately lightweight (HTML structure + security headers, no browser automation)
+
+The `Object.keys(body).sort()` response shape assertion pattern is correct — it catches field additions and removals that typed assertions miss. The `Cache-Control: private, no-store` header assertion on every endpoint is good hygiene.
+
+---
+
+### Summary of required changes to Task 4 prompt
+
+1. Specify subnet prefix for IP counter (recommend `10.0.1.x` starting at 150 to avoid all `192.0.2.x` overlap)
+2. Add `seedUsageCounter` modification to the fixtures task, extending it with `eidasCaptureCount` parameter
+3. Add `periods=24` boundary test to `GET /v1/admin/tenants/:id` test list
+4. Clarify that "Periods param caps history results" test must seed more rows than the cap value

--- a/docs/history/nefario-reports/2026-03-26-150501-admin-dashboard/phase3.5-ux-design-minion.md
+++ b/docs/history/nefario-reports/2026-03-26-150501-admin-dashboard/phase3.5-ux-design-minion.md
@@ -1,0 +1,49 @@
+## UX Design Review — Admin Dashboard
+
+**Verdict: ADVISE**
+
+The plan is structurally sound and the accessibility requirements are well-specified. The issues below are not blockers, but two of them will cause real friction in production and should be addressed before implementation begins.
+
+---
+
+### Issue 1: Table `.table` class is missing `aria-sort` support in the design system (advisory)
+
+The existing `.table` CSS in `design-system.css` has no styles for `[aria-sort]` on `th` elements or for `th button` sort affordances. The plan correctly specifies `<button>` inside `<th>` with `aria-sort`, but without corresponding visual styling the sort state will be invisible.
+
+The `admin-css.js` task includes `.admin-table th button` as a class to define, but the spec only says "inherits font, no border, pointer cursor." That is insufficient — sort direction must be visually indicated (ascending/descending arrow indicator). A button with no visible affordance that merely changes `aria-sort` communicates state only to screen readers, not sighted users.
+
+**Required addition to `admin-css.js` spec:** The `.admin-table th button[aria-sort]` style must include a visual sort indicator (e.g., `::after` pseudo-element with content "↑"/"↓", or a background-image SVG arrow). The active sorted column header also needs a visual distinction from non-sorted headers (e.g., `color: var(--color-primary)` on the active `th`).
+
+---
+
+### Issue 2: Stat cards lack visual hierarchy at the `.admin-stats-row` level (advisory)
+
+The four-column `.admin-stats-row` with `repeat(4, 1fr)` is correct for desktop. The plan says "mirrors the billing-stat pattern," which is a centered text, bold value, muted label pattern. That pattern works.
+
+However, the spec provides no minimum width or wrapping behavior for the grid. At viewport widths between 640–1000px (tablet and small laptop), four equal columns at 1100px max-width will produce very narrow stat cells — the bold numeric value may wrap or be truncated. The plan explicitly opts out of mobile-specific responsive design ("just ensure overflow-x: auto on tables"), but the stat cards are not a table and will not benefit from that.
+
+**Required addition to `admin-css.js` spec:** Add `grid-template-columns: repeat(auto-fit, minmax(200px, 1fr))` in place of `repeat(4, 1fr)`, or add a media query wrapping to 2×2 at medium widths. This prevents layout breakage without adding mobile-specific complexity.
+
+---
+
+### Issue 3: `.table` component missing focus state for row interactivity (minor advisory)
+
+The plan specifies `cursor: pointer` on `.admin-table tr` for clickable rows. However, the rows navigate to the detail view. If the implementation makes `<tr>` itself clickable (via `click` event on the row), that is a keyboard accessibility gap — `<tr>` is not a focusable or operable element.
+
+The plan also specifies the Tenant ID cell as an `<a href="#/tenants/${id}">` link. If the row click is additive (clicking anywhere in the row navigates), that is acceptable as a progressive enhancement — the link in the Tenant ID cell is the keyboard-reachable path. The `cursor: pointer` on `<tr>` is purely visual sugar.
+
+**Recommendation:** Confirm in the Task 3 prompt that `cursor: pointer` on `<tr>` is purely cosmetic and that all keyboard navigation goes through the `<a>` in the Tenant ID cell. No duplicate `tabindex` or `role="button"` should be added to `<tr>`. This is fine as planned but worth making explicit to avoid the frontend-minion reaching for a `role="row"` or `tabindex="0"` on `<tr>`.
+
+---
+
+### Confirmed correct
+
+- Semantic table structure (`<table>`, `<thead>`, `<tbody>`, `<th scope="col">`, `aria-label`) is fully specified and correct.
+- `aria-live="polite"` region for sort changes and refresh confirmation is present and appropriate.
+- Login form with proper `<label>` and no paste-disable is correct.
+- Focus management on view navigation (`tabIndex=-1` + `.focus()` on h1) is the right pattern.
+- Error alerts with `role="alert"` are specified.
+- `role="alert"` on error messages provides immediate announcement — correct for errors, not for routine state updates.
+- `<button>` inside `<th>` (not `<th onclick>`) is the correct ARIA pattern for sortable columns.
+- Design system tokens are used exclusively in `admin-css.js` — no hardcoded values.
+- The 44px minimum height on `.btn` in the existing design system already covers the submit button in the login form.

--- a/docs/history/nefario-reports/2026-03-26-150501-admin-dashboard/phase3.5-ux-strategy-minion.md
+++ b/docs/history/nefario-reports/2026-03-26-150501-admin-dashboard/phase3.5-ux-strategy-minion.md
@@ -1,0 +1,45 @@
+## UX Strategy Review: Admin Dashboard
+
+**Verdict: APPROVE**
+
+### Journey Coherence
+
+The three-level hierarchy (overview stats -> tenant table -> tenant detail) is coherent. The user has one job: replace manual D1 queries with structured operator visibility. The planned flow serves that job directly.
+
+The auth flow is appropriate. A single password field validated against a live endpoint (`/v1/admin/overview`) is the right pattern -- it confirms the key works rather than accepting it blindly, and the feedback path (200 = proceed, 401 = show error) is unambiguous.
+
+One gap worth noting: the plan specifies that on empty hash or `#/`, the router redirects to `#/tenants`. This means the tenant list is the landing view after auth. The stat cards on that view include an overview fetch in parallel, so the operator gets aggregate numbers plus the tenant table in one load. That is a sound decision -- no redundant overview-only page.
+
+### Cognitive Load
+
+The plan is conservative in ways that reduce cognitive load:
+
+- **Manual refresh only**: Correct. Auto-polling on an admin dashboard used by a single operator adds interruption cost and zero value. The refresh button is explicit and visible.
+- **Read-only**: Removing any write affordances eliminates error recovery burden entirely. An operator who cannot delete a tenant cannot accidentally delete one.
+- **Sorted by captures descending by default**: The most active tenants surface first, which is the highest-signal ordering for an operator checking usage health. This is a good satisficing default.
+- **eIDAS count hidden when zero**: Progressive disclosure applied correctly. A field that is zero for most tenants should not occupy permanent visual space.
+
+The four stat cards (Total Tenants, Active This Period, Total Captures, Total Storage) are appropriately few. This fits within working memory limits and avoids the dashboard anti-pattern of showing every available number.
+
+### Simplification
+
+The `config` section on the detail view (raw JSON in a `<pre>`) is a minor concern. Showing raw JSON passes cognitive parsing cost to the operator. However, since config structure is not defined in this scope and the operator is a developer who will understand JSON, this is acceptable. Resist the temptation to structure it further until there is evidence the operator needs to act on specific config fields.
+
+The usage history table on the detail view (period-over-period data) is justified. An operator checking whether a tenant's usage is growing or declining across months needs this. Twelve periods of history is appropriate -- it gives a full year without overwhelming the view.
+
+### User Jobs-to-be-Done
+
+Every planned surface maps to a real operator need:
+
+- Stat cards: "How is the platform performing this month?" -- answered without a click
+- Tenant table: "Which tenants are active / approaching limits?" -- answered by scanning
+- Tenant detail: "What is the full picture for this specific tenant?" -- answered by drilling down
+- Key section: "Does this tenant have active API keys?" -- answered on the detail view
+
+No features are planned that lack a corresponding operator job. The explicit exclusions (billing management, tenant create/delete, real-time streaming, profitability calculations) are all correct calls -- they are either out of scope for the operator's current needs or depend on data not yet available.
+
+### One Advisory Note
+
+The plan instructs the `handleAdminDashboard` handler (for `GET /admin`) to return the HTML shell without admin auth, matching the pattern from the existing `/ui` route. This is correct architecturally -- auth happens client-side. However, the plan notes this route is NOT rate-limited. For a sole-operator tool this is not a usability risk, but it is worth the team being aware the `/admin` URL is publicly fetchable HTML.
+
+This is not a UX concern -- it does not affect the operator's experience. Flag noted for the security review.

--- a/docs/history/nefario-reports/2026-03-26-150501-admin-dashboard/phase4-data-minion-prompt.md
+++ b/docs/history/nefario-reports/2026-03-26-150501-admin-dashboard/phase4-data-minion-prompt.md
@@ -1,0 +1,41 @@
+## Task: Add three admin dashboard DAL functions to src/db.js
+
+You are adding three new data access layer functions to the existing src/db.js module for an admin dashboard. These functions provide read-only aggregate views of tenant and usage data. No schema changes or migrations are needed -- all queries work against existing tables and indexes.
+
+### Context
+
+The existing DAL in src/db.js follows strict conventions:
+- All DB access is centralized in this module (no raw env.DB.prepare() elsewhere)
+- Functions use db.prepare(...).bind(...) for parameterized queries
+- Functions return plain JS objects with camelCase keys (transformed from snake_case DB columns)
+- db.batch() is used when multiple statements need to execute in a single round-trip
+- The computePeriod() function (already exported from db.js) returns the current YYYY-MM period string
+
+The relevant tables are:
+- tenants -- columns: id, tier, billing_status, grace_period_end, payment_method_added_at, stripe_customer_id, eidas_qualified, config, created_at, updated_at
+- usage_counters -- columns: tenant_id, period, capture_count, storage_bytes, api_call_count, eidas_capture_count, updated_at. Composite PK: (tenant_id, period)
+- api_keys -- columns: key_hash, tenant_id, scopes, name, created_at, created_by, revoked, revoked_at
+
+### Functions to add
+
+1. listTenantsWithUsage(db, period)
+2. getTenantDetail(db, tenantId, periodLimit = 6)
+3. getOverviewStats(db, period)
+
+See full synthesis plan for SQL queries and return shapes.
+
+### Implementation rules
+- Export all three functions
+- Follow the exact coding style of existing functions
+- Use COALESCE for LEFT JOINs
+- No new indexes needed
+- Do NOT add standalone getUsageHistory (YAGNI, embedded in getTenantDetail)
+
+### Files to modify
+- src/db.js
+
+### Success criteria
+- All three functions exported
+- Parameterized queries
+- camelCase return keys
+- db.batch() used where multiple statements needed

--- a/docs/history/nefario-reports/2026-03-26-150501-admin-dashboard/phase5-code-review-minion.md
+++ b/docs/history/nefario-reports/2026-03-26-150501-admin-dashboard/phase5-code-review-minion.md
@@ -1,0 +1,79 @@
+# Code Review: Admin Dashboard Feature
+
+Reviewed files: `src/admin-dashboard.js`, `src/admin/admin-shell.js`, `src/admin/admin-auth.js`, `src/admin/admin-tenants.js`, `src/admin/admin-detail.js`, `src/admin/admin-css.js`, `src/db.js` (new DAL), `src/index.js` (routes), `src/rate-limits.js`, `wrangler.toml`, `wrangler.test.toml`, `test/admin-dashboard.test.js`, `test/ui-admin.test.js`, `test/fixtures.js`
+
+---
+
+## VERDICT: ADVISE
+
+No hard blockers. Two semantic correctness issues (naming/label mismatch, missing field) that will mislead operators once in production. Safe to merge if those are addressed or explicitly accepted with a comment.
+
+---
+
+## FINDINGS
+
+### Correctness
+
+- **[ADVISE] src/db.js:2067-2089, src/admin/admin-tenants.js:155** -- `totalStorageBytes` in `getOverviewStats` is period-scoped (the SQL uses `SUM(CASE WHEN period = ? THEN storage_bytes ELSE 0 END)`), but the field name `totalStorageBytes` and the UI label "Total Storage" both imply an all-time aggregate. The analogous fields `totalCapturesCurrentPeriod` vs `totalCapturesAllTime` show the pattern was intentional for captures. Storage does not get the same treatment.
+
+  This will confuse operators: the stat card will show storage shrinking to near-zero at the start of each new billing period.
+
+  Two ways to fix this:
+  - Change the SQL to `SUM(storage_bytes) AS total_storage_all_time` and rename the field `totalStorageBytesAllTime`, matching the captures pattern. Update the UI label to "Total Storage (All Time)".
+  - Or keep the period-scoped behavior but rename the field `currentPeriodStorageBytes` and fix the UI label to "Storage This Period". No test exists that would catch the mismatch: the empty-DB test passes trivially (both approaches return 0).
+
+  FIX: Pick one semantics and make field name, JSDoc `@returns` comment, UI label, and test description consistent. The test at line 227 currently gives no signal on period-scoping because all values are zero.
+
+- **[ADVISE] src/admin/admin-detail.js:318, src/db.js:2021-2026** -- The API keys table in the detail view falls back to `k.keyHashPrefix` if `k.name` is falsy (line 318: `k.name || k.keyHashPrefix || '(unnamed)'`). But `getTenantDetail` does not return a `keyHashPrefix` field -- the key shape from the DAL is `{ keyHash, name, scopes, createdAt, createdBy }`. `keyHash` is the full 64-hex SHA-256 hash, not a prefix.
+
+  As written, `k.keyHashPrefix` is always `undefined`, so the fallback silently degrades to `'(unnamed)'` instead of showing any key identifier. For keys where `name` is null (old keys created before the name column existed), the operator has no way to identify which key they're looking at.
+
+  FIX: Either have `getTenantDetail` compute and return `keyHashPrefix` (first 8 chars of `key_hash` is the convention used elsewhere), or change the fallback to `k.keyHash ? k.keyHash.slice(0, 8) : '(unnamed)'`. The first option keeps formatting logic server-side.
+
+### Security
+
+- **[NIT] src/admin/admin-auth.js:48-73** -- The client-side login throttle (3 failed attempts -> 30s lockout) resets on page reload because `_adminConsecutive401s` lives in JS memory. This is intentional for a single-operator admin tool (noted in the file comment), and the server-side rate limiter (30 req/60s per IP in `wrangler.toml`) is the real abuse guard. No change required, but the comment at line 9 should be updated to explicitly mention that the server-side rate limiter is the primary brute-force protection, not this client-side counter.
+
+  FIX (optional): Add `// Note: the server-side ADMIN_RATE_LIMITER (30 req/60s) is the primary brute-force guard. This client-side counter improves UX only.`
+
+- **[NIT] src/admin/admin-detail.js:10** -- `document.title = tenantId + ' \u2014 WRL Admin'` assigns a tenant ID from the URL hash directly to `document.title`. `document.title` is not an XSS vector (it sets the tab title, not HTML content), and the tenant ID has already passed the route regex `[a-z0-9_-]{1,64}` before this code runs. No injection risk, but the comment pattern used elsewhere for DOM safety ("Safe: ...") is absent here. Low-priority.
+
+### Design / DRY
+
+- **[NIT] src/admin/admin-tenants.js:50-78, src/admin/admin-detail.js:17-23** -- The live region reconstruction block (create `div#admin-live`, set ARIA attributes, append to `view`) is duplicated verbatim in both `renderTenants` and `renderAdminDetail`. It was already defined once in `renderAdminShell` but gets wiped by `view.textContent = ''` when views re-render. Consider extracting to a shared `restoreAdminLiveRegion(view)` helper.
+
+  This is non-blocking since the inline JS is a string constant; the duplication is a template limitation. Worth addressing in a follow-up if the views grow.
+
+- **[NIT] src/admin/admin-auth.js:158-165, 27-31** -- The fetch+timeout race pattern is duplicated identically in `handleAdminLoginSubmit` (lines 158-165) and `adminFetch` (lines 27-31). The login submit path re-implements the race manually instead of calling `adminFetch`. This is intentional (login submit calls before the key is stored in sessionStorage), but a comment clarifying why it duplicates the pattern would prevent future refactoring confusion.
+
+### SQL Correctness
+
+- **[NIT] src/db.js:1984-1993** -- `getTenantDetail` uses `SELECT *` on the tenants table (line 1985). The other two queries in the batch are explicitly column-listed. `SELECT *` is fine for an internal admin-only tool reading a table the code controls, but it diverges from the DAL's convention of explicit column lists (e.g., `listTenantsWithUsage` names every column). Non-blocking, but worth noting for consistency.
+
+### Test Coverage
+
+- **[ADVISE] test/admin-dashboard.test.js** -- No test verifies the cross-period storage scoping behavior of `getOverviewStats`. Add a test that seeds storage counters in two different periods and asserts which period's value appears in `totalStorageBytes`. This would catch the naming/semantics issue described above and prevent regression regardless of which fix direction is chosen.
+
+  FIX: Add a test analogous to the "all-time captures includes all periods" test (line 276) but for storage, asserting the expected behavior explicitly.
+
+- **[NIT] test/admin-dashboard.test.js:386** -- The quota test (`capturesPerMonth: 200`) couples the test to a specific quota constant. If `FREE_CAPTURE_LIMIT` changes, the test breaks without an obvious connection. Consider importing `FREE_CAPTURE_LIMIT` from `quotas.js` and comparing against it rather than a magic number.
+
+### Route / Import Correctness
+
+All imports resolve correctly. Route ordering is correct: `/v1/admin/tenants/:id/config` patterns at lines 89-90 precede `/v1/admin/tenants/:id` at line 95, so the config routes shadow correctly. The `handleAdminDashboard` function at line 762 correctly delegates to `htmlAdminDashboard()` without auth (HTML shell is public; auth is client-side). The `isAdminRoute` check at line 537 correctly covers all three new API routes (`/v1/admin/tenants`, `/v1/admin/tenants/:id`, `/v1/admin/overview`) since all start with `/v1/admin/`.
+
+### Response Shape Consistency
+
+API-to-frontend field mapping is consistent on the happy path. `problemResponse` at line 134 correctly passes `ADMIN_CACHE` as the headers argument (matches the signature `problemResponse(status, detail, headers, extra)`).
+
+---
+
+## Summary
+
+| Severity | Count |
+|----------|-------|
+| BLOCK    | 0     |
+| ADVISE   | 3     |
+| NIT      | 5     |
+
+The two actionable ADVISEs (totalStorageBytes semantics, missing keyHashPrefix fallback) should be resolved before merge. The third ADVISE (missing storage scoping test) is a follow-up if the naming fix is made.

--- a/docs/history/nefario-reports/2026-03-26-150501-admin-dashboard/phase5-lucy.md
+++ b/docs/history/nefario-reports/2026-03-26-150501-admin-dashboard/phase5-lucy.md
@@ -1,0 +1,119 @@
+# Lucy -- Consistency & Alignment Review
+
+**Phase**: 0093 admin-dashboard
+**Scope reference**: `docs/evolution/0093-admin-dashboard/prompt.md`
+**Date**: 2026-03-26
+
+---
+
+## Original Requirements (verbatim from prompt.md)
+
+| # | Requirement | Source |
+|---|-------------|--------|
+| R1 | Dashboard shows list of all tenants | prompt.md: "Tenant list view" |
+| R2 | Per-tenant capture counts (current period and historical) | prompt.md: "per-tenant capture counts (current period and historical)" |
+| R3 | Tier/plan info per tenant | prompt.md: "tier/plan info" |
+| R4 | Usage vs. limits | prompt.md: "usage vs. limits" |
+| R5 | Data is live from D1 (not cached snapshots) | prompt.md: success criteria |
+| R6 | Protected by admin authentication | prompt.md: success criteria |
+| R7 | Loads in under 2 seconds | prompt.md: success criteria |
+| R8 | Aggregate usage overview | prompt.md: "aggregate usage overview" |
+
+**Explicit out-of-scope**: Tenant self-service portal, billing management, real-time streaming metrics, profitability calculations.
+
+---
+
+## Traceability Matrix
+
+| Requirement | Plan Element(s) | Status |
+|-------------|-----------------|--------|
+| R1 Tenant list | `GET /v1/admin/tenants` + `admin-tenants.js` list view | COVERED |
+| R2 Per-tenant capture counts | `listTenantsWithUsage` returns `captureCount`; detail view shows `usageHistory` with historical periods | COVERED |
+| R3 Tier/plan info | List view shows tier badge; detail shows tier, billingStatus, config | COVERED |
+| R4 Usage vs. limits | Detail view renders usage bar with quota from `getEffectiveQuota` | COVERED |
+| R5 Live D1 data | All three DAL functions query `env.DB` directly; `Cache-Control: private, no-store` on all responses | COVERED |
+| R6 Admin auth | Routes under `/v1/admin/*` gated by `verifyAdminKey` + `ADMIN_RATE_LIMITER` in `index.js`; client-side login gate validates key against `/v1/admin/overview` before showing shell | COVERED |
+| R7 <2s load time | `db.batch()` used for detail and overview (single round-trip); list is a single query with LEFT JOIN; no blocking waterfall in client JS (`Promise.all` for overview + tenants) | COVERED (design-level; runtime verification needed) |
+| R8 Aggregate overview | `GET /v1/admin/overview` with `getOverviewStats`; stat cards rendered in tenant list view | COVERED |
+
+**Orphaned plan elements** (not traceable to a stated requirement): None found.
+**Unaddressed requirements**: None found.
+
+---
+
+## CLAUDE.md Compliance
+
+### Vanilla JS (no frameworks) -- PASS
+
+All frontend code uses `document.createElement`, `textContent`, `addEventListener`. No React, no Vue, no jQuery, no Tailwind. Template literal strings exported as constants, inlined into the HTML shell. This matches the existing `src/ui/` pattern exactly.
+
+### YAGNI/KISS -- PASS
+
+The implementation delivers exactly what was requested: three API endpoints, three DAL functions, and a client-side SPA with two views (list + detail). No speculative features. The column sort and refresh button are minimal UX necessities, not scope creep. The `periods` query param on the detail endpoint (default 6, max 24) is proportional -- it serves R2 (historical counts) without building a full analytics engine.
+
+### Fail Loudly -- PASS (with one note)
+
+**Server-side**: No catch blocks. Errors propagate naturally to the worker's top-level error handler.
+
+**Client-side**: All `.catch(function() { ... })` blocks display user-visible error messages via alert elements with `role="alert"`. This matches the existing UI pattern in `src/ui/ui-schedules.js`, `ui-billing.js`, etc. The formatting helper catch blocks in `formatDate`/`formatNumber` degrade to showing the raw value -- a sensible handled degradation, not silent swallowing.
+
+### Lean and Mean -- PASS
+
+No new dependencies. Three new DAL functions added to `db.js` (the centralised data access layer). Frontend uses the existing design system CSS and reuses existing component classes (`badge`, `card`, `alert`, `btn`). The `admin/` directory mirrors the `ui/` directory structure.
+
+### Code Follows Existing Patterns -- PASS
+
+| Pattern | Existing (src/ui/) | New (src/admin/) | Match? |
+|---------|-------------------|------------------|--------|
+| Shell HTML generation | `ui-shell.js` exports `htmlDashboard()` | `admin-shell.js` exports `htmlAdminDashboard()` | Yes |
+| CSS as JS constant | `ui-css.js` exports `UI_CSS` | `admin-css.js` exports `ADMIN_CSS` | Yes |
+| View JS as string constants | `ui-login.js` exports `LOGIN_JS` | `admin-auth.js` exports `ADMIN_AUTH_JS` | Yes |
+| CSP headers | Same CSP policy (unsafe-inline for script/style, no external sources) | Yes |
+| Route registration | One-liner tuple in `routes` array | Yes |
+| Admin API handler signature | `(request, env, ctx)` or `(request, env, ctx, match)` | Yes |
+| DAL in db.js | All DB queries centralised in `db.js` with JSDoc | Yes |
+| Admin cache header | `const ADMIN_CACHE = { 'Cache-Control': 'private, no-store' }` in admin.js | Same pattern in admin-dashboard.js | Yes |
+| IP hashing for logs | `computeCip(env, clientIp)` before logging | Yes |
+| textContent (no innerHTML) | Used throughout UI | Used throughout admin, with explicit XSS prevention comment on config rendering | Yes |
+
+### Test Pattern -- PASS
+
+Test file follows existing conventions: imports from `fixtures.js`, uses `cleanDb` in `beforeEach`, unique IPs per describe block to avoid rate limit interference, tests both DAL functions directly and HTTP endpoints via `SELF.fetch()`. Covers auth rejection, 404, success, parameter validation, and security (tenant key rejected, no CORS headers).
+
+---
+
+## Scope Creep Check
+
+| Indicator | Assessment |
+|-----------|------------|
+| Task count inflation | 3 API endpoints, 3 DAL functions, 5 frontend files. Proportional to scope. |
+| Technology expansion | None. Same stack. |
+| Abstraction layers | No new abstractions. Reuses existing auth, logging, response helpers. |
+| Adjacent features | No billing management, no tenant editing, no profitability calcs. Out-of-scope items stayed out. |
+| Pre-optimization | `db.batch()` is a justified optimisation (single round-trip to D1), not premature. |
+| Dependency introduction | None. |
+
+---
+
+## Findings
+
+### F1 -- [CONVENTION] `keyHashPrefix` fallback in detail view may be dead code
+
+**File**: `src/admin/admin-detail.js`, line 318
+**What**: `nameTd.textContent = k.name || k.keyHashPrefix || '(unnamed)'`
+**Issue**: The `getTenantDetail` DAL function returns `keyHash` (the full hash) but not `keyHashPrefix`. If `k.name` is null, the fallback chain goes to `k.keyHashPrefix` (which is `undefined`) and then to `'(unnamed)'`. The `keyHashPrefix` reference is harmless (falls through to the next `||`) but misleading -- it suggests the API returns a field it does not.
+**Fix**: Either change to `k.name || '(unnamed)'` (since `keyHashPrefix` is never returned), or add a `keyHashPrefix: row.key_hash.slice(0, 8)` field to the DAL mapping in `getTenantDetail` so the display shows a truncated hash as a recognisable identifier.
+**Severity**: ADVISE -- cosmetic, no functional bug, but inconsistent with the actual API response shape.
+
+### F2 -- [CONVENTION] key_hash exposed in full on detail API response
+
+**File**: `src/db.js`, line 2021-2027 (`getTenantDetail` keys mapping)
+**What**: The keys array returned by `getTenantDetail` includes the full `keyHash` (64-character hex). The existing `admin.js` endpoint (`handleAdminListKeys`) also returns the full `keyHash`, so this is consistent with existing behaviour. However, the admin-dashboard.js detail handler at line 163 passes this full `keys` array to the JSON response unchanged.
+**Issue**: No actual violation -- the existing admin key list endpoint already exposes full hashes. Noting for awareness: the detail API exposes the same data. The admin.js security invariant comment says "Raw key is NEVER logged; only returned in the 201 response body" -- this is about the raw API key (the bearer token), not the hash. The hash is safe to expose.
+**Severity**: No action needed. Documenting for completeness.
+
+---
+
+## VERDICT: APPROVE
+
+The implementation is a clean, proportional delivery of the stated requirements. Every requirement traces to plan elements. No scope creep detected. Code follows established patterns faithfully -- same directory structure as `src/ui/`, same HTML shell approach, same DAL centralisation in `db.js`, same auth and rate limiting infrastructure. Tests are comprehensive. The one finding (F1) is a cosmetic inconsistency in a dead-code fallback path -- worth fixing but not blocking.

--- a/docs/history/nefario-reports/2026-03-26-150501-admin-dashboard/phase5-margo.md
+++ b/docs/history/nefario-reports/2026-03-26-150501-admin-dashboard/phase5-margo.md
@@ -1,0 +1,91 @@
+# Margo: Complexity Review -- Admin Dashboard
+
+**VERDICT: ADVISE**
+
+Two non-blocking concerns (one functional bug, one minor). The overall
+implementation is proportional to the problem and follows established project
+patterns well.
+
+---
+
+## What is right
+
+**Minimal complexity budget spend.** No new dependencies, no new frameworks,
+no new infrastructure. The admin UI follows the exact same vanilla-JS,
+inline-everything, no-external-resources pattern as the existing tenant
+dashboard (`src/ui/`). Five files vs. the tenant UI's fourteen -- proportional
+to the simpler scope.
+
+**DB functions are efficient.** `getTenantDetail` and `getOverviewStats` both
+use `db.batch()` for single-round-trip multi-query execution. The SQL is
+straightforward with no unnecessary JOINs or subquery chains.
+`listTenantsWithUsage` is a single query with a correlated subquery for
+key count, which is appropriate for the expected tenant cardinality (low
+hundreds at most).
+
+**No abstraction layers.** Handler functions call DB functions directly and
+return responses. No service layer, no repository pattern, no middleware chain.
+This is correct for the scale.
+
+**Tests are thorough without being bloated.** DAL tests validate the query
+logic directly against the DB. HTTP integration tests verify auth, response
+shape, caching headers, and security boundaries. The IP-rotation strategy
+for rate limit isolation is pragmatic.
+
+**Security posture is solid.** CSP with `default-src 'none'`, `frame-ancestors
+'none'`, `X-Frame-Options: DENY`, `no-store` caching, `textContent` only (no
+innerHTML), admin auth gate with client-side throttle after 3 failures.
+
+---
+
+## Findings
+
+### 1. FUNCTIONAL BUG: Frontend references wrong quota field name
+
+**File:** `src/admin/admin-detail.js`, lines 172, 174, 182
+
+**What:** The usage progress bar reads `quota.captures`, but the API returns
+`quota.capturesPerMonth` (from `getEffectiveQuota` in `src/quotas.js`). Since
+`quota.captures` is always `undefined`, the condition `quota.captures > 0` is
+always false and the usage bar never renders.
+
+**Evidence:** The test at `test/admin-dashboard.test.js:386` confirms the API
+field is `capturesPerMonth`:
+```js
+expect(tenant.quota.capturesPerMonth).toBe(200);
+```
+
+**Fix:** Change `quota.captures` to `quota.capturesPerMonth` in all three
+locations in `admin-detail.js`.
+
+**Complexity assessment:** N/A -- this is a correctness issue, not a complexity
+concern. Noting it because it was caught during the review pass and the fix is
+trivial. Handoff to the implementing minion.
+
+### 2. MINOR: Duplicated `ADMIN_CACHE` constant
+
+**Files:** `src/admin.js` line 28, `src/admin-dashboard.js` line 24
+
+**What:** Both files define `const ADMIN_CACHE = { 'Cache-Control': 'private, no-store' }`.
+
+**Assessment:** This is a one-line constant. Extracting it into a shared module
+would add a file and an import for negligible deduplication. The duplication is
+de minimis and not worth addressing unless the constant grows or a third
+consumer appears. **No action needed.**
+
+---
+
+## Complexity tally
+
+| Addition | Budget cost | Justification |
+|---|---|---|
+| 3 API handlers (`admin-dashboard.js`) | 0 | Functions in existing module pattern |
+| 3 DB functions (`db.js`) | 0 | Added to existing data access layer |
+| 5 UI files (`src/admin/`) | 1 (new abstraction: admin UI module) | Follows existing `src/ui/` pattern; scope-proportional |
+| 2 test files | 0 | Tests are not complexity -- they are validation |
+
+**Total budget spend: ~1 point (managed column).** Proportional to the problem.
+
+No new technologies, no new services, no new dependencies, no unnecessary
+abstraction layers. The implementation is the minimum viable admin dashboard
+and nothing more.

--- a/docs/history/nefario-reports/2026-03-26-150501-admin-dashboard/prompt.md
+++ b/docs/history/nefario-reports/2026-03-26-150501-admin-dashboard/prompt.md
@@ -1,0 +1,11 @@
+**Outcome**: An admin dashboard exists where the operator can see tenant overviews, per-tenant usage, tier consumption, and basic profitability signals — replacing manual D1 queries for operational awareness.
+
+**Success criteria**:
+- Dashboard shows: list of all tenants, per-tenant capture counts (current period and historical), tier/plan info, usage vs. limits
+- Data is live from D1 (not cached snapshots)
+- Protected by admin authentication
+- Loads in under 2 seconds
+
+**Scope**:
+- In: Tenant list view, usage summary per tenant, aggregate usage overview
+- Out: Tenant self-service portal, billing management, real-time streaming metrics, profitability calculations (requires cost data not yet available)

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -25,7 +25,7 @@ tags:
   - name: signing
     description: Signing key management
   - name: admin
-    description: API key management (admin-only)
+    description: Administration endpoints (key management, tenant overview, usage statistics)
   - name: webhooks
     description: Outbound webhook registration and management
   - name: account
@@ -3670,7 +3670,7 @@ paths:
         Creates a new per-tenant API key and returns the raw key exactly once.
         Store the returned key immediately -- it cannot be retrieved after this response.
 
-        Rate limited to 5 requests per 60 seconds per IP. Auth check happens after rate limit.
+        Rate limited to 30 requests per 60 seconds per IP. Auth check happens after rate limit.
 
         ```bash
         curl -X POST https://api.webresourceledger.com/v1/admin/keys \
@@ -3855,7 +3855,7 @@ paths:
         Returns all API keys, optionally filtered by tenant. Revoked keys are
         excluded by default. Raw key values are never included.
 
-        Rate limited to 5 requests per 60 seconds per IP.
+        Rate limited to 30 requests per 60 seconds per IP.
 
         ```bash
         curl https://api.webresourceledger.com/v1/admin/keys \
@@ -4021,7 +4021,7 @@ paths:
         This operation is idempotent -- revoking an already-revoked key returns 200
         with the existing revocation record.
 
-        Rate limited to 5 requests per 60 seconds per IP.
+        Rate limited to 30 requests per 60 seconds per IP.
 
         ```bash
         curl -X DELETE "https://api.webresourceledger.com/v1/admin/keys/$KEY_HASH" \
@@ -4440,7 +4440,7 @@ paths:
         Returns per-tenant usage counters for the specified billing period.
         Defaults to the current calendar month (UTC) if no period is specified.
 
-        Rate limited to 5 requests per 60 seconds per IP. Auth check happens after rate limit.
+        Rate limited to 30 requests per 60 seconds per IP. Auth check happens after rate limit.
 
         ```bash
         # Current period usage
@@ -4533,7 +4533,7 @@ paths:
         Requires `CLOUDFLARE_ZONE_ID` and `CLOUDFLARE_CACHE_PURGE_TOKEN` environment
         variables to be configured. Returns 503 if not configured.
 
-        Rate limited to 5 requests per 60 seconds per IP. Auth check happens after rate limit.
+        Rate limited to 30 requests per 60 seconds per IP. Auth check happens after rate limit.
 
         ```bash
         # Purge signing key cache (e.g., after key rotation)
@@ -4636,6 +4636,329 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/ProblemDetail'
+
+  /v1/admin/tenants:
+    get:
+      operationId: adminListTenants
+      summary: List all tenants with usage
+      description: >
+        Returns a list of all tenants with their current-period usage counters,
+        quota information, and active key count. Designed for the admin dashboard
+        tenant overview.
+
+        Rate limited to 30 requests per 60 seconds per IP.
+
+        ```bash
+        curl "https://api.webresourceledger.com/v1/admin/tenants" \
+          -H "Authorization: Bearer $ADMIN_KEY" | jq .
+
+        # Specific billing period
+        curl "https://api.webresourceledger.com/v1/admin/tenants?period=2026-02" \
+          -H "Authorization: Bearer $ADMIN_KEY" | jq .
+        ```
+      tags: [admin]
+      security:
+        - adminAuth: []
+      parameters:
+        - name: period
+          in: query
+          required: false
+          description: >
+            Billing period in YYYY-MM format. Defaults to the current calendar
+            month (UTC) if omitted.
+          schema:
+            type: string
+            pattern: '^\d{4}-\d{2}$'
+            example: '2026-03'
+      responses:
+        '200':
+          description: Tenant list with usage data.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [data, meta]
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      required: [tenantId, tier, billingStatus, hasPaymentMethod, currentPeriod, quota, keyCount]
+                      properties:
+                        tenantId:
+                          type: string
+                          example: default
+                        tier:
+                          type: string
+                          enum: [free, pro]
+                        billingStatus:
+                          type: string
+                          enum: [active, grace_period, blocked]
+                        hasPaymentMethod:
+                          type: boolean
+                        eidasQualified:
+                          type: boolean
+                        createdAt:
+                          type: string
+                          format: date-time
+                        currentPeriod:
+                          type: object
+                          properties:
+                            period:
+                              type: string
+                              example: '2026-03'
+                            captureCount:
+                              type: integer
+                            eidasCaptureCount:
+                              type: integer
+                            storageBytes:
+                              type: integer
+                            apiCallCount:
+                              type: integer
+                        quota:
+                          type: object
+                          properties:
+                            capturesPerMonth:
+                              type: ['integer', 'null']
+                              description: >
+                                Maximum captures per month. Null means unlimited
+                                (paying tenant with no admin override).
+                            storageBytes:
+                              type: ['integer', 'null']
+                              description: >
+                                Maximum storage in bytes. Null means unlimited.
+                        keyCount:
+                          type: integer
+                          description: Number of active (non-revoked) API keys.
+                  meta:
+                    type: object
+                    properties:
+                      totalTenants:
+                        type: integer
+                      period:
+                        type: string
+        '400':
+          $ref: '#/components/responses/Problem400'
+        '401':
+          $ref: '#/components/responses/Problem401'
+        '429':
+          $ref: '#/components/responses/Problem429'
+
+  /v1/admin/tenants/{tenantId}:
+    get:
+      operationId: adminGetTenant
+      summary: Get tenant detail
+      description: >
+        Returns detailed information for a single tenant including billing state,
+        usage history across multiple periods, active API keys, and configuration.
+
+        Rate limited to 30 requests per 60 seconds per IP.
+
+        ```bash
+        curl "https://api.webresourceledger.com/v1/admin/tenants/default" \
+          -H "Authorization: Bearer $ADMIN_KEY" | jq .
+
+        # More history (up to 24 periods)
+        curl "https://api.webresourceledger.com/v1/admin/tenants/default?periods=12" \
+          -H "Authorization: Bearer $ADMIN_KEY" | jq .
+        ```
+      tags: [admin]
+      security:
+        - adminAuth: []
+      parameters:
+        - name: tenantId
+          in: path
+          required: true
+          description: Tenant ID.
+          schema:
+            type: string
+            pattern: '^[a-z0-9_-]{1,64}$'
+            example: default
+        - name: periods
+          in: query
+          required: false
+          description: >
+            Number of billing periods of history to return.
+            Positive integer, default 6, maximum 24.
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 24
+            default: 6
+      responses:
+        '200':
+          description: Tenant detail with usage history and keys.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [tenantId, tier, billingStatus, hasPaymentMethod, quota, keys, usageHistory]
+                properties:
+                  tenantId:
+                    type: string
+                  tier:
+                    type: string
+                    enum: [free, pro]
+                  billingStatus:
+                    type: string
+                    enum: [active, grace_period, blocked]
+                  gracePeriodEnd:
+                    type: ['string', 'null']
+                    format: date-time
+                  hasPaymentMethod:
+                    type: boolean
+                  paymentMethodAddedAt:
+                    type: ['string', 'null']
+                    format: date-time
+                  stripeCustomerId:
+                    type: ['string', 'null']
+                  eidasQualified:
+                    type: boolean
+                  config:
+                    type: object
+                    description: Tenant configuration overrides (admin-set).
+                  createdAt:
+                    type: string
+                    format: date-time
+                  updatedAt:
+                    type: string
+                    format: date-time
+                  quota:
+                    type: object
+                    properties:
+                      capturesPerMonth:
+                        type: ['integer', 'null']
+                      storageBytes:
+                        type: ['integer', 'null']
+                  keys:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        keyHash:
+                          type: string
+                          description: SHA-256 hex hash of the API key.
+                        name:
+                          type: ['string', 'null']
+                        scopes:
+                          type: array
+                          items:
+                            type: string
+                        createdAt:
+                          type: string
+                          format: date-time
+                        createdBy:
+                          type: ['string', 'null']
+                  usageHistory:
+                    type: array
+                    description: Usage counters per billing period, most recent first.
+                    items:
+                      type: object
+                      properties:
+                        period:
+                          type: string
+                          example: '2026-03'
+                        captureCount:
+                          type: integer
+                        storageBytes:
+                          type: integer
+                        apiCallCount:
+                          type: integer
+                        eidasCaptureCount:
+                          type: integer
+        '400':
+          $ref: '#/components/responses/Problem400'
+        '401':
+          $ref: '#/components/responses/Problem401'
+        '404':
+          description: Tenant not found.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+              example:
+                type: about:blank
+                status: 404
+                title: Not Found
+                detail: "Tenant 'nonexistent' not found"
+        '429':
+          $ref: '#/components/responses/Problem429'
+
+  /v1/admin/overview:
+    get:
+      operationId: adminGetOverview
+      summary: Get platform overview statistics
+      description: >
+        Returns platform-wide aggregate statistics: tenant counts by tier and
+        billing status, total captures (current period and all-time), storage,
+        and active API key count. Designed for the admin dashboard overview cards.
+
+        Rate limited to 30 requests per 60 seconds per IP.
+
+        ```bash
+        curl "https://api.webresourceledger.com/v1/admin/overview" \
+          -H "Authorization: Bearer $ADMIN_KEY" | jq .
+        ```
+      tags: [admin]
+      security:
+        - adminAuth: []
+      parameters:
+        - name: period
+          in: query
+          required: false
+          description: >
+            Billing period in YYYY-MM format. Defaults to the current calendar
+            month (UTC) if omitted.
+          schema:
+            type: string
+            pattern: '^\d{4}-\d{2}$'
+            example: '2026-03'
+      responses:
+        '200':
+          description: Platform-wide aggregate statistics.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [totalTenants, totalCapturesCurrentPeriod, totalCapturesAllTime, currentPeriodStorageBytes, tenantsByTier, tenantsByBillingStatus, activeApiKeys, period]
+                properties:
+                  totalTenants:
+                    type: integer
+                  totalCapturesCurrentPeriod:
+                    type: integer
+                  totalCapturesAllTime:
+                    type: integer
+                  currentPeriodStorageBytes:
+                    type: integer
+                  totalEidasCaptures:
+                    type: integer
+                  tenantsByTier:
+                    type: object
+                    properties:
+                      free:
+                        type: integer
+                      pro:
+                        type: integer
+                  tenantsByBillingStatus:
+                    type: object
+                    properties:
+                      active:
+                        type: integer
+                      gracePeriod:
+                        type: integer
+                      blocked:
+                        type: integer
+                  activeApiKeys:
+                    type: integer
+                  period:
+                    type: string
+                    example: '2026-03'
+        '400':
+          $ref: '#/components/responses/Problem400'
+        '401':
+          $ref: '#/components/responses/Problem401'
+        '429':
+          $ref: '#/components/responses/Problem429'
 
   /v1/account/usage:
     get:

--- a/src/admin-dashboard.js
+++ b/src/admin-dashboard.js
@@ -1,0 +1,212 @@
+/*
+ * admin-dashboard.js -- Admin API handlers for operator dashboard views
+ *
+ * Endpoints:
+ *   GET /v1/admin/tenants          -- list all tenants with current-period usage
+ *   GET /v1/admin/tenants/:id      -- detail view for a single tenant
+ *   GET /v1/admin/overview         -- platform-wide aggregate statistics
+ *
+ * Auth: all routes use verifyAdminKey (infrastructure secret), NOT verifyApiKey.
+ * Rate limit: ADMIN_RATE_LIMITER, 30 req/60s per IP.
+ *
+ * Security invariants:
+ *   - Raw config JSON is NOT returned on the list endpoint; only on tenant detail.
+ *   - payment_method_added_at timestamp is mapped to hasPaymentMethod boolean on list.
+ *   - All responses set Cache-Control: private, no-store.
+ */ // tva
+
+import { jsonResponse, problemResponse } from './responses.js';
+import { listTenantsWithUsage, getTenantDetail, getOverviewStats, computePeriod } from './db.js';
+import { getEffectiveQuota } from './quotas.js';
+import { log } from './log.js';
+import { computeCip } from './ip-hash.js';
+
+const ADMIN_CACHE = { 'Cache-Control': 'private, no-store' };
+const PERIOD_RE = /^\d{4}-\d{2}$/;
+
+/**
+ * GET /v1/admin/tenants -- list all tenants with usage for a billing period
+ *
+ * Query params:
+ *   period (optional) -- billing period in YYYY-MM format (defaults to current)
+ */
+export async function handleAdminListTenants(request, env, ctx) {
+  const clientIp = request.headers.get('CF-Connecting-IP') || 'unknown';
+  const cip = await computeCip(env, clientIp);
+
+  const params = new URL(request.url).searchParams;
+  const periodParam = params.get('period');
+
+  let period;
+  if (periodParam !== null) {
+    if (!PERIOD_RE.test(periodParam)) {
+      return problemResponse(400, "Query parameter 'period' must be in YYYY-MM format");
+    }
+    period = periodParam;
+  } else {
+    period = computePeriod();
+  }
+
+  const rows = await listTenantsWithUsage(env.DB, period);
+
+  const data = rows.map(row => {
+    const hasPaymentMethod = row.paymentMethodAddedAt !== null;
+    const parsedConfig = row.config ? JSON.parse(row.config) : null;
+    const quota = getEffectiveQuota(hasPaymentMethod, parsedConfig);
+
+    return {
+      tenantId: row.id,
+      tier: row.tier,
+      billingStatus: row.billingStatus,
+      hasPaymentMethod,
+      eidasQualified: row.eidasQualified,
+      createdAt: row.createdAt,
+      currentPeriod: {
+        period,
+        captureCount: row.captureCount,
+        eidasCaptureCount: row.eidasCaptureCount,
+        storageBytes: row.storageBytes,
+        apiCallCount: row.apiCallCount,
+      },
+      quota,
+      keyCount: row.keyCount,
+    };
+  });
+
+  ctx.waitUntil(log(env, 3, 'admin', {
+    event: 'admin.list_tenants',
+    count: data.length,
+    period,
+    authMethod: 'admin_key',
+    responseStatus: 200,
+    cip,
+  }) ?? Promise.resolve());
+
+  return jsonResponse({
+    data,
+    meta: {
+      totalTenants: data.length,
+      period,
+    },
+  }, 200, ADMIN_CACHE);
+}
+
+/**
+ * GET /v1/admin/tenants/:id -- detail view for a single tenant
+ *
+ * Route match: match[1] is the tenant ID captured by the route regex.
+ *
+ * Query params:
+ *   periods (optional) -- number of billing periods of history to return
+ *                         (positive integer, default 6, max 24)
+ */
+export async function handleAdminGetTenant(request, env, ctx, match) {
+  const clientIp = request.headers.get('CF-Connecting-IP') || 'unknown';
+  const cip = await computeCip(env, clientIp);
+
+  const tenantId = match[1];
+
+  const params = new URL(request.url).searchParams;
+  const periodsParam = params.get('periods');
+
+  let periods;
+  if (periodsParam !== null) {
+    const parsed = Number(periodsParam);
+    if (!Number.isInteger(parsed) || parsed < 1 || parsed > 24) {
+      return problemResponse(400, "Query parameter 'periods' must be a positive integer between 1 and 24");
+    }
+    periods = parsed;
+  } else {
+    periods = 6;
+  }
+
+  const detail = await getTenantDetail(env.DB, tenantId, periods);
+
+  if (detail === null) {
+    ctx.waitUntil(log(env, 4, 'admin', {
+      event: 'admin.get_tenant_fail',
+      tenantId,
+      reason: 'not_found',
+      authMethod: 'admin_key',
+      responseStatus: 404,
+      cip,
+    }) ?? Promise.resolve());
+    return problemResponse(404, `Tenant '${tenantId}' not found`, ADMIN_CACHE);
+  }
+
+  const { tenant, usageHistory, keys } = detail;
+  const hasPaymentMethod = tenant.paymentMethodAddedAt !== null;
+  const parsedConfig = tenant.config ? JSON.parse(tenant.config) : null;
+  const quota = getEffectiveQuota(hasPaymentMethod, parsedConfig);
+
+  ctx.waitUntil(log(env, 3, 'admin', {
+    event: 'admin.get_tenant',
+    tenantId,
+    authMethod: 'admin_key',
+    responseStatus: 200,
+    cip,
+  }) ?? Promise.resolve());
+
+  return jsonResponse({
+    tenantId: tenant.id,
+    tier: tenant.tier,
+    billingStatus: tenant.billingStatus,
+    gracePeriodEnd: tenant.gracePeriodEnd,
+    hasPaymentMethod,
+    paymentMethodAddedAt: tenant.paymentMethodAddedAt,
+    stripeCustomerId: tenant.stripeCustomerId,
+    eidasQualified: tenant.eidasQualified,
+    config: parsedConfig ?? {},
+    createdAt: tenant.createdAt,
+    updatedAt: tenant.updatedAt,
+    quota,
+    keys,
+    usageHistory,
+  }, 200, ADMIN_CACHE);
+}
+
+/**
+ * GET /v1/admin/overview -- platform-wide aggregate statistics for a billing period
+ *
+ * Query params:
+ *   period (optional) -- billing period in YYYY-MM format (defaults to current)
+ */
+export async function handleAdminGetOverview(request, env, ctx) {
+  const clientIp = request.headers.get('CF-Connecting-IP') || 'unknown';
+  const cip = await computeCip(env, clientIp);
+
+  const params = new URL(request.url).searchParams;
+  const periodParam = params.get('period');
+
+  let period;
+  if (periodParam !== null) {
+    if (!PERIOD_RE.test(periodParam)) {
+      return problemResponse(400, "Query parameter 'period' must be in YYYY-MM format");
+    }
+    period = periodParam;
+  } else {
+    period = computePeriod();
+  }
+
+  const stats = await getOverviewStats(env.DB, period);
+
+  ctx.waitUntil(log(env, 3, 'admin', {
+    event: 'admin.get_overview',
+    period,
+    authMethod: 'admin_key',
+    responseStatus: 200,
+    cip,
+  }) ?? Promise.resolve());
+
+  return jsonResponse({
+    totalTenants: stats.totalTenants,
+    totalCapturesCurrentPeriod: stats.totalCapturesCurrentPeriod,
+    totalCapturesAllTime: stats.totalCapturesAllTime,
+    totalStorageBytes: stats.totalStorageBytes,
+    totalEidasCaptures: stats.totalEidasCaptures,
+    tenantsByTier: stats.tenantsByTier,
+    tenantsByBillingStatus: stats.tenantsByBillingStatus,
+    activeApiKeys: stats.activeApiKeys,
+    period,
+  }, 200, ADMIN_CACHE);
+}

--- a/src/admin-dashboard.js
+++ b/src/admin-dashboard.js
@@ -202,7 +202,7 @@ export async function handleAdminGetOverview(request, env, ctx) {
     totalTenants: stats.totalTenants,
     totalCapturesCurrentPeriod: stats.totalCapturesCurrentPeriod,
     totalCapturesAllTime: stats.totalCapturesAllTime,
-    totalStorageBytes: stats.totalStorageBytes,
+    currentPeriodStorageBytes: stats.currentPeriodStorageBytes,
     totalEidasCaptures: stats.totalEidasCaptures,
     tenantsByTier: stats.tenantsByTier,
     tenantsByBillingStatus: stats.tenantsByBillingStatus,

--- a/src/admin.js
+++ b/src/admin.js
@@ -7,7 +7,7 @@
  *   DELETE /v1/admin/keys/:keyHash -- revoke API key
  *
  * Auth: all routes use verifyAdminKey (infrastructure secret), NOT verifyApiKey.
- * Rate limit: ADMIN_RATE_LIMITER, 5 req/60s per IP.
+ * Rate limit: ADMIN_RATE_LIMITER, 30 req/60s per IP.
  *
  * Security invariants:
  *   - Raw key is NEVER logged; only returned in the 201 response body.

--- a/src/admin/admin-auth.js
+++ b/src/admin/admin-auth.js
@@ -1,0 +1,292 @@
+// Admin dashboard auth gate and fetch wrapper.
+// Exports a JS string constant for inline use in the admin HTML shell.
+
+export const ADMIN_AUTH_JS = `
+// ---------------------------------------------------------------------------
+// Admin auth constants
+// ---------------------------------------------------------------------------
+
+// sessionStorage chosen for single-operator admin tool -- tab-scoped, clears on close.
+// If admin UI ever shares an origin with user content, reassess.
+var ADMIN_KEY_STORAGE = 'wrl_admin_key';
+var ADMIN_FETCH_TIMEOUT_MS = 15000;
+
+// ---------------------------------------------------------------------------
+// adminFetch: wraps fetch() with Authorization header from sessionStorage.
+// On 401, clears sessionStorage and reloads (session expired or key changed).
+// ---------------------------------------------------------------------------
+
+function adminFetch(path, options) {
+  var key = sessionStorage.getItem(ADMIN_KEY_STORAGE);
+  var opts = Object.assign({}, options);
+  opts.headers = Object.assign({}, opts.headers);
+  if (key) {
+    opts.headers['Authorization'] = 'Bearer ' + key;
+  }
+
+  var fetchPromise = fetch(path, opts);
+  var timeoutPromise = new Promise(function(_, reject) {
+    setTimeout(function() {
+      reject(new TypeError('fetch_timeout'));
+    }, ADMIN_FETCH_TIMEOUT_MS);
+  });
+
+  return Promise.race([fetchPromise, timeoutPromise]).then(function(res) {
+    if (res.status === 401) {
+      sessionStorage.removeItem(ADMIN_KEY_STORAGE);
+      location.reload();
+      return res;
+    }
+    return res;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Login throttle state
+// ---------------------------------------------------------------------------
+
+var _adminConsecutive401s = 0;
+var _adminThrottleUntil = 0;
+var _adminCountdownTimer = null;
+
+function isAdminThrottled() {
+  return Date.now() < _adminThrottleUntil;
+}
+
+function startAdminThrottle(btn, errorEl) {
+  _adminThrottleUntil = Date.now() + 30000;
+  btn.disabled = true;
+
+  function tick() {
+    var remaining = Math.ceil((_adminThrottleUntil - Date.now()) / 1000);
+    if (remaining <= 0) {
+      btn.disabled = false;
+      btn.textContent = 'Sign in';
+      errorEl.textContent = 'Too many failed attempts. Try again.';
+      return;
+    }
+    btn.textContent = 'Try again in ' + remaining + 's';
+    _adminCountdownTimer = setTimeout(tick, 1000);
+  }
+
+  tick();
+}
+
+// ---------------------------------------------------------------------------
+// Login form rendering
+// ---------------------------------------------------------------------------
+
+function renderAdminLogin() {
+  var app = document.getElementById('admin-app');
+  // Safe: clearing mount point only
+  app.textContent = '';
+
+  var gate = document.createElement('div');
+  gate.className = 'auth-gate';
+
+  var card = document.createElement('div');
+  card.className = 'auth-card card';
+
+  var wordmark = document.createElement('div');
+  wordmark.className = 'auth-wordmark';
+  wordmark.textContent = 'WRL Admin';
+  card.appendChild(wordmark);
+
+  var tagline = document.createElement('p');
+  tagline.className = 'auth-tagline';
+  tagline.textContent = 'Enter your admin key to continue.';
+  card.appendChild(tagline);
+
+  var form = document.createElement('form');
+  form.id = 'admin-login-form';
+
+  var label = document.createElement('label');
+  label.setAttribute('for', 'admin-key-input');
+  label.className = 'sr-only';
+  label.textContent = 'Admin key';
+  form.appendChild(label);
+
+  var input = document.createElement('input');
+  input.type = 'password';
+  input.id = 'admin-key-input';
+  input.className = 'input';
+  input.placeholder = 'Admin key';
+  input.autocomplete = 'off';
+  // Do NOT disable paste -- paste-friendly for long keys
+  form.appendChild(input);
+
+  var errorEl = document.createElement('div');
+  errorEl.id = 'admin-login-error';
+  errorEl.className = 'alert alert--error';
+  errorEl.setAttribute('role', 'alert');
+  errorEl.style.display = 'none';
+  form.appendChild(errorEl);
+
+  var btn = document.createElement('button');
+  btn.type = 'submit';
+  btn.className = 'btn btn--primary';
+  btn.textContent = 'Sign in';
+  form.appendChild(btn);
+
+  form.addEventListener('submit', function(e) {
+    e.preventDefault();
+    handleAdminLoginSubmit(input, btn, errorEl);
+  });
+
+  card.appendChild(form);
+  gate.appendChild(card);
+  app.appendChild(gate);
+
+  input.focus();
+}
+
+function handleAdminLoginSubmit(input, btn, errorEl) {
+  if (isAdminThrottled()) return;
+
+  var key = input.value.trim();
+  if (!key) {
+    errorEl.textContent = 'Admin key is required.';
+    errorEl.style.display = '';
+    errorEl.focus();
+    return;
+  }
+
+  errorEl.style.display = 'none';
+  btn.disabled = true;
+  btn.textContent = 'Verifying...';
+
+  var fetchPromise = fetch('/v1/admin/overview', {
+    headers: { 'Authorization': 'Bearer ' + key }
+  });
+  var timeoutPromise = new Promise(function(_, reject) {
+    setTimeout(function() {
+      reject(new TypeError('fetch_timeout'));
+    }, ADMIN_FETCH_TIMEOUT_MS);
+  });
+
+  Promise.race([fetchPromise, timeoutPromise]).then(function(res) {
+    if (res.ok) {
+      _adminConsecutive401s = 0;
+      sessionStorage.setItem(ADMIN_KEY_STORAGE, key);
+      renderAdminShell();
+      adminRoute();
+    } else if (res.status === 401 || res.status === 403) {
+      _adminConsecutive401s++;
+      input.value = '';
+      if (_adminConsecutive401s >= 3) {
+        errorEl.textContent = 'Invalid key.';
+        errorEl.style.display = '';
+        startAdminThrottle(btn, errorEl);
+      } else {
+        btn.disabled = false;
+        btn.textContent = 'Sign in';
+        errorEl.textContent = 'Invalid admin key. Check your key and try again.';
+        errorEl.style.display = '';
+        errorEl.focus();
+      }
+    } else {
+      btn.disabled = false;
+      btn.textContent = 'Sign in';
+      errorEl.textContent = 'Connection failed (HTTP ' + res.status + '). Try again.';
+      errorEl.style.display = '';
+      errorEl.focus();
+    }
+  }).catch(function(err) {
+    btn.disabled = false;
+    btn.textContent = 'Sign in';
+    if (err && err.message === 'fetch_timeout') {
+      errorEl.textContent = 'Connection timed out. Check your network and try again.';
+    } else {
+      errorEl.textContent = 'Connection failed. Check your network and try again.';
+    }
+    errorEl.style.display = '';
+    errorEl.focus();
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Admin shell (post-auth nav + content area)
+// ---------------------------------------------------------------------------
+
+function renderAdminShell() {
+  var app = document.getElementById('admin-app');
+  // Safe: clearing mount point only
+  app.textContent = '';
+
+  var nav = document.createElement('nav');
+  nav.className = 'app-nav';
+  nav.setAttribute('aria-label', 'Admin navigation');
+
+  var navLinks = document.createElement('div');
+  navLinks.className = 'nav-links';
+
+  var tenantsLink = document.createElement('a');
+  tenantsLink.href = '#/tenants';
+  tenantsLink.className = 'nav-link';
+  tenantsLink.textContent = 'Tenants';
+  navLinks.appendChild(tenantsLink);
+
+  nav.appendChild(navLinks);
+
+  var navActions = document.createElement('div');
+  navActions.className = 'nav-actions';
+
+  var wordmark = document.createElement('span');
+  wordmark.className = 'nav-link text-muted';
+  wordmark.style.cursor = 'default';
+  wordmark.textContent = 'WRL Admin';
+  navActions.appendChild(wordmark);
+
+  var logoutBtn = document.createElement('button');
+  logoutBtn.type = 'button';
+  logoutBtn.className = 'btn btn--ghost btn--sm';
+  logoutBtn.textContent = 'Logout';
+  logoutBtn.addEventListener('click', function() {
+    sessionStorage.removeItem(ADMIN_KEY_STORAGE);
+    location.reload();
+  });
+  navActions.appendChild(logoutBtn);
+
+  nav.appendChild(navActions);
+
+  var main = document.createElement('main');
+  main.id = 'admin-view';
+  main.className = 'view-container view-container--admin';
+
+  // aria-live region for announcements (screen readers)
+  var liveEl = document.createElement('div');
+  liveEl.id = 'admin-live';
+  liveEl.className = 'sr-only';
+  liveEl.setAttribute('aria-live', 'polite');
+  liveEl.setAttribute('aria-atomic', 'true');
+  main.appendChild(liveEl);
+
+  app.appendChild(nav);
+  app.appendChild(main);
+}
+
+// ---------------------------------------------------------------------------
+// Announce helper (used by views)
+// ---------------------------------------------------------------------------
+
+function adminAnnounce(message) {
+  var el = document.getElementById('admin-live');
+  if (!el) return;
+  el.textContent = '';
+  setTimeout(function() { el.textContent = message; }, 50);
+}
+
+// ---------------------------------------------------------------------------
+// Boot
+// ---------------------------------------------------------------------------
+
+function bootAdminApp() {
+  var key = sessionStorage.getItem(ADMIN_KEY_STORAGE);
+  if (key) {
+    renderAdminShell();
+    adminRoute();
+  } else {
+    renderAdminLogin();
+  }
+}
+`;

--- a/src/admin/admin-css.js
+++ b/src/admin/admin-css.js
@@ -1,0 +1,281 @@
+// Admin dashboard CSS additions.
+// Only admin-specific overrides -- the design system handles everything else.
+// All values use design system custom properties exclusively.
+
+export const ADMIN_CSS = `
+/* ---------------------------------------------------------------------------
+   Admin app layout
+--------------------------------------------------------------------------- */
+
+#admin-app {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+/* Admin-specific view container: wider than tenant views (860px) */
+.view-container--admin {
+  flex: 1;
+  padding: var(--space-8) var(--space-4);
+  width: 100%;
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+/* ---------------------------------------------------------------------------
+   Admin stat cards
+--------------------------------------------------------------------------- */
+
+.admin-stats-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: var(--space-4);
+  margin-bottom: var(--space-6);
+}
+
+.admin-stat {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-4) var(--space-5);
+}
+
+.admin-stat-value {
+  display: block;
+  font-size: var(--text-xl);
+  font-weight: var(--weight-bold);
+  color: var(--color-text);
+  margin-bottom: var(--space-1);
+}
+
+.admin-stat-label {
+  display: block;
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-muted);
+}
+
+/* ---------------------------------------------------------------------------
+   Admin table
+--------------------------------------------------------------------------- */
+
+.admin-table-wrap {
+  overflow-x: auto;
+}
+
+.admin-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--text-base);
+}
+
+.admin-table th {
+  background: var(--color-surface-muted);
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: var(--space-2) var(--space-3);
+  text-align: left;
+  border-bottom: 1px solid var(--color-border);
+  white-space: nowrap;
+}
+
+/* Sortable column header buttons */
+.admin-table th button {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+}
+
+.admin-table th button:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
+}
+
+/* Sort indicator via ::after pseudo-element */
+.admin-table th button[data-sort="asc"]::after  { content: " ↑"; }
+.admin-table th button[data-sort="desc"]::after { content: " ↓"; }
+
+.admin-table td {
+  padding: var(--space-3);
+  border-bottom: 1px solid var(--color-border-subtle);
+  vertical-align: middle;
+}
+
+.admin-table tbody tr {
+  cursor: pointer;
+  background: var(--color-surface);
+  transition: background 0.1s;
+}
+
+.admin-table tbody tr:hover {
+  background: var(--color-surface-muted);
+}
+
+.admin-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+/* Numeric cells: right-aligned with tabular figures */
+.admin-table td.num {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  font-size: var(--text-sm);
+}
+
+/* ---------------------------------------------------------------------------
+   Tenant ID link
+--------------------------------------------------------------------------- */
+
+.admin-tenant-link {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--color-primary);
+  text-decoration: none;
+}
+
+.admin-tenant-link:hover {
+  color: var(--color-accent);
+  text-decoration: underline;
+}
+
+.admin-tenant-link:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
+}
+
+/* ---------------------------------------------------------------------------
+   Refresh button (mirrors .usage-refresh-btn)
+--------------------------------------------------------------------------- */
+
+.admin-refresh-btn {
+  background: none;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  color: var(--color-text-muted);
+  cursor: pointer;
+  padding: 2px 8px;
+  font-size: var(--text-sm);
+}
+
+.admin-refresh-btn:hover {
+  background: var(--color-surface-muted);
+  color: var(--color-text);
+}
+
+.admin-refresh-btn:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.admin-refresh-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* ---------------------------------------------------------------------------
+   Admin detail sections
+--------------------------------------------------------------------------- */
+
+.admin-detail-header {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+  margin-bottom: var(--space-6);
+}
+
+.admin-back-link {
+  display: inline-block;
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+  text-decoration: none;
+  margin-bottom: var(--space-4);
+}
+
+.admin-back-link:hover {
+  color: var(--color-primary);
+}
+
+.admin-back-link:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
+}
+
+.admin-section {
+  border-top: 1px solid var(--color-border);
+  padding: var(--space-6) 0;
+}
+
+.admin-section h2 {
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-text-muted);
+  margin: 0 0 var(--space-4);
+}
+
+/* Config pre/code block */
+.admin-config-block {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  background: var(--color-surface-muted);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-3) var(--space-4);
+  overflow-x: auto;
+  white-space: pre;
+  max-height: 320px;
+  overflow-y: auto;
+}
+
+/* Table within detail sections */
+.admin-detail-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--text-sm);
+}
+
+.admin-detail-table th {
+  text-align: left;
+  font-weight: var(--weight-medium);
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-muted);
+  padding: var(--space-2) var(--space-3);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.admin-detail-table td {
+  padding: var(--space-2) var(--space-3);
+  border-bottom: 1px solid var(--color-border-subtle);
+}
+
+.admin-detail-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+/* Toolbar row between stats and table */
+.admin-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  margin-bottom: var(--space-3);
+}
+`;

--- a/src/admin/admin-detail.js
+++ b/src/admin/admin-detail.js
@@ -315,7 +315,7 @@ function buildKeysSection(keys) {
     var nameTd = document.createElement('td');
     nameTd.style.fontFamily = 'var(--font-mono)';
     nameTd.style.fontSize = 'var(--text-sm)';
-    nameTd.textContent = k.name || k.keyHashPrefix || '(unnamed)';
+    nameTd.textContent = k.name || (k.keyHash ? k.keyHash.slice(0, 8) + '\\u2026' : '(unnamed)');
     tr.appendChild(nameTd);
 
     var scopesTd = document.createElement('td');

--- a/src/admin/admin-detail.js
+++ b/src/admin/admin-detail.js
@@ -1,0 +1,365 @@
+// Admin per-tenant detail view.
+// Exports a JS string constant for inline use in the admin HTML shell.
+
+export const ADMIN_DETAIL_JS = `
+// ---------------------------------------------------------------------------
+// renderDetail(tenantId) -- builds the static DOM skeleton for detail view
+// ---------------------------------------------------------------------------
+
+function renderAdminDetail(tenantId) {
+  document.title = tenantId + ' \u2014 WRL Admin';
+
+  var view = document.getElementById('admin-view');
+  if (!view) return;
+  // Safe: clearing static view container only
+  view.textContent = '';
+
+  // Restore live region
+  var liveEl = document.createElement('div');
+  liveEl.id = 'admin-live';
+  liveEl.className = 'sr-only';
+  liveEl.setAttribute('aria-live', 'polite');
+  liveEl.setAttribute('aria-atomic', 'true');
+  view.appendChild(liveEl);
+
+  // Back link
+  var backLink = document.createElement('a');
+  backLink.href = '#/tenants';
+  backLink.className = 'admin-back-link';
+  backLink.textContent = '\u2190 Back to tenants';
+  view.appendChild(backLink);
+
+  // h1 + badge placeholder
+  var header = document.createElement('div');
+  header.className = 'admin-detail-header';
+  var h1 = document.createElement('h1');
+  h1.className = 'captures-heading';
+  h1.style.margin = '0';
+  h1.tabIndex = -1;
+  h1.textContent = tenantId;
+  header.appendChild(h1);
+  view.appendChild(header);
+  h1.focus();
+
+  // Loading placeholder
+  var loadingEl = document.createElement('p');
+  loadingEl.id = 'detail-loading';
+  loadingEl.className = 'view-placeholder';
+  loadingEl.textContent = 'Loading tenant details...';
+  view.appendChild(loadingEl);
+}
+
+// ---------------------------------------------------------------------------
+// mountAdminDetail(tenantId) -- fetches data and populates content
+// ---------------------------------------------------------------------------
+
+function mountAdminDetail(tenantId) {
+  var view = document.getElementById('admin-view');
+  if (!view) return;
+
+  adminFetch('/v1/admin/tenants/' + encodeURIComponent(tenantId) + '?periods=12')
+    .then(function(res) {
+      if (!res || !res.ok) {
+        return res ? res.json().then(function(body) {
+          return { error: true, status: res.status, body: body };
+        }).catch(function() {
+          return { error: true, status: res.status };
+        }) : { error: true, status: 0 };
+      }
+      return res.json().then(function(data) { return { error: false, data: data }; });
+    })
+    .then(function(result) {
+      var loadingEl = document.getElementById('detail-loading');
+      if (loadingEl) loadingEl.remove();
+
+      if (result.error) {
+        var errEl = document.createElement('div');
+        errEl.className = 'alert alert--error';
+        errEl.setAttribute('role', 'alert');
+        if (result.status === 404) {
+          errEl.textContent = 'Tenant not found.';
+        } else {
+          errEl.textContent = 'Could not load tenant data. Please try refreshing.';
+        }
+        view.appendChild(errEl);
+        return;
+      }
+
+      buildDetailContent(result.data);
+    })
+    .catch(function() {
+      var loadingEl = document.getElementById('detail-loading');
+      if (loadingEl) loadingEl.remove();
+      var errEl = document.createElement('div');
+      errEl.className = 'alert alert--error';
+      errEl.setAttribute('role', 'alert');
+      errEl.textContent = 'Could not load tenant data. Please try refreshing.';
+      view.appendChild(errEl);
+    });
+}
+
+// ---------------------------------------------------------------------------
+// buildDetailContent -- builds all sections from API data
+// ---------------------------------------------------------------------------
+
+function buildDetailContent(data) {
+  var view = document.getElementById('admin-view');
+  if (!view) return;
+
+  // Update h1 header with tier badge (it was already rendered by renderAdminDetail)
+  var header = view.querySelector('.admin-detail-header');
+  if (header) {
+    var existingBadge = header.querySelector('.badge');
+    if (!existingBadge) {
+      var tierBadge = document.createElement('span');
+      tierBadge.className = 'badge badge--skip';
+      tierBadge.textContent = data.tier || 'free';
+      header.appendChild(tierBadge);
+    }
+  }
+
+  // Section: Current period usage
+  view.appendChild(buildCurrentPeriodSection(data));
+
+  // Section: Usage history
+  if (data.usageHistory && data.usageHistory.length > 0) {
+    view.appendChild(buildUsageHistorySection(data.usageHistory));
+  }
+
+  // Section: API keys
+  if (data.keys && data.keys.length > 0) {
+    view.appendChild(buildKeysSection(data.keys));
+  }
+
+  // Section: Config (only if non-empty)
+  if (data.config && Object.keys(data.config).length > 0) {
+    view.appendChild(buildConfigSection(data.config));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Section: Current period usage
+// ---------------------------------------------------------------------------
+
+function buildCurrentPeriodSection(data) {
+  var section = document.createElement('section');
+  section.className = 'admin-section';
+
+  var h2 = document.createElement('h2');
+  h2.textContent = 'Current Period';
+  section.appendChild(h2);
+
+  var current = data.usageHistory && data.usageHistory.length > 0
+    ? data.usageHistory[0]
+    : { captureCount: 0, storageBytes: 0, apiCallCount: 0, eidasCaptureCount: 0 };
+
+  // Stat cards row
+  var statsRow = document.createElement('div');
+  statsRow.className = 'admin-stats-row';
+
+  statsRow.appendChild(buildAdminStat(formatNumber(current.captureCount || 0), 'Captures'));
+  statsRow.appendChild(buildAdminStat(formatBytes(current.storageBytes || 0), 'Storage'));
+  statsRow.appendChild(buildAdminStat(formatNumber(current.apiCallCount || 0), 'API Calls'));
+
+  if (current.eidasCaptureCount > 0) {
+    statsRow.appendChild(buildAdminStat(formatNumber(current.eidasCaptureCount), 'eIDAS Captures'));
+  }
+
+  section.appendChild(statsRow);
+
+  // Usage bar if quota is finite
+  var quota = data.quota;
+  if (quota && quota.captures !== null && quota.captures > 0) {
+    var used = current.captureCount || 0;
+    var pct = Math.min(100, Math.round((used / quota.captures) * 100));
+    var barWrap = document.createElement('div');
+    barWrap.style.marginBottom = 'var(--space-4)';
+
+    var barLabel = document.createElement('p');
+    barLabel.className = 'text-muted';
+    barLabel.style.fontSize = 'var(--text-sm)';
+    barLabel.style.marginBottom = 'var(--space-2)';
+    barLabel.textContent = formatNumber(used) + ' / ' + formatNumber(quota.captures) + ' captures (' + pct + '%)';
+    barWrap.appendChild(barLabel);
+
+    var bar = document.createElement('div');
+    bar.className = 'usage-bar';
+    bar.setAttribute('role', 'progressbar');
+    bar.setAttribute('aria-valuenow', String(pct));
+    bar.setAttribute('aria-valuemin', '0');
+    bar.setAttribute('aria-valuemax', '100');
+    bar.setAttribute('aria-label', 'Capture quota usage');
+
+    var fill = document.createElement('div');
+    fill.className = 'usage-bar-fill' + (pct >= 95 ? ' usage-bar-fill--critical' : pct >= 80 ? ' usage-bar-fill--warning' : '');
+    fill.style.width = pct + '%';
+    bar.appendChild(fill);
+    barWrap.appendChild(bar);
+    section.appendChild(barWrap);
+  }
+
+  // Billing status
+  var billingRow = document.createElement('p');
+  billingRow.className = 'text-muted';
+  billingRow.style.fontSize = 'var(--text-sm)';
+  billingRow.textContent = 'Billing status: ' + (data.billingStatus || 'unknown') +
+    (data.hasPaymentMethod ? ' \u00b7 Payment method on file' : ' \u00b7 No payment method');
+  section.appendChild(billingRow);
+
+  return section;
+}
+
+// ---------------------------------------------------------------------------
+// Section: Usage history table
+// ---------------------------------------------------------------------------
+
+function buildUsageHistorySection(history) {
+  var section = document.createElement('section');
+  section.className = 'admin-section';
+
+  var h2 = document.createElement('h2');
+  h2.textContent = 'Usage History';
+  section.appendChild(h2);
+
+  var wrap = document.createElement('div');
+  wrap.className = 'admin-table-wrap';
+
+  var table = document.createElement('table');
+  table.className = 'admin-detail-table';
+  table.setAttribute('aria-label', 'Usage history');
+
+  var thead = document.createElement('thead');
+  var headerRow = document.createElement('tr');
+  var histCols = ['Period', 'Captures', 'Storage', 'API Calls', 'eIDAS'];
+  for (var i = 0; i < histCols.length; i++) {
+    var th = document.createElement('th');
+    th.setAttribute('scope', 'col');
+    th.textContent = histCols[i];
+    headerRow.appendChild(th);
+  }
+  thead.appendChild(headerRow);
+  table.appendChild(thead);
+
+  var tbody = document.createElement('tbody');
+  for (var j = 0; j < history.length; j++) {
+    var h = history[j];
+    var tr = document.createElement('tr');
+
+    var periodTd = document.createElement('td');
+    periodTd.textContent = h.period || '';
+    tr.appendChild(periodTd);
+
+    var capTd = document.createElement('td');
+    capTd.style.fontVariantNumeric = 'tabular-nums';
+    capTd.textContent = formatNumber(h.captureCount || 0);
+    tr.appendChild(capTd);
+
+    var storageTd = document.createElement('td');
+    storageTd.textContent = formatBytes(h.storageBytes || 0);
+    tr.appendChild(storageTd);
+
+    var apiTd = document.createElement('td');
+    apiTd.style.fontVariantNumeric = 'tabular-nums';
+    apiTd.textContent = formatNumber(h.apiCallCount || 0);
+    tr.appendChild(apiTd);
+
+    var eidasTd = document.createElement('td');
+    eidasTd.style.fontVariantNumeric = 'tabular-nums';
+    eidasTd.textContent = formatNumber(h.eidasCaptureCount || 0);
+    tr.appendChild(eidasTd);
+
+    tbody.appendChild(tr);
+  }
+  table.appendChild(tbody);
+  wrap.appendChild(table);
+  section.appendChild(wrap);
+  return section;
+}
+
+// ---------------------------------------------------------------------------
+// Section: API keys
+// ---------------------------------------------------------------------------
+
+function buildKeysSection(keys) {
+  var section = document.createElement('section');
+  section.className = 'admin-section';
+
+  var h2 = document.createElement('h2');
+  h2.textContent = 'API Keys';
+  section.appendChild(h2);
+
+  var wrap = document.createElement('div');
+  wrap.className = 'admin-table-wrap';
+
+  var table = document.createElement('table');
+  table.className = 'admin-detail-table';
+  table.setAttribute('aria-label', 'API keys');
+
+  var thead = document.createElement('thead');
+  var headerRow = document.createElement('tr');
+  var keyCols = ['Name', 'Scopes', 'Created'];
+  for (var i = 0; i < keyCols.length; i++) {
+    var th = document.createElement('th');
+    th.setAttribute('scope', 'col');
+    th.textContent = keyCols[i];
+    headerRow.appendChild(th);
+  }
+  thead.appendChild(headerRow);
+  table.appendChild(thead);
+
+  var tbody = document.createElement('tbody');
+  for (var j = 0; j < keys.length; j++) {
+    var k = keys[j];
+    var tr = document.createElement('tr');
+
+    var nameTd = document.createElement('td');
+    nameTd.style.fontFamily = 'var(--font-mono)';
+    nameTd.style.fontSize = 'var(--text-sm)';
+    nameTd.textContent = k.name || k.keyHashPrefix || '(unnamed)';
+    tr.appendChild(nameTd);
+
+    var scopesTd = document.createElement('td');
+    var scopes = k.scopes || [];
+    for (var s = 0; s < scopes.length; s++) {
+      var badge = document.createElement('span');
+      badge.className = 'badge badge--skip';
+      badge.style.marginRight = 'var(--space-1)';
+      badge.textContent = scopes[s];
+      scopesTd.appendChild(badge);
+    }
+    tr.appendChild(scopesTd);
+
+    var createdTd = document.createElement('td');
+    createdTd.textContent = formatDate(k.createdAt);
+    tr.appendChild(createdTd);
+
+    tbody.appendChild(tr);
+  }
+  table.appendChild(tbody);
+  wrap.appendChild(table);
+  section.appendChild(wrap);
+  return section;
+}
+
+// ---------------------------------------------------------------------------
+// Section: Config
+// ---------------------------------------------------------------------------
+
+function buildConfigSection(config) {
+  var section = document.createElement('section');
+  section.className = 'admin-section';
+
+  var h2 = document.createElement('h2');
+  h2.textContent = 'Configuration';
+  section.appendChild(h2);
+
+  var pre = document.createElement('pre');
+  pre.className = 'admin-config-block';
+  var code = document.createElement('code');
+  // IMPORTANT: textContent only -- never innerHTML for config data (XSS prevention)
+  code.textContent = JSON.stringify(config, null, 2);
+  pre.appendChild(code);
+  section.appendChild(pre);
+  return section;
+}
+`;

--- a/src/admin/admin-detail.js
+++ b/src/admin/admin-detail.js
@@ -169,9 +169,9 @@ function buildCurrentPeriodSection(data) {
 
   // Usage bar if quota is finite
   var quota = data.quota;
-  if (quota && quota.captures !== null && quota.captures > 0) {
+  if (quota && quota.capturesPerMonth !== null && quota.capturesPerMonth > 0) {
     var used = current.captureCount || 0;
-    var pct = Math.min(100, Math.round((used / quota.captures) * 100));
+    var pct = Math.min(100, Math.round((used / quota.capturesPerMonth) * 100));
     var barWrap = document.createElement('div');
     barWrap.style.marginBottom = 'var(--space-4)';
 
@@ -179,7 +179,7 @@ function buildCurrentPeriodSection(data) {
     barLabel.className = 'text-muted';
     barLabel.style.fontSize = 'var(--text-sm)';
     barLabel.style.marginBottom = 'var(--space-2)';
-    barLabel.textContent = formatNumber(used) + ' / ' + formatNumber(quota.captures) + ' captures (' + pct + '%)';
+    barLabel.textContent = formatNumber(used) + ' / ' + formatNumber(quota.capturesPerMonth) + ' captures (' + pct + '%)';
     barWrap.appendChild(barLabel);
 
     var bar = document.createElement('div');

--- a/src/admin/admin-shell.js
+++ b/src/admin/admin-shell.js
@@ -1,0 +1,125 @@
+// tva
+import { DESIGN_SYSTEM_CSS } from '../design-system.js';
+import { ADMIN_CSS } from './admin-css.js';
+import { ADMIN_AUTH_JS } from './admin-auth.js';
+import { ADMIN_TENANTS_JS } from './admin-tenants.js';
+import { ADMIN_DETAIL_JS } from './admin-detail.js';
+
+export function htmlAdminDashboard() {
+  const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>WRL Admin</title>
+<link rel="icon" type="image/svg+xml" href="/favicon.ico">
+<style>
+${DESIGN_SYSTEM_CSS}
+${ADMIN_CSS}
+</style>
+</head>
+<body>
+<div id="admin-app"></div>
+<noscript>
+  <div style="max-width:480px;margin:4rem auto;padding:1rem;font-family:sans-serif;">
+    <h1 style="font-size:1.25rem;margin-bottom:0.75rem;">JavaScript Required</h1>
+    <p>WRL Admin requires JavaScript to run. Enable JavaScript in your browser settings to continue.</p>
+  </div>
+</noscript>
+<script>
+(function () {
+'use strict';
+
+// === AUTH + FETCH ===
+${ADMIN_AUTH_JS}
+
+// === VIEW: TENANTS ===
+${ADMIN_TENANTS_JS}
+
+// === VIEW: DETAIL ===
+${ADMIN_DETAIL_JS}
+
+// ---------------------------------------------------------------------------
+// Hash router
+// ---------------------------------------------------------------------------
+
+function updateAdminNavCurrent(activePath) {
+  var links = document.querySelectorAll('.nav-link');
+  for (var i = 0; i < links.length; i++) {
+    var href = links[i].getAttribute('href') || '';
+    if (href.startsWith('http')) continue;
+    var route = href.replace(/^#/, '');
+    if (activePath === route || activePath.indexOf(route + '/') === 0) {
+      links[i].setAttribute('aria-current', 'page');
+    } else {
+      links[i].removeAttribute('aria-current');
+    }
+  }
+}
+
+function adminRoute() {
+  var hash = location.hash || '';
+  var path = hash.replace(/^#/, '') || '/';
+
+  // Redirect bare / or empty to #/tenants
+  if (path === '/' || path === '') {
+    location.replace('#/tenants');
+    return;
+  }
+
+  // #/tenants/:id
+  var detailMatch = path.match(/^\\/tenants\\/([^/]+)$/);
+  if (detailMatch) {
+    var tenantId = decodeURIComponent(detailMatch[1]);
+    updateAdminNavCurrent('/tenants');
+    renderAdminDetail(tenantId);
+    mountAdminDetail(tenantId);
+    return;
+  }
+
+  // #/tenants (list)
+  if (path === '/tenants') {
+    updateAdminNavCurrent('/tenants');
+    renderTenants();
+    mountTenants();
+    return;
+  }
+
+  // Unmatched: fall back to tenants list
+  location.replace('#/tenants');
+}
+
+window.addEventListener('hashchange', function () {
+  adminRoute();
+});
+
+// ---------------------------------------------------------------------------
+// Boot
+// ---------------------------------------------------------------------------
+
+bootAdminApp();
+
+}());
+</script>
+</body>
+</html>`;
+
+  return new Response(html, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/html;charset=UTF-8',
+      'Content-Security-Policy': [
+        "default-src 'none'",
+        "script-src 'unsafe-inline'",
+        "style-src 'unsafe-inline'",
+        "img-src 'self'",
+        "connect-src 'self'",
+        "base-uri 'none'",
+        "form-action 'none'",
+        "frame-ancestors 'none'",
+      ].join('; '),
+      'Cache-Control': 'no-store',
+      'X-Frame-Options': 'DENY',
+    },
+  });
+}

--- a/src/admin/admin-tenants.js
+++ b/src/admin/admin-tenants.js
@@ -1,0 +1,376 @@
+// Admin tenant list view.
+// Exports a JS string constant for inline use in the admin HTML shell.
+
+export const ADMIN_TENANTS_JS = `
+// ---------------------------------------------------------------------------
+// Formatting helpers (used by both tenants and detail views)
+// ---------------------------------------------------------------------------
+
+function formatBytes(bytes) {
+  if (bytes === null || bytes === undefined || isNaN(bytes)) return '0 B';
+  var n = Number(bytes);
+  if (n < 1000) return n + ' B';
+  if (n < 1000000) return (n / 1000).toFixed(n % 1000 === 0 ? 0 : 1) + ' KB';
+  if (n < 1000000000) return (n / 1000000).toFixed(n % 1000000 === 0 ? 0 : 1) + ' MB';
+  return (n / 1000000000).toFixed(n % 1000000000 === 0 ? 0 : 1) + ' GB';
+}
+
+function formatDate(isoString) {
+  if (!isoString) return '';
+  try {
+    return new Date(isoString).toLocaleDateString(undefined, {
+      year: 'numeric', month: 'short', day: 'numeric'
+    });
+  } catch (e) {
+    return isoString;
+  }
+}
+
+function formatNumber(n) {
+  if (n === null || n === undefined) return '0';
+  try {
+    return Number(n).toLocaleString();
+  } catch (e) {
+    return String(n);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tenant list module state
+// ---------------------------------------------------------------------------
+
+var _tenantsData = null;
+var _tenantsSortCol = 'captures';
+var _tenantsSortDir = 'desc';
+
+// ---------------------------------------------------------------------------
+// renderTenants() -- builds the static DOM skeleton for the tenant list view
+// ---------------------------------------------------------------------------
+
+function renderTenants() {
+  document.title = 'Tenants \u2014 WRL Admin';
+
+  var view = document.getElementById('admin-view');
+  if (!view) return;
+  // Safe: clearing static view container only
+  view.textContent = '';
+
+  // Restore live region (cleared by textContent)
+  var liveEl = document.createElement('div');
+  liveEl.id = 'admin-live';
+  liveEl.className = 'sr-only';
+  liveEl.setAttribute('aria-live', 'polite');
+  liveEl.setAttribute('aria-atomic', 'true');
+  view.appendChild(liveEl);
+
+  var h1 = document.createElement('h1');
+  h1.className = 'captures-heading';
+  h1.tabIndex = -1;
+  h1.textContent = 'Tenants';
+  view.appendChild(h1);
+  h1.focus();
+
+  // Loading placeholder
+  var loadingEl = document.createElement('p');
+  loadingEl.id = 'tenants-loading';
+  loadingEl.className = 'view-placeholder';
+  loadingEl.textContent = 'Loading tenant data...';
+  view.appendChild(loadingEl);
+}
+
+// ---------------------------------------------------------------------------
+// mountTenants() -- fetches data and populates content
+// ---------------------------------------------------------------------------
+
+function mountTenants() {
+  var view = document.getElementById('admin-view');
+  if (!view) return;
+
+  var overviewPromise = adminFetch('/v1/admin/overview')
+    .then(function(res) {
+      if (!res || !res.ok) return null;
+      return res.json();
+    })
+    .catch(function() { return null; });
+
+  var tenantsPromise = adminFetch('/v1/admin/tenants')
+    .then(function(res) {
+      if (!res || !res.ok) return null;
+      return res.json();
+    })
+    .catch(function() { return null; });
+
+  Promise.all([overviewPromise, tenantsPromise]).then(function(results) {
+    var overviewData = results[0];
+    var tenantsData = results[1];
+
+    var loadingEl = document.getElementById('tenants-loading');
+    if (loadingEl) loadingEl.remove();
+
+    if (!overviewData || !tenantsData) {
+      var errEl = document.createElement('div');
+      errEl.className = 'alert alert--error';
+      errEl.setAttribute('role', 'alert');
+      errEl.textContent = 'Could not load tenant data. Please try refreshing.';
+      view.appendChild(errEl);
+      return;
+    }
+
+    _tenantsData = { overview: overviewData, tenants: tenantsData.data || [] };
+    buildTenantsContent(_tenantsData.overview, _tenantsData.tenants);
+  }).catch(function() {
+    var loadingEl = document.getElementById('tenants-loading');
+    if (loadingEl) loadingEl.remove();
+    var errEl = document.createElement('div');
+    errEl.className = 'alert alert--error';
+    errEl.setAttribute('role', 'alert');
+    errEl.textContent = 'Could not load tenant data. Please try refreshing.';
+    view.appendChild(errEl);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// buildTenantsContent -- builds stat cards, toolbar, and table
+// ---------------------------------------------------------------------------
+
+function buildTenantsContent(overview, tenants) {
+  var view = document.getElementById('admin-view');
+  if (!view) return;
+
+  // Remove any previously rendered content sections
+  var existing = view.querySelectorAll('.admin-stats-row, .admin-toolbar, .admin-table-wrap, .alert--error');
+  for (var i = 0; i < existing.length; i++) existing[i].remove();
+
+  // --- Stat cards ---
+  var activeCount = 0;
+  for (var j = 0; j < tenants.length; j++) {
+    if (tenants[j].currentPeriod && tenants[j].currentPeriod.captureCount > 0) activeCount++;
+  }
+
+  var statsRow = document.createElement('div');
+  statsRow.className = 'admin-stats-row';
+  statsRow.appendChild(buildAdminStat(formatNumber(overview.totalTenants), 'Total Tenants'));
+  statsRow.appendChild(buildAdminStat(formatNumber(activeCount), 'Active This Period'));
+  statsRow.appendChild(buildAdminStat(formatNumber(overview.totalCapturesCurrentPeriod), 'Captures This Period'));
+  statsRow.appendChild(buildAdminStat(formatBytes(overview.totalStorageBytes), 'Total Storage'));
+  view.appendChild(statsRow);
+
+  // --- Toolbar (refresh button) ---
+  var toolbar = document.createElement('div');
+  toolbar.className = 'admin-toolbar';
+  var refreshBtn = document.createElement('button');
+  refreshBtn.type = 'button';
+  refreshBtn.className = 'admin-refresh-btn';
+  refreshBtn.textContent = 'Refresh';
+  refreshBtn.addEventListener('click', function() {
+    refreshBtn.disabled = true;
+    refreshBtn.textContent = 'Refreshing...';
+    reloadTenantsData(refreshBtn);
+  });
+  toolbar.appendChild(refreshBtn);
+  view.appendChild(toolbar);
+
+  // --- Table ---
+  view.appendChild(buildTenantsTable(tenants));
+}
+
+function buildAdminStat(value, label) {
+  var cell = document.createElement('div');
+  cell.className = 'admin-stat';
+  var valEl = document.createElement('span');
+  valEl.className = 'admin-stat-value';
+  valEl.textContent = value;
+  var lblEl = document.createElement('span');
+  lblEl.className = 'admin-stat-label';
+  lblEl.textContent = label;
+  cell.appendChild(valEl);
+  cell.appendChild(lblEl);
+  return cell;
+}
+
+function reloadTenantsData(refreshBtn) {
+  var overviewPromise = adminFetch('/v1/admin/overview')
+    .then(function(res) { return res && res.ok ? res.json() : null; })
+    .catch(function() { return null; });
+  var tenantsPromise = adminFetch('/v1/admin/tenants')
+    .then(function(res) { return res && res.ok ? res.json() : null; })
+    .catch(function() { return null; });
+
+  Promise.all([overviewPromise, tenantsPromise]).then(function(results) {
+    if (refreshBtn) { refreshBtn.disabled = false; refreshBtn.textContent = 'Refresh'; }
+    if (!results[0] || !results[1]) {
+      adminAnnounce('Refresh failed. Please try again.');
+      return;
+    }
+    _tenantsData = { overview: results[0], tenants: results[1].data || [] };
+    buildTenantsContent(_tenantsData.overview, _tenantsData.tenants);
+    adminAnnounce('Tenant data refreshed.');
+  }).catch(function() {
+    if (refreshBtn) { refreshBtn.disabled = false; refreshBtn.textContent = 'Refresh'; }
+    adminAnnounce('Refresh failed. Please try again.');
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Table builder
+// ---------------------------------------------------------------------------
+
+var SORT_COLS = {
+  tenant: function(t) { return t.tenantId || ''; },
+  tier:   function(t) { return t.tier || ''; },
+  captures: function(t) { return (t.currentPeriod && t.currentPeriod.captureCount) || 0; },
+  storage:  function(t) { return (t.currentPeriod && t.currentPeriod.storageBytes) || 0; },
+  keys:     function(t) { return t.keyCount || 0; },
+  created:  function(t) { return t.createdAt || ''; },
+};
+
+function sortedTenants(tenants) {
+  var col = _tenantsSortCol;
+  var dir = _tenantsSortDir;
+  var getter = SORT_COLS[col] || SORT_COLS.captures;
+
+  var copy = tenants.slice();
+  copy.sort(function(a, b) {
+    var av = getter(a);
+    var bv = getter(b);
+    if (av < bv) return dir === 'asc' ? -1 : 1;
+    if (av > bv) return dir === 'asc' ? 1 : -1;
+    return 0;
+  });
+  return copy;
+}
+
+function buildTenantsTable(tenants) {
+  var wrap = document.createElement('div');
+  wrap.className = 'admin-table-wrap';
+
+  if (!tenants || tenants.length === 0) {
+    var empty = document.createElement('p');
+    empty.className = 'view-placeholder';
+    empty.textContent = 'No tenants found.';
+    wrap.appendChild(empty);
+    return wrap;
+  }
+
+  var table = document.createElement('table');
+  table.className = 'admin-table';
+  table.setAttribute('aria-label', 'Tenant list');
+
+  // Build thead
+  var thead = document.createElement('thead');
+  var headerRow = document.createElement('tr');
+
+  var cols = [
+    { key: 'tenant',   label: 'Tenant ID',  sortable: true },
+    { key: 'tier',     label: 'Tier',        sortable: true },
+    { key: 'captures', label: 'Captures',    sortable: true },
+    { key: 'storage',  label: 'Storage',     sortable: true },
+    { key: 'keys',     label: 'Keys',        sortable: true },
+    { key: 'created',  label: 'Created',     sortable: true },
+  ];
+
+  for (var i = 0; i < cols.length; i++) {
+    var col = cols[i];
+    var th = document.createElement('th');
+    th.setAttribute('scope', 'col');
+
+    if (col.sortable) {
+      var sortBtn = document.createElement('button');
+      sortBtn.type = 'button';
+      sortBtn.textContent = col.label;
+
+      if (_tenantsSortCol === col.key) {
+        th.setAttribute('aria-sort', _tenantsSortDir === 'asc' ? 'ascending' : 'descending');
+        sortBtn.setAttribute('data-sort', _tenantsSortDir);
+      }
+
+      (function(colKey, thEl, btnEl) {
+        btnEl.addEventListener('click', function() {
+          if (_tenantsSortCol === colKey) {
+            _tenantsSortDir = _tenantsSortDir === 'asc' ? 'desc' : 'asc';
+          } else {
+            _tenantsSortCol = colKey;
+            _tenantsSortDir = 'asc';
+          }
+          if (_tenantsData) {
+            buildTenantsContent(_tenantsData.overview, _tenantsData.tenants);
+          }
+          adminAnnounce('Sorted by ' + colKey + ' ' + _tenantsSortDir + 'ending');
+        });
+      }(col.key, th, sortBtn));
+
+      th.appendChild(sortBtn);
+    } else {
+      th.textContent = col.label;
+    }
+
+    headerRow.appendChild(th);
+  }
+
+  thead.appendChild(headerRow);
+  table.appendChild(thead);
+
+  // Build tbody
+  var tbody = document.createElement('tbody');
+  var sorted = sortedTenants(tenants);
+
+  for (var j = 0; j < sorted.length; j++) {
+    var t = sorted[j];
+    var tr = document.createElement('tr');
+
+    // Tenant ID -- navigate to detail on row click
+    var idTd = document.createElement('td');
+    var link = document.createElement('a');
+    link.href = '#/tenants/' + encodeURIComponent(t.tenantId);
+    link.className = 'admin-tenant-link';
+    link.textContent = t.tenantId;
+    idTd.appendChild(link);
+    tr.appendChild(idTd);
+
+    // Tier badge
+    var tierTd = document.createElement('td');
+    var badge = document.createElement('span');
+    badge.className = 'badge badge--skip';
+    badge.textContent = t.tier || 'free';
+    tierTd.appendChild(badge);
+    tr.appendChild(tierTd);
+
+    // Captures (numeric)
+    var capTd = document.createElement('td');
+    capTd.className = 'num';
+    capTd.textContent = formatNumber((t.currentPeriod && t.currentPeriod.captureCount) || 0);
+    tr.appendChild(capTd);
+
+    // Storage (numeric)
+    var storageTd = document.createElement('td');
+    storageTd.className = 'num';
+    storageTd.textContent = formatBytes((t.currentPeriod && t.currentPeriod.storageBytes) || 0);
+    tr.appendChild(storageTd);
+
+    // Key count (numeric)
+    var keysTd = document.createElement('td');
+    keysTd.className = 'num';
+    keysTd.textContent = formatNumber(t.keyCount || 0);
+    tr.appendChild(keysTd);
+
+    // Created date
+    var createdTd = document.createElement('td');
+    createdTd.textContent = formatDate(t.createdAt);
+    tr.appendChild(createdTd);
+
+    // Row click navigates to detail (excluding link clicks which handle themselves)
+    (function(tenantId) {
+      tr.addEventListener('click', function(e) {
+        if (e.target.tagName === 'A') return;
+        location.hash = '#/tenants/' + encodeURIComponent(tenantId);
+      });
+    }(t.tenantId));
+
+    tbody.appendChild(tr);
+  }
+
+  table.appendChild(tbody);
+  wrap.appendChild(table);
+  return wrap;
+}
+`;

--- a/src/admin/admin-tenants.js
+++ b/src/admin/admin-tenants.js
@@ -152,7 +152,7 @@ function buildTenantsContent(overview, tenants) {
   statsRow.appendChild(buildAdminStat(formatNumber(overview.totalTenants), 'Total Tenants'));
   statsRow.appendChild(buildAdminStat(formatNumber(activeCount), 'Active This Period'));
   statsRow.appendChild(buildAdminStat(formatNumber(overview.totalCapturesCurrentPeriod), 'Captures This Period'));
-  statsRow.appendChild(buildAdminStat(formatBytes(overview.totalStorageBytes), 'Total Storage'));
+  statsRow.appendChild(buildAdminStat(formatBytes(overview.currentPeriodStorageBytes), 'Storage This Period'));
   view.appendChild(statsRow);
 
   // --- Toolbar (refresh button) ---

--- a/src/db.js
+++ b/src/db.js
@@ -1902,3 +1902,192 @@ export async function setChangeSummary(db, captureId, summary) {
     'UPDATE captures SET change_summary = ? WHERE id = ?',
   ).bind(JSON.stringify(summary), captureId).run();
 }
+
+// ---------------------------------------------------------------------------
+// Admin dashboard operations
+// ---------------------------------------------------------------------------
+
+/**
+ * List all tenants with their current-period usage counters in a single query.
+ * Active key count is included as a correlated subquery so no second round-trip
+ * is needed. Tenants with no usage row for the period return zeroed counters via
+ * COALESCE.
+ *
+ * @param {D1Database} db
+ * @param {string} period  'YYYY-MM' billing period (use computePeriod() for current)
+ * @returns {Promise<Array<{
+ *   id: string,
+ *   tier: string,
+ *   billingStatus: string,
+ *   paymentMethodAddedAt: string|null,
+ *   eidasQualified: boolean,
+ *   config: string|null,
+ *   createdAt: string,
+ *   captureCount: number,
+ *   storageBytes: number,
+ *   apiCallCount: number,
+ *   eidasCaptureCount: number,
+ *   keyCount: number
+ * }>>}
+ */
+export async function listTenantsWithUsage(db, period) {
+  const { results } = await db.prepare(
+    `SELECT
+       t.id,
+       t.tier,
+       t.billing_status,
+       t.payment_method_added_at,
+       t.eidas_qualified,
+       t.config,
+       t.created_at,
+       COALESCE(u.capture_count, 0) AS capture_count,
+       COALESCE(u.storage_bytes, 0) AS storage_bytes,
+       COALESCE(u.api_call_count, 0) AS api_call_count,
+       COALESCE(u.eidas_capture_count, 0) AS eidas_capture_count,
+       (SELECT COUNT(*) FROM api_keys ak WHERE ak.tenant_id = t.id AND ak.revoked = 0) AS key_count
+     FROM tenants t
+     LEFT JOIN usage_counters u
+       ON u.tenant_id = t.id AND u.period = ?
+     ORDER BY t.created_at DESC`,
+  ).bind(period).all();
+
+  return (results ?? []).map(row => ({
+    id: row.id,
+    tier: row.tier,
+    billingStatus: row.billing_status,
+    paymentMethodAddedAt: row.payment_method_added_at ?? null,
+    eidasQualified: Boolean(row.eidas_qualified),
+    config: row.config ?? null,
+    createdAt: row.created_at,
+    captureCount: row.capture_count,
+    storageBytes: row.storage_bytes,
+    apiCallCount: row.api_call_count,
+    eidasCaptureCount: row.eidas_capture_count,
+    keyCount: row.key_count,
+  }));
+}
+
+/**
+ * Return comprehensive data for a single tenant in one db.batch() round-trip:
+ * the tenant row, recent usage history, and active API key summaries.
+ *
+ * @param {D1Database} db
+ * @param {string} tenantId
+ * @param {number} [periodLimit=6]  Number of billing periods of history to return
+ * @returns {Promise<{
+ *   tenant: object,
+ *   usageHistory: object[],
+ *   keys: object[]
+ * }|null>}  null if the tenant does not exist
+ */
+export async function getTenantDetail(db, tenantId, periodLimit = 6) {
+  const [tenantResult, usageResult, keysResult] = await db.batch([
+    db.prepare('SELECT * FROM tenants WHERE id = ?').bind(tenantId),
+    db.prepare(
+      `SELECT period, capture_count, storage_bytes, api_call_count, eidas_capture_count, updated_at
+       FROM usage_counters WHERE tenant_id = ? ORDER BY period DESC LIMIT ?`,
+    ).bind(tenantId, periodLimit),
+    db.prepare(
+      `SELECT key_hash, name, scopes, created_at, created_by
+       FROM api_keys WHERE tenant_id = ? AND revoked = 0 ORDER BY created_at DESC`,
+    ).bind(tenantId),
+  ]);
+
+  const tenantRow = tenantResult.results?.[0] ?? null;
+  if (!tenantRow) return null;
+
+  const tenant = {
+    id: tenantRow.id,
+    tier: tenantRow.tier,
+    billingStatus: tenantRow.billing_status,
+    gracePeriodEnd: tenantRow.grace_period_end ?? null,
+    paymentMethodAddedAt: tenantRow.payment_method_added_at ?? null,
+    stripeCustomerId: tenantRow.stripe_customer_id ?? null,
+    eidasQualified: Boolean(tenantRow.eidas_qualified),
+    config: tenantRow.config ?? null,
+    createdAt: tenantRow.created_at,
+    updatedAt: tenantRow.updated_at ?? null,
+  };
+
+  const usageHistory = (usageResult.results ?? []).map(row => ({
+    period: row.period,
+    captureCount: row.capture_count,
+    storageBytes: row.storage_bytes,
+    apiCallCount: row.api_call_count,
+    eidasCaptureCount: row.eidas_capture_count ?? 0,
+    updatedAt: row.updated_at ?? null,
+  }));
+
+  const keys = (keysResult.results ?? []).map(row => ({
+    keyHash: row.key_hash,
+    name: row.name,
+    scopes: JSON.parse(row.scopes),
+    createdAt: row.created_at,
+    createdBy: row.created_by,
+  }));
+
+  return { tenant, usageHistory, keys };
+}
+
+/**
+ * Return platform-wide aggregate statistics in a single db.batch() round-trip.
+ * Tenant breakdown and usage aggregates are fetched simultaneously and merged
+ * into a flat result object.
+ *
+ * @param {D1Database} db
+ * @param {string} period  'YYYY-MM' billing period for current-period metrics
+ * @returns {Promise<{
+ *   totalTenants: number,
+ *   tenantsByTier: { free: number, pro: number },
+ *   tenantsByBillingStatus: { active: number, gracePeriod: number, blocked: number },
+ *   totalCapturesCurrentPeriod: number,
+ *   totalCapturesAllTime: number,
+ *   totalStorageBytes: number,
+ *   totalEidasCaptures: number,
+ *   activeApiKeys: number
+ * }>}
+ */
+export async function getOverviewStats(db, period) {
+  const [tenantsResult, usageResult] = await db.batch([
+    db.prepare(
+      `SELECT
+         COUNT(*) AS total_tenants,
+         SUM(CASE WHEN tier = 'free' THEN 1 ELSE 0 END) AS free_count,
+         SUM(CASE WHEN tier = 'pro' THEN 1 ELSE 0 END) AS pro_count,
+         SUM(CASE WHEN billing_status = 'active' THEN 1 ELSE 0 END) AS active_count,
+         SUM(CASE WHEN billing_status = 'grace_period' THEN 1 ELSE 0 END) AS grace_count,
+         SUM(CASE WHEN billing_status = 'blocked' THEN 1 ELSE 0 END) AS blocked_count,
+         (SELECT COUNT(*) FROM api_keys WHERE revoked = 0) AS active_api_keys
+       FROM tenants`,
+    ),
+    db.prepare(
+      `SELECT
+         SUM(CASE WHEN period = ? THEN capture_count ELSE 0 END) AS current_captures,
+         SUM(capture_count) AS all_time_captures,
+         SUM(CASE WHEN period = ? THEN storage_bytes ELSE 0 END) AS current_storage,
+         SUM(CASE WHEN period = ? THEN eidas_capture_count ELSE 0 END) AS current_eidas_captures
+       FROM usage_counters`,
+    ).bind(period, period, period),
+  ]);
+
+  const t = tenantsResult.results?.[0] ?? {};
+  const u = usageResult.results?.[0] ?? {};
+
+  return {
+    totalTenants: t.total_tenants ?? 0,
+    tenantsByTier: {
+      free: t.free_count ?? 0,
+      pro: t.pro_count ?? 0,
+    },
+    tenantsByBillingStatus: {
+      active: t.active_count ?? 0,
+      gracePeriod: t.grace_count ?? 0,
+      blocked: t.blocked_count ?? 0,
+    },
+    totalCapturesCurrentPeriod: u.current_captures ?? 0,
+    totalCapturesAllTime: u.all_time_captures ?? 0,
+    totalStorageBytes: u.current_storage ?? 0,
+    totalEidasCaptures: u.current_eidas_captures ?? 0,
+    activeApiKeys: t.active_api_keys ?? 0,
+  };
+}

--- a/src/db.js
+++ b/src/db.js
@@ -2042,7 +2042,7 @@ export async function getTenantDetail(db, tenantId, periodLimit = 6) {
  *   tenantsByBillingStatus: { active: number, gracePeriod: number, blocked: number },
  *   totalCapturesCurrentPeriod: number,
  *   totalCapturesAllTime: number,
- *   totalStorageBytes: number,
+ *   currentPeriodStorageBytes: number,
  *   totalEidasCaptures: number,
  *   activeApiKeys: number
  * }>}
@@ -2086,7 +2086,7 @@ export async function getOverviewStats(db, period) {
     },
     totalCapturesCurrentPeriod: u.current_captures ?? 0,
     totalCapturesAllTime: u.all_time_captures ?? 0,
-    totalStorageBytes: u.current_storage ?? 0,
+    currentPeriodStorageBytes: u.current_storage ?? 0,
     totalEidasCaptures: u.current_eidas_captures ?? 0,
     activeApiKeys: t.active_api_keys ?? 0,
   };

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,7 @@ import { RATE_LIMITS, getEffectiveLimit } from './rate-limits.js';
 import { checkQuota, FREE_CAPTURE_LIMIT } from './quotas.js';
 import { computeCip } from './ip-hash.js';
 import { handleAdminCreateKey, handleAdminListKeys, handleAdminRevokeKey, handleAdminGetUsage, handleAdminCachePurge } from './admin.js';
+import { handleAdminListTenants, handleAdminGetTenant, handleAdminGetOverview } from './admin-dashboard.js';
 import { handleMcp } from './mcp.js';
 import { buildCacheKey, buildSimpleCacheKey, getCache } from './cache.js';
 import { htmlDashboard } from './ui/ui-shell.js';
@@ -84,6 +85,12 @@ const routes = [
   ['POST',   /^\/v1\/admin\/cache\/purge$/, handleAdminCachePurge],
   ['GET',    /^\/v1\/admin\/tenants\/([a-z0-9_-]{1,64})\/config$/, handleGetTenantConfig],
   ['PUT',    /^\/v1\/admin\/tenants\/([a-z0-9_-]{1,64})\/config$/, handlePutTenantConfig],
+  // Dashboard routes. List-tenants and overview use exact-match ($); tenant detail
+  // pattern is less specific but placed after the /config routes above so /config
+  // matches first when that path is requested.
+  ['GET',    /^\/v1\/admin\/tenants$/, handleAdminListTenants],
+  ['GET',    /^\/v1\/admin\/tenants\/([a-z0-9_-]{1,64})$/, handleAdminGetTenant],
+  ['GET',    /^\/v1\/admin\/overview$/, handleAdminGetOverview],
   ['POST',   /^\/v1\/webhooks$/, handleCreateWebhook],
   ['GET',    /^\/v1\/webhooks$/, handleListWebhooks],
   ['DELETE', /^\/v1\/webhooks\/(whk_[a-f0-9]{32})$/, handleDeleteWebhook],

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ import { handleAdminListTenants, handleAdminGetTenant, handleAdminGetOverview } 
 import { handleMcp } from './mcp.js';
 import { buildCacheKey, buildSimpleCacheKey, getCache } from './cache.js';
 import { htmlDashboard } from './ui/ui-shell.js';
+import { htmlAdminDashboard } from './admin/admin-shell.js';
 import { handleCreateWebhook, handleListWebhooks, handleDeleteWebhook, handlePingWebhook } from './webhooks.js';
 import { handleCreateSchedule, handleListSchedules, handleGetSchedule, handleDeleteSchedule } from './schedules.js';
 import { handleWebhookMessage, handleWebhookDlqMessage, dispatchWebhooks } from './webhook-dispatch.js';
@@ -67,6 +68,8 @@ const routes = [
   ['GET',    /^\/health$/, handleHealth],
   // UI dashboard -- same-origin only; no CORS needed (browser-only, uses credentials via sessionStorage)
   ['GET',    /^\/ui$/, handleDashboard],
+  // Admin dashboard -- HTML shell served unauthenticated; auth happens client-side before API calls
+  ['GET',    /^\/admin$/, handleAdminDashboard],
   ['POST',   /^\/v1\/captures\/batch$/, handleBatchCapture],
   ['POST',   /^\/v1\/captures$/, handleCreateCapture],
   ['GET',    /^\/v1\/captures$/, handleListCaptures],
@@ -754,6 +757,10 @@ function handleHealth() {
 
 function handleDashboard() {
   return htmlDashboard();
+}
+
+function handleAdminDashboard() {
+  return htmlAdminDashboard();
 }
 
 /**

--- a/src/rate-limits.js
+++ b/src/rate-limits.js
@@ -6,7 +6,7 @@
 export const RATE_LIMITS = {
   capture: { limit: 10, period: 60 },   // per-tenant default (all authenticated endpoints)
   verify:  { limit: 60, period: 60 },    // per-IP (unauthenticated)
-  admin:   { limit: 5,  period: 60 },    // per-IP (admin)
+  admin:   { limit: 30, period: 60 },    // per-IP (admin)
   auth:    { limit: 20, period: 60 },    // per-IP (OAuth flow)
   account: { limit: 30, period: 60 },    // per-IP (account settings)
 };

--- a/test/admin-dashboard.test.js
+++ b/test/admin-dashboard.test.js
@@ -224,7 +224,7 @@ describe('DAL getOverviewStats -- empty database', () => {
     expect(stats.totalTenants).toBe(0);
     expect(stats.totalCapturesCurrentPeriod).toBe(0);
     expect(stats.totalCapturesAllTime).toBe(0);
-    expect(stats.totalStorageBytes).toBe(0);
+    expect(stats.currentPeriodStorageBytes).toBe(0);
     expect(stats.totalEidasCaptures).toBe(0);
     expect(stats.activeApiKeys).toBe(0);
     expect(stats.tenantsByTier.free).toBe(0);
@@ -577,7 +577,7 @@ describe('GET /v1/admin/overview -- success', () => {
         'totalCapturesAllTime',
         'totalCapturesCurrentPeriod',
         'totalEidasCaptures',
-        'totalStorageBytes',
+        'currentPeriodStorageBytes',
         'totalTenants',
       ].sort(),
     );

--- a/test/admin-dashboard.test.js
+++ b/test/admin-dashboard.test.js
@@ -1,0 +1,648 @@
+// tva
+// Integration tests for admin dashboard: DAL functions and HTTP endpoints.
+// DAL tests use env.DB directly. HTTP tests use SELF.fetch() through the real worker.
+//
+// IMPORTANT: Admin rate limiter is 30 req/60s per IP (wrangler.test.toml).
+// Each describe block uses a distinct CF-Connecting-IP to avoid cross-test
+// rate limit exhaustion. IP range: 10.0.1.150+
+
+import { env, SELF } from 'cloudflare:test';
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  TEST_ADMIN_KEY,
+  TEST_TENANT_KEY,
+  cleanDb,
+  seedApiKey,
+  seedUsageCounter,
+  seedTenantWithTier,
+} from './fixtures.js';
+import { listTenantsWithUsage, getTenantDetail, getOverviewStats } from '../src/db.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const ADMIN_AUTH = `Bearer ${TEST_ADMIN_KEY}`;
+
+let ipCounter = 150;
+function nextIp() {
+  return `10.0.1.${ipCounter++}`;
+}
+
+function adminGet(path, ip) {
+  return SELF.fetch(`https://worker.test${path}`, {
+    headers: {
+      Authorization: ADMIN_AUTH,
+      'CF-Connecting-IP': ip,
+    },
+  });
+}
+
+beforeEach(async () => {
+  await cleanDb(env.DB);
+});
+
+// ===========================================================================
+// DAL: listTenantsWithUsage
+// ===========================================================================
+
+describe('DAL listTenantsWithUsage -- empty database', () => {
+  it('returns empty array when no tenants exist', async () => {
+    const rows = await listTenantsWithUsage(env.DB, '2026-03');
+    expect(rows).toEqual([]);
+  });
+});
+
+describe('DAL listTenantsWithUsage -- tenant with no usage row', () => {
+  it('returns zeroed counters when tenant has no usage_counters row', async () => {
+    await seedTenantWithTier(env.DB, 'tenant-nousage');
+    const rows = await listTenantsWithUsage(env.DB, '2026-03');
+    expect(rows).toHaveLength(1);
+    const row = rows[0];
+    expect(row.id).toBe('tenant-nousage');
+    expect(row.captureCount).toBe(0);
+    expect(row.storageBytes).toBe(0);
+    expect(row.apiCallCount).toBe(0);
+    expect(row.eidasCaptureCount).toBe(0);
+    expect(row.keyCount).toBe(0);
+  });
+});
+
+describe('DAL listTenantsWithUsage -- multiple tenants with mixed usage', () => {
+  it('returns correct data for all tenants in the requested period', async () => {
+    await seedTenantWithTier(env.DB, 'tenant-alpha', { createdAt: '2026-01-01T00:00:00.000Z' });
+    await seedTenantWithTier(env.DB, 'tenant-beta', { createdAt: '2026-02-01T00:00:00.000Z' });
+    await seedUsageCounter(env.DB, {
+      tenantId: 'tenant-alpha',
+      period: '2026-03',
+      captureCount: 10,
+      storageBytes: 1000,
+      apiCallCount: 5,
+      eidasCaptureCount: 3,
+    });
+    // tenant-beta has no usage row for this period
+
+    const rows = await listTenantsWithUsage(env.DB, '2026-03');
+    expect(rows).toHaveLength(2);
+
+    const alpha = rows.find(r => r.id === 'tenant-alpha');
+    expect(alpha.captureCount).toBe(10);
+    expect(alpha.storageBytes).toBe(1000);
+    expect(alpha.apiCallCount).toBe(5);
+    expect(alpha.eidasCaptureCount).toBe(3);
+
+    const beta = rows.find(r => r.id === 'tenant-beta');
+    expect(beta.captureCount).toBe(0);
+    expect(beta.eidasCaptureCount).toBe(0);
+  });
+});
+
+describe('DAL listTenantsWithUsage -- ordering', () => {
+  it('returns tenants ordered by created_at DESC', async () => {
+    await seedTenantWithTier(env.DB, 'oldest', { createdAt: '2025-01-01T00:00:00.000Z' });
+    await seedTenantWithTier(env.DB, 'middle', { createdAt: '2025-06-01T00:00:00.000Z' });
+    await seedTenantWithTier(env.DB, 'newest', { createdAt: '2026-01-01T00:00:00.000Z' });
+
+    const rows = await listTenantsWithUsage(env.DB, '2026-03');
+    expect(rows.map(r => r.id)).toEqual(['newest', 'middle', 'oldest']);
+  });
+});
+
+describe('DAL listTenantsWithUsage -- keyCount', () => {
+  it('keyCount reflects only active (non-revoked) keys', async () => {
+    await seedTenantWithTier(env.DB, 'tenant-keys');
+    await seedApiKey(env.DB, 'wrl_live_' + 'k'.repeat(43), {
+      tenantId: 'tenant-keys',
+      name: 'active-1',
+    });
+    await seedApiKey(env.DB, 'wrl_live_' + 'l'.repeat(43), {
+      tenantId: 'tenant-keys',
+      name: 'active-2',
+    });
+    await seedApiKey(env.DB, 'wrl_live_' + 'm'.repeat(43), {
+      tenantId: 'tenant-keys',
+      name: 'revoked-key',
+      revoked: true,
+      revokedAt: new Date().toISOString(),
+    });
+
+    const rows = await listTenantsWithUsage(env.DB, '2026-03');
+    const row = rows.find(r => r.id === 'tenant-keys');
+    expect(row.keyCount).toBe(2);
+  });
+});
+
+// ===========================================================================
+// DAL: getTenantDetail
+// ===========================================================================
+
+describe('DAL getTenantDetail -- not found', () => {
+  it('returns null for a nonexistent tenant', async () => {
+    const result = await getTenantDetail(env.DB, 'does-not-exist');
+    expect(result).toBeNull();
+  });
+});
+
+describe('DAL getTenantDetail -- full detail', () => {
+  it('includes tenant metadata, usage history, and active keys', async () => {
+    await seedTenantWithTier(env.DB, 'detail-tenant', {
+      tier: 'pro',
+      billingStatus: 'active',
+      stripeCustomerId: 'cus_test123',
+    });
+    await seedUsageCounter(env.DB, {
+      tenantId: 'detail-tenant',
+      period: '2026-03',
+      captureCount: 50,
+      storageBytes: 9999,
+      apiCallCount: 12,
+      eidasCaptureCount: 5,
+    });
+    await seedApiKey(env.DB, 'wrl_live_' + 'd'.repeat(43), {
+      tenantId: 'detail-tenant',
+      name: 'my-key',
+    });
+
+    const result = await getTenantDetail(env.DB, 'detail-tenant');
+    expect(result).not.toBeNull();
+    expect(result.tenant.id).toBe('detail-tenant');
+    expect(result.tenant.tier).toBe('pro');
+    expect(result.tenant.stripeCustomerId).toBe('cus_test123');
+    expect(result.usageHistory).toHaveLength(1);
+    expect(result.usageHistory[0].captureCount).toBe(50);
+    expect(result.usageHistory[0].eidasCaptureCount).toBe(5);
+    expect(result.keys).toHaveLength(1);
+    expect(result.keys[0].name).toBe('my-key');
+  });
+
+  it('keys array excludes revoked keys', async () => {
+    await seedTenantWithTier(env.DB, 'detail-revoked');
+    await seedApiKey(env.DB, 'wrl_live_' + 'e'.repeat(43), {
+      tenantId: 'detail-revoked',
+      name: 'active',
+    });
+    await seedApiKey(env.DB, 'wrl_live_' + 'f'.repeat(43), {
+      tenantId: 'detail-revoked',
+      name: 'revoked',
+      revoked: true,
+      revokedAt: new Date().toISOString(),
+    });
+
+    const result = await getTenantDetail(env.DB, 'detail-revoked');
+    expect(result.keys).toHaveLength(1);
+    expect(result.keys[0].name).toBe('active');
+  });
+});
+
+describe('DAL getTenantDetail -- periodLimit', () => {
+  it('periodLimit caps history results -- LIMIT fires with fewer rows than seeded', async () => {
+    await seedTenantWithTier(env.DB, 'tenant-hist');
+    // Seed 8 usage rows (more than the default limit of 6)
+    const periods = [
+      '2025-08', '2025-09', '2025-10', '2025-11', '2025-12',
+      '2026-01', '2026-02', '2026-03',
+    ];
+    for (const p of periods) {
+      await seedUsageCounter(env.DB, { tenantId: 'tenant-hist', period: p, captureCount: 1 });
+    }
+
+    const result3 = await getTenantDetail(env.DB, 'tenant-hist', 3);
+    expect(result3.usageHistory).toHaveLength(3);
+
+    const result6 = await getTenantDetail(env.DB, 'tenant-hist', 6);
+    expect(result6.usageHistory).toHaveLength(6);
+  });
+});
+
+// ===========================================================================
+// DAL: getOverviewStats
+// ===========================================================================
+
+describe('DAL getOverviewStats -- empty database', () => {
+  it('returns zeroed stats when database is empty', async () => {
+    const stats = await getOverviewStats(env.DB, '2026-03');
+    expect(stats.totalTenants).toBe(0);
+    expect(stats.totalCapturesCurrentPeriod).toBe(0);
+    expect(stats.totalCapturesAllTime).toBe(0);
+    expect(stats.totalStorageBytes).toBe(0);
+    expect(stats.totalEidasCaptures).toBe(0);
+    expect(stats.activeApiKeys).toBe(0);
+    expect(stats.tenantsByTier.free).toBe(0);
+    expect(stats.tenantsByTier.pro).toBe(0);
+    expect(stats.tenantsByBillingStatus.active).toBe(0);
+    expect(stats.tenantsByBillingStatus.gracePeriod).toBe(0);
+    expect(stats.tenantsByBillingStatus.blocked).toBe(0);
+  });
+});
+
+describe('DAL getOverviewStats -- tenant counts by tier', () => {
+  it('correctly counts tenants by tier', async () => {
+    await seedTenantWithTier(env.DB, 'free-1', { tier: 'free' });
+    await seedTenantWithTier(env.DB, 'free-2', { tier: 'free' });
+    await seedTenantWithTier(env.DB, 'pro-1', { tier: 'pro' });
+
+    const stats = await getOverviewStats(env.DB, '2026-03');
+    expect(stats.totalTenants).toBe(3);
+    expect(stats.tenantsByTier.free).toBe(2);
+    expect(stats.tenantsByTier.pro).toBe(1);
+  });
+});
+
+describe('DAL getOverviewStats -- tenant counts by billing status', () => {
+  it('correctly counts tenants by billing status', async () => {
+    await seedTenantWithTier(env.DB, 'active-1', { billingStatus: 'active' });
+    await seedTenantWithTier(env.DB, 'active-2', { billingStatus: 'active' });
+    await seedTenantWithTier(env.DB, 'grace-1', { billingStatus: 'grace_period' });
+    await seedTenantWithTier(env.DB, 'blocked-1', { billingStatus: 'blocked' });
+
+    const stats = await getOverviewStats(env.DB, '2026-03');
+    expect(stats.tenantsByBillingStatus.active).toBe(2);
+    expect(stats.tenantsByBillingStatus.gracePeriod).toBe(1);
+    expect(stats.tenantsByBillingStatus.blocked).toBe(1);
+  });
+});
+
+describe('DAL getOverviewStats -- capture aggregates', () => {
+  it('aggregates current period captures across all tenants', async () => {
+    await seedUsageCounter(env.DB, { tenantId: 'agg-a', period: '2026-03', captureCount: 30 });
+    await seedUsageCounter(env.DB, { tenantId: 'agg-b', period: '2026-03', captureCount: 20 });
+    // Different period -- should not appear in current-period total
+    await seedUsageCounter(env.DB, { tenantId: 'agg-a', period: '2026-02', captureCount: 100 });
+
+    const stats = await getOverviewStats(env.DB, '2026-03');
+    expect(stats.totalCapturesCurrentPeriod).toBe(50);
+  });
+
+  it('all-time captures includes all periods', async () => {
+    await seedUsageCounter(env.DB, { tenantId: 'alltime-a', period: '2026-03', captureCount: 10 });
+    await seedUsageCounter(env.DB, { tenantId: 'alltime-a', period: '2026-02', captureCount: 7 });
+    await seedUsageCounter(env.DB, { tenantId: 'alltime-b', period: '2026-01', captureCount: 3 });
+
+    const stats = await getOverviewStats(env.DB, '2026-03');
+    expect(stats.totalCapturesAllTime).toBe(20);
+  });
+
+  it('eIDAS captures aggregated correctly for current period', async () => {
+    await seedUsageCounter(env.DB, {
+      tenantId: 'eidas-tenant-a',
+      period: '2026-03',
+      captureCount: 10,
+      eidasCaptureCount: 4,
+    });
+    await seedUsageCounter(env.DB, {
+      tenantId: 'eidas-tenant-b',
+      period: '2026-03',
+      captureCount: 5,
+      eidasCaptureCount: 2,
+    });
+    // Different period eIDAS -- must NOT be included in current-period total
+    await seedUsageCounter(env.DB, {
+      tenantId: 'eidas-tenant-a',
+      period: '2026-02',
+      captureCount: 8,
+      eidasCaptureCount: 8,
+    });
+
+    const stats = await getOverviewStats(env.DB, '2026-03');
+    expect(stats.totalEidasCaptures).toBe(6);
+  });
+});
+
+describe('DAL getOverviewStats -- active API keys', () => {
+  it('active API keys count excludes revoked keys', async () => {
+    await seedApiKey(env.DB, 'wrl_live_' + 'n'.repeat(43), { tenantId: 'keys-tenant', name: 'active' });
+    await seedApiKey(env.DB, 'wrl_live_' + 'o'.repeat(43), {
+      tenantId: 'keys-tenant',
+      name: 'revoked',
+      revoked: true,
+      revokedAt: new Date().toISOString(),
+    });
+
+    const stats = await getOverviewStats(env.DB, '2026-03');
+    expect(stats.activeApiKeys).toBe(1);
+  });
+});
+
+// ===========================================================================
+// API: GET /v1/admin/tenants
+// ===========================================================================
+
+describe('GET /v1/admin/tenants -- auth', () => {
+  const ip = nextIp();
+
+  it('returns 401 without Authorization header', async () => {
+    const res = await SELF.fetch('https://worker.test/v1/admin/tenants', {
+      headers: { 'CF-Connecting-IP': ip },
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 with wrong admin key', async () => {
+    const res = await SELF.fetch('https://worker.test/v1/admin/tenants', {
+      headers: {
+        Authorization: 'Bearer wrong-key',
+        'CF-Connecting-IP': ip,
+      },
+    });
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('GET /v1/admin/tenants -- success', () => {
+  const ip = nextIp();
+
+  it('returns 200 with valid admin key', async () => {
+    const res = await adminGet('/v1/admin/tenants', ip);
+    expect(res.status).toBe(200);
+  });
+
+  it('response has data array and meta object', async () => {
+    const res = await adminGet('/v1/admin/tenants', ip);
+    const body = await res.json();
+    expect(Array.isArray(body.data)).toBe(true);
+    expect(typeof body.meta).toBe('object');
+    expect(typeof body.meta.totalTenants).toBe('number');
+    expect(typeof body.meta.period).toBe('string');
+  });
+
+  it('each tenant object has the expected fields', async () => {
+    await seedTenantWithTier(env.DB, 'shape-tenant');
+    const res = await adminGet('/v1/admin/tenants', ip);
+    const body = await res.json();
+    expect(body.data.length).toBeGreaterThanOrEqual(1);
+    const tenant = body.data.find(t => t.tenantId === 'shape-tenant');
+    expect(tenant).toBeDefined();
+    expect(Object.keys(tenant).sort()).toEqual(
+      ['billingStatus', 'createdAt', 'currentPeriod', 'eidasQualified',
+        'hasPaymentMethod', 'keyCount', 'quota', 'tenantId', 'tier'].sort(),
+    );
+  });
+
+  it('quota is computed correctly for free tier tenant without payment method', async () => {
+    await seedTenantWithTier(env.DB, 'free-quota-tenant', { tier: 'free', paymentMethodAddedAt: null });
+    const res = await adminGet('/v1/admin/tenants', ip);
+    const body = await res.json();
+    const tenant = body.data.find(t => t.tenantId === 'free-quota-tenant');
+    expect(tenant.quota.capturesPerMonth).toBe(200);
+  });
+
+  it('Content-Type is application/json', async () => {
+    const res = await adminGet('/v1/admin/tenants', ip);
+    expect(res.headers.get('Content-Type')).toContain('application/json');
+  });
+
+  it('Cache-Control is private, no-store', async () => {
+    const res = await adminGet('/v1/admin/tenants', ip);
+    expect(res.headers.get('Cache-Control')).toBe('private, no-store');
+  });
+});
+
+describe('GET /v1/admin/tenants -- period param validation', () => {
+  const ip = nextIp();
+
+  it('returns 400 for invalid period format', async () => {
+    const res = await SELF.fetch('https://worker.test/v1/admin/tenants?period=2026-3', {
+      headers: { Authorization: ADMIN_AUTH, 'CF-Connecting-IP': ip },
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('accepts valid YYYY-MM period param', async () => {
+    const res = await SELF.fetch('https://worker.test/v1/admin/tenants?period=2026-03', {
+      headers: { Authorization: ADMIN_AUTH, 'CF-Connecting-IP': ip },
+    });
+    expect(res.status).toBe(200);
+  });
+});
+
+// ===========================================================================
+// API: GET /v1/admin/tenants/:id
+// ===========================================================================
+
+describe('GET /v1/admin/tenants/:id -- auth', () => {
+  const ip = nextIp();
+
+  it('returns 401 without Authorization header', async () => {
+    const res = await SELF.fetch('https://worker.test/v1/admin/tenants/any-tenant', {
+      headers: { 'CF-Connecting-IP': ip },
+    });
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('GET /v1/admin/tenants/:id -- not found', () => {
+  const ip = nextIp();
+
+  it('returns 404 for nonexistent tenant', async () => {
+    const res = await adminGet('/v1/admin/tenants/no-such-tenant', ip);
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('GET /v1/admin/tenants/:id -- success', () => {
+  const ip = nextIp();
+
+  it('returns 200 with full tenant detail including usageHistory and keys arrays', async () => {
+    await seedTenantWithTier(env.DB, 'full-detail-tenant', {
+      tier: 'pro',
+      billingStatus: 'active',
+      stripeCustomerId: 'cus_abc',
+      eidasQualified: 1,
+    });
+    await seedUsageCounter(env.DB, {
+      tenantId: 'full-detail-tenant',
+      period: '2026-03',
+      captureCount: 15,
+      eidasCaptureCount: 7,
+    });
+    await seedApiKey(env.DB, 'wrl_live_' + 'g'.repeat(43), {
+      tenantId: 'full-detail-tenant',
+      name: 'detail-key',
+      scopes: ['capture'],
+    });
+
+    const res = await adminGet('/v1/admin/tenants/full-detail-tenant', ip);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.tenantId).toBe('full-detail-tenant');
+    expect(body.tier).toBe('pro');
+    expect(body.stripeCustomerId).toBe('cus_abc');
+    expect(Array.isArray(body.usageHistory)).toBe(true);
+    expect(body.usageHistory[0].captureCount).toBe(15);
+    expect(body.usageHistory[0].eidasCaptureCount).toBe(7);
+    expect(Array.isArray(body.keys)).toBe(true);
+    expect(body.keys[0].name).toBe('detail-key');
+    expect(body.keys[0].scopes).toEqual(['capture']);
+  });
+
+  it('keys array shows name, scopes, createdAt, createdBy', async () => {
+    await seedTenantWithTier(env.DB, 'keys-shape-tenant');
+    await seedApiKey(env.DB, 'wrl_live_' + 'h'.repeat(43), {
+      tenantId: 'keys-shape-tenant',
+      name: 'shape-key',
+      scopes: ['read'],
+    });
+
+    const res = await adminGet('/v1/admin/tenants/keys-shape-tenant', ip);
+    const body = await res.json();
+    expect(body.keys).toHaveLength(1);
+    const key = body.keys[0];
+    expect(Object.keys(key)).toEqual(expect.arrayContaining(['keyHash', 'name', 'scopes', 'createdAt', 'createdBy']));
+  });
+
+  it('Cache-Control is private, no-store', async () => {
+    await seedTenantWithTier(env.DB, 'cache-detail-tenant');
+    const res = await adminGet('/v1/admin/tenants/cache-detail-tenant', ip);
+    expect(res.headers.get('Cache-Control')).toBe('private, no-store');
+  });
+});
+
+describe('GET /v1/admin/tenants/:id -- periods param', () => {
+  const ip = nextIp();
+
+  it('periods defaults to 6 when omitted', async () => {
+    await seedTenantWithTier(env.DB, 'periods-default-tenant');
+    // Seed 8 periods to prove that only 6 are returned by default
+    const periods = [
+      '2025-08', '2025-09', '2025-10', '2025-11', '2025-12',
+      '2026-01', '2026-02', '2026-03',
+    ];
+    for (const p of periods) {
+      await seedUsageCounter(env.DB, {
+        tenantId: 'periods-default-tenant',
+        period: p,
+        captureCount: 1,
+      });
+    }
+
+    const res = await adminGet('/v1/admin/tenants/periods-default-tenant', ip);
+    const body = await res.json();
+    expect(body.usageHistory).toHaveLength(6);
+  });
+
+  it('periods=24 boundary value succeeds', async () => {
+    await seedTenantWithTier(env.DB, 'periods-max-tenant');
+    const res = await SELF.fetch('https://worker.test/v1/admin/tenants/periods-max-tenant?periods=24', {
+      headers: { Authorization: ADMIN_AUTH, 'CF-Connecting-IP': ip },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it('invalid periods param returns 400 (not silently coerced)', async () => {
+    await seedTenantWithTier(env.DB, 'periods-bad-tenant');
+    const res = await SELF.fetch('https://worker.test/v1/admin/tenants/periods-bad-tenant?periods=25', {
+      headers: { Authorization: ADMIN_AUTH, 'CF-Connecting-IP': ip },
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('periods=0 returns 400', async () => {
+    await seedTenantWithTier(env.DB, 'periods-zero-tenant');
+    const res = await SELF.fetch('https://worker.test/v1/admin/tenants/periods-zero-tenant?periods=0', {
+      headers: { Authorization: ADMIN_AUTH, 'CF-Connecting-IP': ip },
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+// ===========================================================================
+// API: GET /v1/admin/overview
+// ===========================================================================
+
+describe('GET /v1/admin/overview -- auth', () => {
+  const ip = nextIp();
+
+  it('returns 401 without Authorization header', async () => {
+    const res = await SELF.fetch('https://worker.test/v1/admin/overview', {
+      headers: { 'CF-Connecting-IP': ip },
+    });
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('GET /v1/admin/overview -- success', () => {
+  const ip = nextIp();
+
+  it('returns 200 with aggregate stats and expected fields', async () => {
+    const res = await adminGet('/v1/admin/overview', ip);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(Object.keys(body).sort()).toEqual(
+      [
+        'activeApiKeys',
+        'period',
+        'tenantsByBillingStatus',
+        'tenantsByTier',
+        'totalCapturesAllTime',
+        'totalCapturesCurrentPeriod',
+        'totalEidasCaptures',
+        'totalStorageBytes',
+        'totalTenants',
+      ].sort(),
+    );
+  });
+
+  it('tenantsByTier and tenantsByBillingStatus reflect seeded data', async () => {
+    await seedTenantWithTier(env.DB, 'ov-free-1', { tier: 'free', billingStatus: 'active' });
+    await seedTenantWithTier(env.DB, 'ov-pro-1', { tier: 'pro', billingStatus: 'active' });
+    await seedTenantWithTier(env.DB, 'ov-grace-1', { tier: 'free', billingStatus: 'grace_period' });
+
+    const res = await adminGet('/v1/admin/overview', ip);
+    const body = await res.json();
+    expect(body.totalTenants).toBe(3);
+    expect(body.tenantsByTier.free).toBe(2);
+    expect(body.tenantsByTier.pro).toBe(1);
+    expect(body.tenantsByBillingStatus.active).toBe(2);
+    expect(body.tenantsByBillingStatus.gracePeriod).toBe(1);
+  });
+
+  it('Cache-Control is private, no-store', async () => {
+    const res = await adminGet('/v1/admin/overview', ip);
+    expect(res.headers.get('Cache-Control')).toBe('private, no-store');
+  });
+});
+
+// ===========================================================================
+// Security
+// ===========================================================================
+
+describe('Security -- tenant key rejected on admin endpoints', () => {
+  const ip = nextIp();
+
+  it('tenant API key rejected on GET /v1/admin/tenants', async () => {
+    await seedApiKey(env.DB, TEST_TENANT_KEY, { tenantId: 'security-tenant' });
+    const res = await SELF.fetch('https://worker.test/v1/admin/tenants', {
+      headers: {
+        Authorization: `Bearer ${TEST_TENANT_KEY}`,
+        'CF-Connecting-IP': ip,
+      },
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('tenant API key rejected on GET /v1/admin/overview', async () => {
+    await seedApiKey(env.DB, TEST_TENANT_KEY, { tenantId: 'security-tenant' });
+    const res = await SELF.fetch('https://worker.test/v1/admin/overview', {
+      headers: {
+        Authorization: `Bearer ${TEST_TENANT_KEY}`,
+        'CF-Connecting-IP': ip,
+      },
+    });
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('Security -- no CORS headers on admin responses', () => {
+  const ip = nextIp();
+
+  it('GET /v1/admin/tenants does not include Access-Control-Allow-Origin', async () => {
+    const res = await adminGet('/v1/admin/tenants', ip);
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBeNull();
+  });
+
+  it('GET /v1/admin/overview does not include Access-Control-Allow-Origin', async () => {
+    const res = await adminGet('/v1/admin/overview', ip);
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBeNull();
+  });
+});

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -380,14 +380,40 @@ export async function seedUsageCounter(db, {
   captureCount = 0,
   storageBytes = 0,
   apiCallCount = 0,
+  eidasCaptureCount = 0,
 } = {}) {
   await db.batch([
     db.prepare('INSERT OR IGNORE INTO tenants (id) VALUES (?)').bind(tenantId),
     db.prepare(
-      `INSERT INTO usage_counters (tenant_id, period, capture_count, storage_bytes, api_call_count)
-       VALUES (?, ?, ?, ?, ?)`,
-    ).bind(tenantId, period, captureCount, storageBytes, apiCallCount),
+      `INSERT INTO usage_counters (tenant_id, period, capture_count, storage_bytes, api_call_count, eidas_capture_count)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    ).bind(tenantId, period, captureCount, storageBytes, apiCallCount, eidasCaptureCount),
   ]);
+}
+
+/**
+ * Seed a tenant row with customizable billing and tier columns.
+ * Uses INSERT OR REPLACE so the same tenantId can be updated in a test.
+ *
+ * @param {D1Database} db
+ * @param {string} tenantId
+ * @param {object} overrides  column overrides
+ */
+export async function seedTenantWithTier(db, tenantId, {
+  tier = 'free',
+  billingStatus = 'active',
+  stripeCustomerId = null,
+  paymentMethodAddedAt = null,
+  eidasQualified = 0,
+  config = null,
+  createdAt = new Date().toISOString(),
+} = {}) {
+  await db.prepare(
+    `INSERT OR REPLACE INTO tenants
+       (id, tier, billing_status, stripe_customer_id, payment_method_added_at, eidas_qualified, config, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).bind(tenantId, tier, billingStatus, stripeCustomerId, paymentMethodAddedAt, eidasQualified,
+    config ? JSON.stringify(config) : null, createdAt).run();
 }
 
 /**

--- a/test/mcp-sync.test.js
+++ b/test/mcp-sync.test.js
@@ -48,6 +48,9 @@ const EXCLUDED_OPERATIONS = {
   adminRevokeKey: 'admin auth boundary',
   adminGetUsage: 'admin auth boundary',
   adminCachePurge: 'admin auth boundary',
+  adminListTenants: 'admin auth boundary',
+  adminGetTenant: 'admin auth boundary',
+  adminGetOverview: 'admin auth boundary',
 
   // Infrastructure / health -- not meaningful as an MCP tool action
   getHealth: 'infrastructure/health',

--- a/test/ui-admin.test.js
+++ b/test/ui-admin.test.js
@@ -1,0 +1,120 @@
+// tva
+// Lightweight UI tests for the /admin HTML shell.
+// Uses SELF.fetch() for HTTP integration tests and direct import for unit tests.
+// Follows the same pattern as ui-dashboard.test.js.
+
+import { SELF } from 'cloudflare:test';
+import { describe, it, expect } from 'vitest';
+import { htmlAdminDashboard } from '../src/admin/admin-shell.js';
+
+// ---------------------------------------------------------------------------
+// htmlAdminDashboard() -- response headers
+// ---------------------------------------------------------------------------
+
+describe('htmlAdminDashboard -- response headers', () => {
+  it('returns a Response with status 200', () => {
+    const res = htmlAdminDashboard();
+    expect(res).toBeInstanceOf(Response);
+    expect(res.status).toBe(200);
+  });
+
+  it('Content-Type is text/html;charset=UTF-8', () => {
+    const res = htmlAdminDashboard();
+    expect(res.headers.get('Content-Type')).toBe('text/html;charset=UTF-8');
+  });
+
+  it('Cache-Control is no-store', () => {
+    const res = htmlAdminDashboard();
+    expect(res.headers.get('Cache-Control')).toBe('no-store');
+  });
+
+  it('CSP includes frame-ancestors none', () => {
+    const res = htmlAdminDashboard();
+    expect(res.headers.get('Content-Security-Policy')).toContain("frame-ancestors 'none'");
+  });
+
+  it('X-Frame-Options is DENY', () => {
+    const res = htmlAdminDashboard();
+    expect(res.headers.get('X-Frame-Options')).toBe('DENY');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// htmlAdminDashboard() -- HTML structure
+// ---------------------------------------------------------------------------
+
+describe('htmlAdminDashboard -- HTML structure', () => {
+  it('contains <!DOCTYPE html>', async () => {
+    const html = await htmlAdminDashboard().text();
+    expect(html).toContain('<!DOCTYPE html>');
+  });
+
+  it('contains <html lang="en">', async () => {
+    const html = await htmlAdminDashboard().text();
+    expect(html).toContain('<html lang="en">');
+  });
+
+  it('contains <div id="admin-app">', async () => {
+    const html = await htmlAdminDashboard().text();
+    expect(html).toContain('<div id="admin-app">');
+  });
+
+  it('contains <noscript> fallback', async () => {
+    const html = await htmlAdminDashboard().text();
+    expect(html).toContain('<noscript>');
+    expect(html).toContain('JavaScript Required');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// htmlAdminDashboard() -- no external resources
+// ---------------------------------------------------------------------------
+
+describe('htmlAdminDashboard -- no external resources', () => {
+  it('does not contain <script src=', async () => {
+    const html = await htmlAdminDashboard().text();
+    expect(html).not.toContain('<script src=');
+  });
+
+  it('does not contain <link rel="stylesheet" href=', async () => {
+    const html = await htmlAdminDashboard().text();
+    expect(html).not.toContain('<link rel="stylesheet" href=');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /admin -- SELF.fetch() integration tests
+// ---------------------------------------------------------------------------
+
+describe('GET /admin', () => {
+  it('returns 200', async () => {
+    const res = await SELF.fetch('https://worker.test/admin');
+    expect(res.status).toBe(200);
+  });
+
+  it('Content-Type is text/html;charset=UTF-8', async () => {
+    const res = await SELF.fetch('https://worker.test/admin');
+    expect(res.headers.get('Content-Type')).toBe('text/html;charset=UTF-8');
+  });
+
+  it('Cache-Control is no-store', async () => {
+    const res = await SELF.fetch('https://worker.test/admin');
+    expect(res.headers.get('Cache-Control')).toBe('no-store');
+  });
+
+  it('CSP header includes frame-ancestors none', async () => {
+    const res = await SELF.fetch('https://worker.test/admin');
+    expect(res.headers.get('Content-Security-Policy')).toContain("frame-ancestors 'none'");
+  });
+
+  it('X-Frame-Options is DENY', async () => {
+    const res = await SELF.fetch('https://worker.test/admin');
+    expect(res.headers.get('X-Frame-Options')).toBe('DENY');
+  });
+
+  it('response body contains <div id="admin-app">', async () => {
+    const res = await SELF.fetch('https://worker.test/admin');
+    const html = await res.text();
+    expect(html).toContain('<div id="admin-app">');
+  });
+});

--- a/wrangler.test.toml
+++ b/wrangler.test.toml
@@ -50,7 +50,7 @@ simple = { limit = 200, period = 60 }
 name = "ADMIN_RATE_LIMITER"
 type = "ratelimit"
 namespace_id = "1004"
-simple = { limit = 5, period = 60 }
+simple = { limit = 30, period = 60 }
 
 [[unsafe.bindings]]
 name = "CAPTURE_IP_GUARD"
@@ -176,7 +176,7 @@ simple = { limit = 200, period = 60 }
 name = "ADMIN_RATE_LIMITER"
 type = "ratelimit"
 namespace_id = "2004"
-simple = { limit = 5, period = 60 }
+simple = { limit = 30, period = 60 }
 
 [[env.staging.unsafe.bindings]]
 name = "CAPTURE_IP_GUARD"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -45,7 +45,7 @@ simple = { limit = 200, period = 60 }
 name = "ADMIN_RATE_LIMITER"
 type = "ratelimit"
 namespace_id = "1004"
-simple = { limit = 5, period = 60 }
+simple = { limit = 30, period = 60 }
 
 [[unsafe.bindings]]
 name = "CAPTURE_IP_GUARD"
@@ -255,7 +255,7 @@ simple = { limit = 200, period = 60 }
 name = "ADMIN_RATE_LIMITER"
 type = "ratelimit"
 namespace_id = "2004"
-simple = { limit = 5, period = 60 }
+simple = { limit = 30, period = 60 }
 
 [[env.staging.unsafe.bindings]]
 name = "CAPTURE_IP_GUARD"


### PR DESCRIPTION
## Summary

- Add operator admin dashboard at `GET /admin` with tenant list, per-tenant detail, and platform overview
- Three new API endpoints: `GET /v1/admin/tenants`, `GET /v1/admin/tenants/:id`, `GET /v1/admin/overview`
- Three new DAL functions in `src/db.js`: `listTenantsWithUsage`, `getTenantDetail`, `getOverviewStats`
- Admin auth gate with sessionStorage Bearer token, 3-strike throttle
- Vanilla JS SPA with hash routing, reuses design system tokens
- 43 new tests (DAL + API + security), all 1634 tests passing
- OpenAPI spec updated with all three new endpoints
- Admin rate limit raised from 5 to 30 req/60s

## Test plan

- [x] DAL functions: empty DB, single tenant, multi-tenant, period filtering
- [x] API endpoints: auth rejection, 200 response shapes, 404 tenant, parameter validation
- [x] Security: tenant key rejected on admin endpoints, no CORS headers
- [x] UI: HTML structure, CSP header, no external resources
- [x] OpenAPI: `npm run lint:api` passes
- [x] Full test suite: 63 files, 1634 passed, 0 failed

Resolves #203
