### PR TITLE
fix(docs,landing): flip comparison tables to features-as-rows orientation

### DIFF
--- a/docs/evolution/0097-table-flip/decisions.md
+++ b/docs/evolution/0097-table-flip/decisions.md
@@ -1,0 +1,57 @@
+# Phase 0097 Decisions
+
+## 1. Table orientation: features-as-rows, tools-as-columns
+
+**Chosen**: Transpose both tables so features are rows and tools are columns.
+
+**Rationale**: Standard SaaS comparison pattern. Evaluators think feature-first
+("who has RFC 3161 timestamps?"). WRL's column becomes a vertical stripe of
+green badges. The strongest differentiators (Crypto Signing, Independent
+Timestamps, Public Verification, eIDAS) are placed as the first rows.
+
+**Alternative considered**: Keep tools-as-rows. Rejected because the old layout
+required readers to scan horizontally across a row to compare one tool's
+capabilities, which is harder to parse when there are 7+ feature columns.
+
+## 2. Wide content modifier vs. site-wide layout change
+
+**Chosen**: Scoped `docs-content--wide` CSS class applied via front matter flag.
+
+**Rationale**: The 42rem max-width is correct for prose readability on all other
+docs pages. Only the compare page needs more room. A front matter flag
+(`wideContent: true`) keeps the change scoped to one page without affecting
+the other 16 docs pages.
+
+**Alternative considered**: Remove max-width site-wide. Rejected because long
+prose lines become unreadable past ~80 characters.
+
+## 3. Card-stack breakpoint: 767px -> 1024px (docs only)
+
+**Chosen**: Raise the card-stack breakpoint on the docs comparison table from
+767px to 1024px.
+
+**Rationale**: At 768px, the sidebar (240px) leaves only ~528px for content.
+A 10-column table overflows badly in that range. Card-stacking at <= 1024px
+means tablet users get a readable card layout instead of a tiny scrollable
+table. The landing page breakpoint stays at 767px because its 5-column table
+fits better on wider viewports.
+
+## 4. Sticky first column for feature names
+
+**Chosen**: CSS `position: sticky; left: 0` on the feature name column (first
+column) in the docs comparison table.
+
+**Rationale**: With 10 tool columns, horizontal scrolling is expected on
+viewports between 1025px and ~1400px. The reader needs to always see which
+feature row they are looking at. Sticky positioning is supported in all
+modern browsers and degrades gracefully.
+
+## 5. data-tool attribute for mobile card labels
+
+**Chosen**: Replace `data-label` with `data-tool` on `<td>` elements for the
+flipped table. The mobile card-stack uses `content: attr(data-tool)` to show
+the tool name before each cell's value.
+
+**Rationale**: In the old orientation, `data-label` showed the feature name.
+In the new orientation, the feature name is already the row header (card
+title). What the reader needs on mobile is the tool name for each cell.

--- a/docs/evolution/0097-table-flip/outcome.md
+++ b/docs/evolution/0097-table-flip/outcome.md
@@ -1,0 +1,36 @@
+# Phase 0097 Outcome
+
+## What was produced
+
+Flipped both comparison tables (landing page and docs site) from tools-as-rows
+to the standard features-as-rows orientation, and fixed the docs layout overflow.
+
+### Files changed
+
+- **`landing/public/index.html`** -- Comparison table transposed: 4 feature rows,
+  5 tool columns (WRL + 4 competitors). Uses `data-tool` attribute for mobile
+  card labels. WRL column highlighted with `comparison-highlight-col`.
+
+- **`landing/public/css/landing.css`** -- Added `.comparison-highlight-col` style.
+  Updated mobile card-stack `td::before` to use `attr(data-tool)` instead of
+  `attr(data-label)`.
+
+- **`site/content/compare.njk`** -- Comparison table transposed: 7 feature rows,
+  10 tool columns (WRL + 9 competitors). Added `wideContent: true` front matter
+  flag. Feature name column uses `comparison-sticky-col` for sticky positioning.
+  Feature rows ordered by WRL's strongest differentiators first: Crypto Signing,
+  Independent Timestamps, Public Verification, eIDAS, API Access, Standard Format,
+  Source Available.
+
+- **`site/_includes/layouts/doc.njk`** -- Conditional `docs-content--wide` class
+  based on `wideContent` front matter flag.
+
+- **`site/css/docs.css`** -- Added `docs-content--wide` modifier
+  (`max-width: calc(100vw - 240px - var(--space-12))`). Added
+  `.comparison-highlight-col` and `.comparison-sticky-col` styles. Raised
+  card-stack breakpoint from 767px to 1024px for the comparison table.
+
+### Backlog changes
+
+No backlog changes. This phase resolves Issue #233 which was a refinement of
+the Phase 0090 comparison table work. No new items were deferred or discovered.

