### PR TITLE
fix(email): align email link domains with sending domain

### DIFF
--- a/docs/evolution/0096-link-domain-matching/decisions.md
+++ b/docs/evolution/0096-link-domain-matching/decisions.md
@@ -1,0 +1,20 @@
+# Phase 0096 — Decisions
+
+## Replace Stripe URL with WRL billing page
+
+The `invoice_generated` email template received `hosted_invoice_url` from
+Stripe as its `portalUrl`. This caused Resend to flag the email for domain
+mismatch (link domain `invoice.stripe.com` doesn't match sending domain
+`webresourceledger.com`).
+
+Instead of building a redirect proxy (more infrastructure), we point the
+email link to the WRL billing UI (`/ui#billing`) which already shows
+invoices and links to Stripe from within the authenticated context. The
+user experience is equivalent — they land on their billing page where
+they can view and pay invoices.
+
+## Scope was smaller than expected
+
+Audit of all 7 email templates showed only one third-party URL: the
+`hosted_invoice_url` in `invoice_generated`. All other templates already
+use WRL domain URLs exclusively.

--- a/docs/evolution/0096-link-domain-matching/outcome.md
+++ b/docs/evolution/0096-link-domain-matching/outcome.md
@@ -1,0 +1,16 @@
+# Phase 0096 — Outcome
+
+## What changed
+
+One-line fix in `src/billing.js`: replaced `invoice?.hosted_invoice_url`
+with `${baseUrl}/ui#billing` for the `invoice_generated` email template
+data. All outbound WRL emails now exclusively link to WRL domain URLs.
+
+## PR
+
+Created by supervisor after killing a stalled nefario session (35 min,
+31 subagents, zero commits). The fix was a single line change.
+
+## Backlog changes
+
+None.

--- a/docs/evolution/0096-link-domain-matching/process.md
+++ b/docs/evolution/0096-link-domain-matching/process.md
@@ -1,0 +1,35 @@
+# Phase 0096 — Process
+
+## TL;DR
+
+The nefario session dispatched 31 subagents and spent 35 minutes researching
+without producing a single commit. The supervisor killed the session,
+audited the email templates directly, and found a one-line fix. Total
+supervisor time: ~10 minutes.
+
+## What happened
+
+The orchestrator launched phase 0096 normally. The nefario session entered
+Phase 1 (Meta-Plan), dispatched an Explore agent to audit email code, and
+then spiraled into increasingly deep subagent coordination — 31 subagents
+total, many of which were re-auditing the same code paths.
+
+After 35 minutes with zero file modifications beyond the initial timestamp,
+the supervisor diagnosed the stall via session JSONL inspection and killed
+the process.
+
+## Supervisor fix
+
+The supervisor:
+1. Audited all 7 email templates for third-party URLs
+2. Found exactly one: `hosted_invoice_url` from Stripe in the
+   `invoice_generated` notification dispatch (billing.js:380)
+3. Replaced it with the WRL billing page URL (`/ui#billing`)
+4. Verified all other email templates already use WRL domain URLs
+5. Created the PR with evolution log
+
+## Lesson
+
+Simple bug fixes don't need nefario orchestration. The phase prompt should
+have specified `--skip-nefario` or the orchestrator should detect when a
+phase is a straightforward code fix vs. a feature build.

--- a/docs/evolution/0096-link-domain-matching/prompt.md
+++ b/docs/evolution/0096-link-domain-matching/prompt.md
@@ -1,0 +1,7 @@
+# Phase 0096 — Align email link domains with sending domain
+
+Issue: #216
+
+Ensure all links in outbound WRL emails use the WRL sending domain instead
+of third-party domains (e.g., invoice.stripe.com), so Resend's deliverability
+checks don't flag domain mismatches.

--- a/src/billing.js
+++ b/src/billing.js
@@ -377,7 +377,7 @@ async function handleInvoiceFinalized(event, env, ctx) {
     amountFormatted,
     currency,
     period,
-    portalUrl: invoice?.hosted_invoice_url || `${baseUrl}/ui#billing`,
+    portalUrl: `${baseUrl}/ui#billing`,
   }).catch(err => log(env, 4, 'email', { event: 'email.dispatch_error', error: err?.message, tenantId: tenant.id })));
 
   ctx.waitUntil(log(env, 3, 'billing', {


### PR DESCRIPTION
## Summary

- Replace `invoice?.hosted_invoice_url` (Stripe domain) with WRL billing page URL in `invoice_generated` email notifications
- All 7 email templates now exclusively link to WRL domain URLs
- Prevents Resend deliverability flags for sending domain / link domain mismatch

## Test plan

- [x] Existing email dispatch tests pass (the fix is in billing.js template data, not in template rendering)
- [x] Audit confirmed all other templates already use WRL domain URLs

Resolves #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)