--- a/docs/evolution/0097-table-flip/process.md
+++ b/docs/evolution/0097-table-flip/process.md
@@ -1,0 +1,58 @@
+# Phase 0097 Process
+
+## TL;DR
+
+Direct implementation (no multi-agent orchestration). Flipped both comparison
+tables from tools-as-rows to features-as-rows, added a scoped wide-content
+CSS modifier for the compare page, and raised the docs card-stack breakpoint
+from 767px to 1024px. Five files changed, zero tests needed (CSS/HTML only).
+
+## How the work was done
+
+This phase was executed as a single-agent task per orchestrator directive --
+the scope was narrow enough (CSS/HTML table restructuring) that multi-agent
+consultation would have been overhead without value.
+
+### Implementation sequence
+
+1. **Read the issue** (#233) to understand the three requirements: table flip,
+   wide content modifier, and raised breakpoint.
+
+2. **Analyzed existing table structure** in both `landing/public/index.html`
+   (5 tools x 4 features) and `site/content/compare.njk` (10 tools x 7
+   features). The old orientation had tools as rows and features as column
+   headers.
+
+3. **Transposed both tables manually** -- each tool's cells became a column,
+   each feature became a row. The landing page table is small enough (5x4)
+   that the transpose was straightforward. The docs table (10x7) required
+   careful data migration to avoid swapping cells.
+
+4. **Added `comparison-highlight-col`** CSS class to replace the old
+   `comparison-highlight` row class. In the new orientation, the WRL column
+   (not row) needs the highlight background.
+
+5. **Added sticky first column** on the docs table via `position: sticky;
+   left: 0`. The feature name column stays visible during horizontal scroll
+   on wide-enough viewports.
+
+6. **Added `docs-content--wide`** modifier class, gated by a `wideContent`
+   front matter flag in the doc layout template. Only `compare.njk` sets
+   this flag -- all other docs pages keep the 42rem prose column.
+
+7. **Raised card-stack breakpoint** in `docs.css` from `max-width: 767px` to
+   `max-width: 1024px`. The landing page breakpoint stays at 767px because
+   its 5-column table fits on tablets.
+
+8. **Switched `data-label` to `data-tool`** on table cells. In the old
+   orientation, mobile card-stack used `data-label` (feature name) as the
+   label before each cell. In the new orientation, the feature name is the
+   card title (row header), so the cell label needs to be the tool name
+   (`data-tool`).
+
+### What was NOT changed
+
+- No docs pages other than the compare page were affected
+- The sidebar remains present on the compare page
+- The landing page layout was not changed (it is already fine)
+- No test runs -- this is a CSS/HTML-only change with no runtime behavior

--- a/docs/evolution/0097-table-flip/prompt.md
+++ b/docs/evolution/0097-table-flip/prompt.md
@@ -1,0 +1,25 @@
+# Phase 0097: Flip comparison table to standard orientation and fix docs layout overflow
+
+Issue #233.
+
+## Task
+
+1. Flip comparison tables on both landing page and docs site from tools-as-rows
+   to the standard features-as-rows orientation (features as rows, tools as columns).
+2. Fix docs layout overflow by adding a `docs-content--wide` CSS modifier for the
+   compare page only.
+3. Raise the card-stack breakpoint on docs from 767px to 1024px to eliminate the
+   dead zone where tablet users see a horizontally-scrolling table.
+4. Add sticky first column on the docs comparison table so feature names remain
+   visible during horizontal scroll.
+
+## Rationale
+
+- Standard SaaS comparison pattern: options as columns, attributes as rows
+  (per Nielsen Norman Group research)
+- "Column of green" effect: WRL's column becomes a vertical stripe of green
+  badges the reader hits on every feature row
+- Narrative ordering: strongest differentiators (Crypto Signing, Independent
+  Timestamps, Public Verification) appear as the first rows
+- The 42rem content column is correct for prose readability but too narrow
+  for a 10-column comparison table

--- a/docs/evolution/README.md
+++ b/docs/evolution/README.md
@@ -104,3 +104,4 @@ software development.
 | [0093-admin-dashboard](0093-admin-dashboard/) | Operator admin dashboard: tenant list, per-tenant detail, platform overview, admin auth gate, 3 API endpoints (Issue #203) |
 | [0094-sign-in-button-contrast-fix](0094-sign-in-button-contrast-fix/) | Fix CSS specificity bug: Sign-in button text unreadable in landing page header, WCAG AA contrast failure (Issue #225) |
 | [0095-fix-toctou-swap-verified-email](0095-fix-toctou-swap-verified-email/) | Fix TOCTOU gap in swapVerifiedEmail() WHERE clause — pin pending_email = ? (Issue #222) |
+| [0097-table-flip](0097-table-flip/) | Flip comparison tables to standard features-as-rows orientation, fix docs layout overflow with scoped wide-content modifier (Issue #233) |

--- a/landing/public/css/landing.css
+++ b/landing/public/css/landing.css
@@ -506,12 +506,19 @@ body {
   font-size: var(--text-sm);
 }
 
+/* Row highlight (old tools-as-rows orientation) */
 .comparison-highlight {
   background: var(--color-surface-muted);
 }
 
 .comparison-highlight td,
 .comparison-highlight th {
+  font-weight: var(--weight-medium);
+}
+
+/* Column highlight (features-as-rows orientation) */
+.comparison-highlight-col {
+  background: var(--color-surface-muted);
   font-weight: var(--weight-medium);
 }
 
@@ -533,7 +540,8 @@ body {
   text-underline-offset: 2px;
 }
 
-/* Mobile card-stack for comparison table */
+/* Mobile card-stack for comparison table (features-as-rows) */
+/* Each feature row becomes a card; tool names shown via data-tool */
 /* Similar card-stack pattern in site/css/docs.css — contexts differ intentionally, do not merge */
 @media (max-width: 767px) {
   .comparison-table thead {
@@ -565,7 +573,7 @@ body {
     border-bottom: 1px solid var(--color-border-subtle);
   }
   .comparison-table td::before {
-    content: attr(data-label);
+    content: attr(data-tool);
     font-weight: var(--weight-medium);
     font-size: var(--text-xs);
     text-transform: uppercase;

--- a/landing/public/index.html
+++ b/landing/public/index.html
@@ -344,7 +344,7 @@
           </div>
 
         </div>
-        <p class="features-more"><a href="https://docs.webresourceledger.com/compare/">Full feature comparison across 9 tools &rarr;</a></p>
+        <p class="features-more"><a href="https://docs.webresourceledger.com/compare/">Full feature comparison across 10 tools &rarr;</a></p>
       </div>
     </section>
 
@@ -387,57 +387,55 @@
           <h2 id="compare-heading">How WRL Compares</h2>
         </div>
         <div class="comparison-table-wrapper">
-          <table class="comparison-table">
+          <table class="comparison-table comparison-table--flipped">
             <caption class="sr-only">Comparison of WRL with other web evidence tools</caption>
             <thead>
               <tr>
-                <th scope="col">Tool</th>
-                <th scope="col">Crypto Signing</th>
-                <th scope="col">Independent Timestamps</th>
-                <th scope="col">Public Verification</th>
-                <th scope="col">Open Format</th>
+                <th scope="col">Feature</th>
+                <th scope="col" class="comparison-highlight-col">WRL</th>
+                <th scope="col">Wayback Machine</th>
+                <th scope="col">PageFreezer</th>
+                <th scope="col">Webrecorder</th>
+                <th scope="col">Manual + Notary</th>
               </tr>
             </thead>
             <tbody>
-              <tr class="comparison-highlight">
-                <th scope="row">WRL</th>
-                <td data-label="Crypto Signing"><span class="badge badge--pass">Ed25519 (every capture)</span></td>
-                <td data-label="Independent Timestamps"><span class="badge badge--pass">RFC 3161 (default)</span></td>
-                <td data-label="Public Verification"><span class="badge badge--pass">Yes (no account)</span></td>
-                <td data-label="Open Format"><span class="badge badge--pass">WACZ</span></td>
+              <tr>
+                <th scope="row">Crypto Signing</th>
+                <td class="comparison-highlight-col" data-tool="WRL"><span class="badge badge--pass">Ed25519 (every capture)</span></td>
+                <td data-tool="Wayback Machine"><span class="badge badge--fail">No</span></td>
+                <td data-tool="PageFreezer"><span class="badge badge--skip">SHA-256</span></td>
+                <td data-tool="Webrecorder"><span class="badge badge--skip">Spec exists (not default)</span></td>
+                <td data-tool="Manual + Notary"><span class="badge badge--skip">Notary attestation</span></td>
               </tr>
               <tr>
-                <th scope="row">Wayback Machine</th>
-                <td data-label="Crypto Signing"><span class="badge badge--fail">No</span></td>
-                <td data-label="Independent Timestamps"><span class="badge badge--fail">No</span></td>
-                <td data-label="Public Verification"><span class="badge badge--skip">Public access (no crypto)</span></td>
-                <td data-label="Open Format"><span class="badge badge--pass">WARC</span></td>
+                <th scope="row">Independent Timestamps</th>
+                <td class="comparison-highlight-col" data-tool="WRL"><span class="badge badge--pass">RFC 3161 (default)</span></td>
+                <td data-tool="Wayback Machine"><span class="badge badge--fail">No</span></td>
+                <td data-tool="PageFreezer"><span class="badge badge--skip">Proprietary clock</span></td>
+                <td data-tool="Webrecorder"><span class="badge badge--skip">In spec (not default)</span></td>
+                <td data-tool="Manual + Notary"><span class="badge badge--skip">Notary timestamp</span></td>
               </tr>
               <tr>
-                <th scope="row">PageFreezer</th>
-                <td data-label="Crypto Signing"><span class="badge badge--skip">SHA-256</span></td>
-                <td data-label="Independent Timestamps"><span class="badge badge--skip">Proprietary clock</span></td>
-                <td data-label="Public Verification"><span class="badge badge--fail">No</span></td>
-                <td data-label="Open Format"><span class="badge badge--fail">PDF</span></td>
+                <th scope="row">Public Verification</th>
+                <td class="comparison-highlight-col" data-tool="WRL"><span class="badge badge--pass">Yes (no account)</span></td>
+                <td data-tool="Wayback Machine"><span class="badge badge--skip">Public access (no crypto)</span></td>
+                <td data-tool="PageFreezer"><span class="badge badge--fail">No</span></td>
+                <td data-tool="Webrecorder"><span class="badge badge--skip">Validator tools</span></td>
+                <td data-tool="Manual + Notary"><span class="badge badge--skip">Via notary records</span></td>
               </tr>
               <tr>
-                <th scope="row">Webrecorder</th>
-                <td data-label="Crypto Signing"><span class="badge badge--skip">Spec exists (not default)</span></td>
-                <td data-label="Independent Timestamps"><span class="badge badge--skip">In spec (not default)</span></td>
-                <td data-label="Public Verification"><span class="badge badge--skip">Validator tools</span></td>
-                <td data-label="Open Format"><span class="badge badge--pass">WACZ + WARC</span></td>
-              </tr>
-              <tr>
-                <th scope="row">Manual + Notary</th>
-                <td data-label="Crypto Signing"><span class="badge badge--skip">Notary attestation</span></td>
-                <td data-label="Independent Timestamps"><span class="badge badge--skip">Notary timestamp</span></td>
-                <td data-label="Public Verification"><span class="badge badge--skip">Via notary records</span></td>
-                <td data-label="Open Format"><span class="badge badge--fail">N/A</span></td>
+                <th scope="row">Open Format</th>
+                <td class="comparison-highlight-col" data-tool="WRL"><span class="badge badge--pass">WACZ</span></td>
+                <td data-tool="Wayback Machine"><span class="badge badge--pass">WARC</span></td>
+                <td data-tool="PageFreezer"><span class="badge badge--fail">PDF</span></td>
+                <td data-tool="Webrecorder"><span class="badge badge--pass">WACZ + WARC</span></td>
+                <td data-tool="Manual + Notary"><span class="badge badge--fail">N/A</span></td>
               </tr>
             </tbody>
           </table>
         </div>
-        <p class="compare-more"><a href="https://docs.webresourceledger.com/compare/">Full comparison of 9 tools across 8 criteria &rarr;</a></p>
+        <p class="compare-more"><a href="https://docs.webresourceledger.com/compare/">Full comparison across 10 tools and 7 criteria &rarr;</a></p>
       </div>
     </section>
 

--- a/site/_includes/layouts/doc.njk
+++ b/site/_includes/layouts/doc.njk
@@ -1,7 +1,7 @@
 ---
 layout: layouts/base.njk
 ---
-<div class="docs-content">
+<div class="docs-content{% if wideContent %} docs-content--wide{% endif %}">
   <article class="docs-prose">
     {{ content | safe }}
   </article>

--- a/site/content/compare.njk
+++ b/site/content/compare.njk
@@ -2,6 +2,7 @@
 layout: layouts/doc.njk
 title: How WRL Compares
 description: Feature comparison of WRL with Wayback Machine, PageFreezer, Webrecorder, and 6 other web archiving and evidence tools. Last verified March 2026.
+wideContent: true
 ---
 <h1>How WRL Compares</h1>
 
@@ -12,120 +13,114 @@ description: Feature comparison of WRL with Wayback Machine, PageFreezer, Webrec
 </p>
 
 <div class="comparison-table-wrapper">
-  <table class="comparison-table">
+  <table class="comparison-table comparison-table--flipped">
     <caption class="sr-only">Feature comparison of web evidence and archiving tools</caption>
     <thead>
       <tr>
-        <th scope="col">Tool</th>
-        <th scope="col">Cryptographic Signing</th>
-        <th scope="col">Independent Timestamps</th>
-        <th scope="col">Public Verification</th>
-        <th scope="col">API Access</th>
-        <th scope="col">Standard Format</th>
-        <th scope="col">eIDAS Qualified</th>
-        <th scope="col">Source</th>
+        <th scope="col" class="comparison-sticky-col">Feature</th>
+        <th scope="col" class="comparison-highlight-col">WRL</th>
+        <th scope="col">Wayback Machine</th>
+        <th scope="col">PageFreezer</th>
+        <th scope="col">Hanzo</th>
+        <th scope="col">Page Vault</th>
+        <th scope="col">MirrorWeb</th>
+        <th scope="col">Stillio</th>
+        <th scope="col">Archive-It</th>
+        <th scope="col">Webrecorder</th>
+        <th scope="col">Manual + Notary</th>
       </tr>
     </thead>
     <tbody>
-      <tr class="comparison-highlight">
-        <th scope="row">WRL</th>
-        <td data-label="Cryptographic Signing"><span class="badge badge--pass">Ed25519 (every capture)</span></td>
-        <td data-label="Independent Timestamps"><span class="badge badge--pass">RFC 3161 (DigiCert TSA)</span></td>
-        <td data-label="Public Verification"><span class="badge badge--pass">Yes (no account needed)</span></td>
-        <td data-label="API Access"><span class="badge badge--pass">REST API, MCP</span></td>
-        <td data-label="Standard Format"><span class="badge badge--pass">WACZ</span></td>
-        <td data-label="eIDAS Qualified"><span class="badge badge--pass">Optional</span></td>
-        <td data-label="Source"><span class="badge badge--pass">PolyForm Shield</span></td>
+      <tr>
+        <th scope="row" class="comparison-sticky-col">Cryptographic Signing</th>
+        <td class="comparison-highlight-col" data-tool="WRL"><span class="badge badge--pass">Ed25519 (every capture)</span></td>
+        <td data-tool="Wayback Machine"><span class="badge badge--fail">No</span></td>
+        <td data-tool="PageFreezer"><span class="badge badge--skip">SHA-256 signing</span></td>
+        <td data-tool="Hanzo"><span class="badge badge--skip">Not documented</span></td>
+        <td data-tool="Page Vault"><span class="badge badge--skip">SHA-256 hashing</span></td>
+        <td data-tool="MirrorWeb"><span class="badge badge--skip">SHA-1 per docs</span></td>
+        <td data-tool="Stillio"><span class="badge badge--fail">No</span></td>
+        <td data-tool="Archive-It"><span class="badge badge--fail">Checksums only</span></td>
+        <td data-tool="Webrecorder"><span class="badge badge--skip">WACZ-Auth spec (not default)</span></td>
+        <td data-tool="Manual + Notary"><span class="badge badge--skip">Notary attestation</span></td>
       </tr>
       <tr>
-        <th scope="row">Wayback Machine</th>
-        <td data-label="Cryptographic Signing"><span class="badge badge--fail">No</span></td>
-        <td data-label="Independent Timestamps"><span class="badge badge--fail">Crawl timestamps only</span></td>
-        <td data-label="Public Verification"><span class="badge badge--skip">Public access (no crypto)</span></td>
-        <td data-label="API Access"><span class="badge badge--skip">Yes (rate-limited)</span></td>
-        <td data-label="Standard Format"><span class="badge badge--pass">WARC</span></td>
-        <td data-label="eIDAS Qualified"><span class="badge badge--fail">No</span></td>
-        <td data-label="Source"><span class="badge badge--skip">Partial (some tools)</span></td>
+        <th scope="row" class="comparison-sticky-col">Independent Timestamps</th>
+        <td class="comparison-highlight-col" data-tool="WRL"><span class="badge badge--pass">RFC 3161 (DigiCert TSA)</span></td>
+        <td data-tool="Wayback Machine"><span class="badge badge--fail">Crawl timestamps only</span></td>
+        <td data-tool="PageFreezer"><span class="badge badge--skip">Stratum-1 clock (not RFC 3161)</span></td>
+        <td data-tool="Hanzo"><span class="badge badge--skip">Not documented</span></td>
+        <td data-tool="Page Vault"><span class="badge badge--skip">Internal timestamps</span></td>
+        <td data-tool="MirrorWeb"><span class="badge badge--skip">Timestamped (not RFC 3161)</span></td>
+        <td data-tool="Stillio"><span class="badge badge--fail">Metadata only</span></td>
+        <td data-tool="Archive-It"><span class="badge badge--fail">Crawl timestamps</span></td>
+        <td data-tool="Webrecorder"><span class="badge badge--skip">RFC 3161 in spec (not default)</span></td>
+        <td data-tool="Manual + Notary"><span class="badge badge--skip">Notary timestamp</span></td>
       </tr>
       <tr>
-        <th scope="row">PageFreezer</th>
-        <td data-label="Cryptographic Signing"><span class="badge badge--skip">SHA-256 signing</span></td>
-        <td data-label="Independent Timestamps"><span class="badge badge--skip">Stratum-1 clock (not RFC 3161)</span></td>
-        <td data-label="Public Verification"><span class="badge badge--fail">No (platform-only)</span></td>
-        <td data-label="API Access"><span class="badge badge--skip">Partner API</span></td>
-        <td data-label="Standard Format"><span class="badge badge--fail">PDF</span></td>
-        <td data-label="eIDAS Qualified"><span class="badge badge--fail">No</span></td>
-        <td data-label="Source"><span class="badge badge--fail">No</span></td>
+        <th scope="row" class="comparison-sticky-col">Public Verification</th>
+        <td class="comparison-highlight-col" data-tool="WRL"><span class="badge badge--pass">Yes (no account needed)</span></td>
+        <td data-tool="Wayback Machine"><span class="badge badge--skip">Public access (no crypto)</span></td>
+        <td data-tool="PageFreezer"><span class="badge badge--fail">No (platform-only)</span></td>
+        <td data-tool="Hanzo"><span class="badge badge--fail">No</span></td>
+        <td data-tool="Page Vault"><span class="badge badge--skip">Expert witness service</span></td>
+        <td data-tool="MirrorWeb"><span class="badge badge--fail">No (platform-only)</span></td>
+        <td data-tool="Stillio"><span class="badge badge--fail">No</span></td>
+        <td data-tool="Archive-It"><span class="badge badge--skip">Public access (no crypto)</span></td>
+        <td data-tool="Webrecorder"><span class="badge badge--skip">Validator tools exist</span></td>
+        <td data-tool="Manual + Notary"><span class="badge badge--skip">Via notary records</span></td>
       </tr>
       <tr>
-        <th scope="row">Hanzo</th>
-        <td data-label="Cryptographic Signing"><span class="badge badge--skip">Not documented</span></td>
-        <td data-label="Independent Timestamps"><span class="badge badge--skip">Not documented</span></td>
-        <td data-label="Public Verification"><span class="badge badge--fail">No</span></td>
-        <td data-label="API Access"><span class="badge badge--fail">No</span></td>
-        <td data-label="Standard Format"><span class="badge badge--pass">WARC</span></td>
-        <td data-label="eIDAS Qualified"><span class="badge badge--fail">No</span></td>
-        <td data-label="Source"><span class="badge badge--fail">No</span></td>
+        <th scope="row" class="comparison-sticky-col">eIDAS Qualified</th>
+        <td class="comparison-highlight-col" data-tool="WRL"><span class="badge badge--pass">Optional</span></td>
+        <td data-tool="Wayback Machine"><span class="badge badge--fail">No</span></td>
+        <td data-tool="PageFreezer"><span class="badge badge--fail">No</span></td>
+        <td data-tool="Hanzo"><span class="badge badge--fail">No</span></td>
+        <td data-tool="Page Vault"><span class="badge badge--fail">No</span></td>
+        <td data-tool="MirrorWeb"><span class="badge badge--fail">No</span></td>
+        <td data-tool="Stillio"><span class="badge badge--fail">No</span></td>
+        <td data-tool="Archive-It"><span class="badge badge--fail">No</span></td>
+        <td data-tool="Webrecorder"><span class="badge badge--fail">No</span></td>
+        <td data-tool="Manual + Notary"><span class="badge badge--skip">Separate framework</span></td>
       </tr>
       <tr>
-        <th scope="row">Page Vault</th>
-        <td data-label="Cryptographic Signing"><span class="badge badge--skip">SHA-256 hashing</span></td>
-        <td data-label="Independent Timestamps"><span class="badge badge--skip">Internal timestamps</span></td>
-        <td data-label="Public Verification"><span class="badge badge--skip">Expert witness service</span></td>
-        <td data-label="API Access"><span class="badge badge--fail">No</span></td>
-        <td data-label="Standard Format"><span class="badge badge--fail">Proprietary / PDF</span></td>
-        <td data-label="eIDAS Qualified"><span class="badge badge--fail">No</span></td>
-        <td data-label="Source"><span class="badge badge--fail">No</span></td>
+        <th scope="row" class="comparison-sticky-col">API Access</th>
+        <td class="comparison-highlight-col" data-tool="WRL"><span class="badge badge--pass">REST API, MCP</span></td>
+        <td data-tool="Wayback Machine"><span class="badge badge--skip">Yes (rate-limited)</span></td>
+        <td data-tool="PageFreezer"><span class="badge badge--skip">Partner API</span></td>
+        <td data-tool="Hanzo"><span class="badge badge--fail">No</span></td>
+        <td data-tool="Page Vault"><span class="badge badge--fail">No</span></td>
+        <td data-tool="MirrorWeb"><span class="badge badge--skip">Limited API</span></td>
+        <td data-tool="Stillio"><span class="badge badge--skip">Basic API</span></td>
+        <td data-tool="Archive-It"><span class="badge badge--pass">Yes (WASAPI)</span></td>
+        <td data-tool="Webrecorder"><span class="badge badge--pass">Browsertrix API</span></td>
+        <td data-tool="Manual + Notary"><span class="badge badge--fail">No</span></td>
       </tr>
       <tr>
-        <th scope="row">MirrorWeb</th>
-        <td data-label="Cryptographic Signing"><span class="badge badge--skip">SHA-1 per docs</span></td>
-        <td data-label="Independent Timestamps"><span class="badge badge--skip">Timestamped (not RFC 3161)</span></td>
-        <td data-label="Public Verification"><span class="badge badge--fail">No (platform-only)</span></td>
-        <td data-label="API Access"><span class="badge badge--skip">Limited API</span></td>
-        <td data-label="Standard Format"><span class="badge badge--pass">WARC</span></td>
-        <td data-label="eIDAS Qualified"><span class="badge badge--fail">No</span></td>
-        <td data-label="Source"><span class="badge badge--fail">No</span></td>
+        <th scope="row" class="comparison-sticky-col">Standard Format</th>
+        <td class="comparison-highlight-col" data-tool="WRL"><span class="badge badge--pass">WACZ</span></td>
+        <td data-tool="Wayback Machine"><span class="badge badge--pass">WARC</span></td>
+        <td data-tool="PageFreezer"><span class="badge badge--fail">PDF</span></td>
+        <td data-tool="Hanzo"><span class="badge badge--pass">WARC</span></td>
+        <td data-tool="Page Vault"><span class="badge badge--fail">Proprietary / PDF</span></td>
+        <td data-tool="MirrorWeb"><span class="badge badge--pass">WARC</span></td>
+        <td data-tool="Stillio"><span class="badge badge--fail">PNG / JPEG</span></td>
+        <td data-tool="Archive-It"><span class="badge badge--pass">WARC</span></td>
+        <td data-tool="Webrecorder"><span class="badge badge--pass">WACZ + WARC</span></td>
+        <td data-tool="Manual + Notary"><span class="badge badge--fail">N/A</span></td>
       </tr>
       <tr>
-        <th scope="row">Stillio</th>
-        <td data-label="Cryptographic Signing"><span class="badge badge--fail">No</span></td>
-        <td data-label="Independent Timestamps"><span class="badge badge--fail">Metadata only</span></td>
-        <td data-label="Public Verification"><span class="badge badge--fail">No</span></td>
-        <td data-label="API Access"><span class="badge badge--skip">Basic API</span></td>
-        <td data-label="Standard Format"><span class="badge badge--fail">PNG / JPEG</span></td>
-        <td data-label="eIDAS Qualified"><span class="badge badge--fail">No</span></td>
-        <td data-label="Source"><span class="badge badge--fail">No</span></td>
-      </tr>
-      <tr>
-        <th scope="row">Archive-It</th>
-        <td data-label="Cryptographic Signing"><span class="badge badge--fail">Checksums only</span></td>
-        <td data-label="Independent Timestamps"><span class="badge badge--fail">Crawl timestamps</span></td>
-        <td data-label="Public Verification"><span class="badge badge--skip">Public access (no crypto)</span></td>
-        <td data-label="API Access"><span class="badge badge--pass">Yes (WASAPI)</span></td>
-        <td data-label="Standard Format"><span class="badge badge--pass">WARC</span></td>
-        <td data-label="eIDAS Qualified"><span class="badge badge--fail">No</span></td>
-        <td data-label="Source"><span class="badge badge--fail">No</span></td>
-      </tr>
-      <tr>
-        <th scope="row">Webrecorder</th>
-        <td data-label="Cryptographic Signing"><span class="badge badge--skip">WACZ-Auth spec (not default)</span></td>
-        <td data-label="Independent Timestamps"><span class="badge badge--skip">RFC 3161 in spec (not default)</span></td>
-        <td data-label="Public Verification"><span class="badge badge--skip">Validator tools exist</span></td>
-        <td data-label="API Access"><span class="badge badge--pass">Browsertrix API</span></td>
-        <td data-label="Standard Format"><span class="badge badge--pass">WACZ + WARC</span></td>
-        <td data-label="eIDAS Qualified"><span class="badge badge--fail">No</span></td>
-        <td data-label="Source"><span class="badge badge--pass">Yes</span></td>
-      </tr>
-      <tr>
-        <th scope="row">Manual Screenshots + Notarization</th>
-        <td data-label="Cryptographic Signing"><span class="badge badge--skip">Notary attestation</span></td>
-        <td data-label="Independent Timestamps"><span class="badge badge--skip">Notary timestamp</span></td>
-        <td data-label="Public Verification"><span class="badge badge--skip">Via notary records</span></td>
-        <td data-label="API Access"><span class="badge badge--fail">No</span></td>
-        <td data-label="Standard Format"><span class="badge badge--fail">N/A</span></td>
-        <td data-label="eIDAS Qualified"><span class="badge badge--skip">Separate framework</span></td>
-        <td data-label="Source"><span class="badge badge--fail">N/A</span></td>
+        <th scope="row" class="comparison-sticky-col">Source Available</th>
+        <td class="comparison-highlight-col" data-tool="WRL"><span class="badge badge--pass">PolyForm Shield</span></td>
+        <td data-tool="Wayback Machine"><span class="badge badge--skip">Partial (some tools)</span></td>
+        <td data-tool="PageFreezer"><span class="badge badge--fail">No</span></td>
+        <td data-tool="Hanzo"><span class="badge badge--fail">No</span></td>
+        <td data-tool="Page Vault"><span class="badge badge--fail">No</span></td>
+        <td data-tool="MirrorWeb"><span class="badge badge--fail">No</span></td>
+        <td data-tool="Stillio"><span class="badge badge--fail">No</span></td>
+        <td data-tool="Archive-It"><span class="badge badge--fail">No</span></td>
+        <td data-tool="Webrecorder"><span class="badge badge--pass">Yes</span></td>
+        <td data-tool="Manual + Notary"><span class="badge badge--fail">N/A</span></td>
       </tr>
     </tbody>
   </table>

--- a/site/css/docs.css
+++ b/site/css/docs.css
@@ -251,9 +251,18 @@ body {
   box-sizing: border-box;
 }
 
+/* Wide content modifier — used by compare page to let the table breathe */
+.docs-content--wide {
+  max-width: calc(100vw - 240px - var(--space-12));
+}
+
 @media (max-width: 767px) {
   .docs-content {
     padding: var(--space-4) var(--space-4);
+  }
+
+  .docs-content--wide {
+    max-width: 100%;
   }
 }
 
@@ -557,6 +566,7 @@ pre:focus-within .copy-btn {
   font-size: var(--text-sm);
 }
 
+/* Row highlight (old tools-as-rows orientation) */
 .comparison-highlight {
   background: var(--color-surface-muted);
 }
@@ -566,9 +576,29 @@ pre:focus-within .copy-btn {
   font-weight: var(--weight-medium);
 }
 
-/* Mobile card-stack */
+/* Column highlight (features-as-rows orientation) */
+.comparison-highlight-col {
+  background: var(--color-surface-muted);
+  font-weight: var(--weight-medium);
+}
+
+/* Sticky first column — feature names stay visible during horizontal scroll */
+.comparison-sticky-col {
+  position: sticky;
+  left: 0;
+  z-index: 1;
+  background: var(--color-surface);
+}
+
+thead .comparison-sticky-col {
+  background: var(--color-surface-muted);
+  z-index: 2;
+}
+
+/* Card-stack breakpoint raised to 1024px — eliminates dead zone where
+   tablet users see a horizontally-scrolling table that doesn't fit */
 /* Similar pattern in landing/public/css/landing.css -- contexts differ, do not merge */
-@media (max-width: 767px) {
+@media (max-width: 1024px) {
   .comparison-table-wrapper {
     margin: var(--space-6) 0;
     padding: 0;
@@ -604,7 +634,7 @@ pre:focus-within .copy-btn {
   }
 
   .comparison-table td::before {
-    content: attr(data-label);
+    content: attr(data-tool);
     font-weight: var(--weight-medium);
     font-size: var(--text-xs);
     text-transform: uppercase;
@@ -623,5 +653,10 @@ pre:focus-within .copy-btn {
     padding: 0 0 var(--space-3);
     margin-bottom: var(--space-2);
     white-space: normal;
+  }
+
+  /* Disable sticky in card-stack mode */
+  .comparison-sticky-col {
+    position: static;
   }
 }


### PR DESCRIPTION
## Summary

- Flip both comparison tables (landing page and docs site) from tools-as-rows to the standard features-as-rows orientation — evaluators think feature-first, and WRL's column becomes a vertical stripe of green badges
- Add scoped `docs-content--wide` CSS modifier for the compare page via front matter flag — keeps 42rem prose column on all other docs pages
- Add sticky first column on docs comparison table so feature names remain visible during horizontal scroll
- Raise docs card-stack breakpoint from 767px to 1024px to eliminate the dead zone where tablet users see a tiny scrollable table

## Test plan

- [ ] Verify landing page comparison table renders correctly at desktop, tablet, and mobile widths
- [ ] Verify docs comparison table renders with sticky first column at wide viewports (>1024px)
- [ ] Verify docs comparison table card-stacks at <=1024px with tool names as card labels
- [ ] Verify other docs pages are unaffected (still use 42rem max-width)
- [ ] Check WRL column highlighting (light background) appears on both tables

Resolves #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)
