### PR TITLE
fix(landing): raise card-stack breakpoint and clean up comparison CSS

### DIFF
--- a/docs/evolution/0097-table-flip/outcome.md
+++ b/docs/evolution/0097-table-flip/outcome.md
@@ -30,6 +30,18 @@ to the standard features-as-rows orientation, and fixed the docs layout overflow
   `.comparison-highlight-col` and `.comparison-sticky-col` styles. Raised
   card-stack breakpoint from 767px to 1024px for the comparison table.
 
+### Follow-up (PR #246)
+
+A nefario orchestration session identified gaps in the initial implementation:
+
+- Landing card-stack breakpoint was not raised (still 767px vs docs' 1024px)
+- Dead `.comparison-highlight` CSS class was left in landing.css
+- `data-tool` attribute inconsistent with docs' `data-label`
+- Unused `comparison-table--flipped` class on table element
+- No WRL highlight in card-stack mode on landing page
+
+These were fixed in PR #246 (`fix/landing-comparison-cleanup`).
+
 ### Backlog changes
 
 No backlog changes. This phase resolves Issue #233 which was a refinement of

--- a/docs/evolution/README.md
+++ b/docs/evolution/README.md
@@ -104,5 +104,6 @@ software development.
 | [0093-admin-dashboard](0093-admin-dashboard/) | Operator admin dashboard: tenant list, per-tenant detail, platform overview, admin auth gate, 3 API endpoints (Issue #203) |
 | [0094-sign-in-button-contrast-fix](0094-sign-in-button-contrast-fix/) | Fix CSS specificity bug: Sign-in button text unreadable in landing page header, WCAG AA contrast failure (Issue #225) |
 | [0095-fix-toctou-swap-verified-email](0095-fix-toctou-swap-verified-email/) | Fix TOCTOU gap in swapVerifiedEmail() WHERE clause — pin pending_email = ? (Issue #222) |
+| [0096-link-domain-matching](0096-link-domain-matching/) | Align email link domains with WRL sending domain instead of third-party URLs (Issue #216) |
 | [0097-table-flip](0097-table-flip/) | Flip comparison tables to standard features-as-rows orientation, fix docs layout overflow with scoped wide-content modifier (Issue #233) |
 | [0098-docs-nav](0098-docs-nav/) | Add 2-level hierarchy to docs left rail navigation with section grouping (Issue #235) |

--- a/landing/public/css/landing.css
+++ b/landing/public/css/landing.css
@@ -506,17 +506,6 @@ body {
   font-size: var(--text-sm);
 }
 
-/* Row highlight (old tools-as-rows orientation) */
-.comparison-highlight {
-  background: var(--color-surface-muted);
-}
-
-.comparison-highlight td,
-.comparison-highlight th {
-  font-weight: var(--weight-medium);
-}
-
-/* Column highlight (features-as-rows orientation) */
 .comparison-highlight-col {
   background: var(--color-surface-muted);
   font-weight: var(--weight-medium);
@@ -541,9 +530,8 @@ body {
 }
 
 /* Mobile card-stack for comparison table (features-as-rows) */
-/* Each feature row becomes a card; tool names shown via data-tool */
 /* Similar card-stack pattern in site/css/docs.css — contexts differ intentionally, do not merge */
-@media (max-width: 767px) {
+@media (max-width: 1023px) {
   .comparison-table thead {
     position: absolute; width: 1px; height: 1px;
     overflow: hidden; clip: rect(0,0,0,0);
@@ -573,7 +561,7 @@ body {
     border-bottom: 1px solid var(--color-border-subtle);
   }
   .comparison-table td::before {
-    content: attr(data-tool);
+    content: attr(data-label);
     font-weight: var(--weight-medium);
     font-size: var(--text-xs);
     text-transform: uppercase;
@@ -583,6 +571,10 @@ body {
     margin-right: var(--space-3);
   }
   .comparison-table td:last-child { border-bottom: none; }
+  .comparison-table td.comparison-highlight-col {
+    background: var(--color-surface-muted);
+    border-radius: var(--radius-sm);
+  }
 }
 
 /* ===================================================================

--- a/landing/public/css/landing.css
+++ b/landing/public/css/landing.css
@@ -477,7 +477,8 @@ body {
 
 .comparison-table {
   width: 100%;
-  border-collapse: collapse;
+  border-collapse: separate;
+  border-spacing: 0;
 }
 
 .comparison-table th[scope="col"] {

--- a/landing/public/index.html
+++ b/landing/public/index.html
@@ -387,7 +387,7 @@
           <h2 id="compare-heading">How WRL Compares</h2>
         </div>
         <div class="comparison-table-wrapper">
-          <table class="comparison-table comparison-table--flipped">
+          <table class="comparison-table">
             <caption class="sr-only">Comparison of WRL with other web evidence tools</caption>
             <thead>
               <tr>
@@ -402,35 +402,35 @@
             <tbody>
               <tr>
                 <th scope="row">Crypto Signing</th>
-                <td class="comparison-highlight-col" data-tool="WRL"><span class="badge badge--pass">Ed25519 (every capture)</span></td>
-                <td data-tool="Wayback Machine"><span class="badge badge--fail">No</span></td>
-                <td data-tool="PageFreezer"><span class="badge badge--skip">SHA-256</span></td>
-                <td data-tool="Webrecorder"><span class="badge badge--skip">Spec exists (not default)</span></td>
-                <td data-tool="Manual + Notary"><span class="badge badge--skip">Notary attestation</span></td>
+                <td class="comparison-highlight-col" data-label="WRL"><span class="badge badge--pass">Ed25519 (every capture)</span></td>
+                <td data-label="Wayback Machine"><span class="badge badge--fail">No</span></td>
+                <td data-label="PageFreezer"><span class="badge badge--skip">SHA-256</span></td>
+                <td data-label="Webrecorder"><span class="badge badge--skip">Spec exists (not default)</span></td>
+                <td data-label="Manual + Notary"><span class="badge badge--skip">Notary attestation</span></td>
               </tr>
               <tr>
                 <th scope="row">Independent Timestamps</th>
-                <td class="comparison-highlight-col" data-tool="WRL"><span class="badge badge--pass">RFC 3161 (default)</span></td>
-                <td data-tool="Wayback Machine"><span class="badge badge--fail">No</span></td>
-                <td data-tool="PageFreezer"><span class="badge badge--skip">Proprietary clock</span></td>
-                <td data-tool="Webrecorder"><span class="badge badge--skip">In spec (not default)</span></td>
-                <td data-tool="Manual + Notary"><span class="badge badge--skip">Notary timestamp</span></td>
+                <td class="comparison-highlight-col" data-label="WRL"><span class="badge badge--pass">RFC 3161 (default)</span></td>
+                <td data-label="Wayback Machine"><span class="badge badge--fail">No</span></td>
+                <td data-label="PageFreezer"><span class="badge badge--skip">Proprietary clock</span></td>
+                <td data-label="Webrecorder"><span class="badge badge--skip">In spec (not default)</span></td>
+                <td data-label="Manual + Notary"><span class="badge badge--skip">Notary timestamp</span></td>
               </tr>
               <tr>
                 <th scope="row">Public Verification</th>
-                <td class="comparison-highlight-col" data-tool="WRL"><span class="badge badge--pass">Yes (no account)</span></td>
-                <td data-tool="Wayback Machine"><span class="badge badge--skip">Public access (no crypto)</span></td>
-                <td data-tool="PageFreezer"><span class="badge badge--fail">No</span></td>
-                <td data-tool="Webrecorder"><span class="badge badge--skip">Validator tools</span></td>
-                <td data-tool="Manual + Notary"><span class="badge badge--skip">Via notary records</span></td>
+                <td class="comparison-highlight-col" data-label="WRL"><span class="badge badge--pass">Yes (no account)</span></td>
+                <td data-label="Wayback Machine"><span class="badge badge--skip">Public access (no crypto)</span></td>
+                <td data-label="PageFreezer"><span class="badge badge--fail">No</span></td>
+                <td data-label="Webrecorder"><span class="badge badge--skip">Validator tools</span></td>
+                <td data-label="Manual + Notary"><span class="badge badge--skip">Via notary records</span></td>
               </tr>
               <tr>
                 <th scope="row">Open Format</th>
-                <td class="comparison-highlight-col" data-tool="WRL"><span class="badge badge--pass">WACZ</span></td>
-                <td data-tool="Wayback Machine"><span class="badge badge--pass">WARC</span></td>
-                <td data-tool="PageFreezer"><span class="badge badge--fail">PDF</span></td>
-                <td data-tool="Webrecorder"><span class="badge badge--pass">WACZ + WARC</span></td>
-                <td data-tool="Manual + Notary"><span class="badge badge--fail">N/A</span></td>
+                <td class="comparison-highlight-col" data-label="WRL"><span class="badge badge--pass">WACZ</span></td>
+                <td data-label="Wayback Machine"><span class="badge badge--pass">WARC</span></td>
+                <td data-label="PageFreezer"><span class="badge badge--fail">PDF</span></td>
+                <td data-label="Webrecorder"><span class="badge badge--pass">WACZ + WARC</span></td>
+                <td data-label="Manual + Notary"><span class="badge badge--fail">N/A</span></td>
               </tr>
             </tbody>
           </table>

--- a/site/_includes/layouts/doc.njk
+++ b/site/_includes/layouts/doc.njk
@@ -1,7 +1,7 @@
 ---
 layout: layouts/base.njk
 ---
-<div class="docs-content{% if wideContent %} docs-content--wide{% endif %}">
+<div class="docs-content{% if wide %} docs-content--wide{% endif %}">
   <article class="docs-prose">
     {{ content | safe }}
   </article>

--- a/site/content/compare.njk
+++ b/site/content/compare.njk
@@ -2,7 +2,7 @@
 layout: layouts/doc.njk
 title: How WRL Compares
 description: Feature comparison of WRL with Wayback Machine, PageFreezer, Webrecorder, and 6 other web archiving and evidence tools. Last verified March 2026.
-wideContent: true
+wide: true
 ---
 <h1>How WRL Compares</h1>
 
@@ -12,12 +12,12 @@ wideContent: true
   <a href="https://github.com/benpeter/web-resource-ledger/issues">open an issue</a>.
 </p>
 
-<div class="comparison-table-wrapper">
-  <table class="comparison-table comparison-table--flipped">
+<div class="comparison-table-wrapper" tabindex="0" role="region" aria-label="Comparison table, scroll for more tools">
+  <table class="comparison-table">
     <caption class="sr-only">Feature comparison of web evidence and archiving tools</caption>
     <thead>
       <tr>
-        <th scope="col" class="comparison-sticky-col">Feature</th>
+        <th scope="col">Feature</th>
         <th scope="col" class="comparison-highlight-col">WRL</th>
         <th scope="col">Wayback Machine</th>
         <th scope="col">PageFreezer</th>
@@ -27,100 +27,100 @@ wideContent: true
         <th scope="col">Stillio</th>
         <th scope="col">Archive-It</th>
         <th scope="col">Webrecorder</th>
-        <th scope="col">Manual + Notary</th>
+        <th scope="col">Manual Screenshots + Notarization</th>
       </tr>
     </thead>
     <tbody>
       <tr>
-        <th scope="row" class="comparison-sticky-col">Cryptographic Signing</th>
-        <td class="comparison-highlight-col" data-tool="WRL"><span class="badge badge--pass">Ed25519 (every capture)</span></td>
-        <td data-tool="Wayback Machine"><span class="badge badge--fail">No</span></td>
-        <td data-tool="PageFreezer"><span class="badge badge--skip">SHA-256 signing</span></td>
-        <td data-tool="Hanzo"><span class="badge badge--skip">Not documented</span></td>
-        <td data-tool="Page Vault"><span class="badge badge--skip">SHA-256 hashing</span></td>
-        <td data-tool="MirrorWeb"><span class="badge badge--skip">SHA-1 per docs</span></td>
-        <td data-tool="Stillio"><span class="badge badge--fail">No</span></td>
-        <td data-tool="Archive-It"><span class="badge badge--fail">Checksums only</span></td>
-        <td data-tool="Webrecorder"><span class="badge badge--skip">WACZ-Auth spec (not default)</span></td>
-        <td data-tool="Manual + Notary"><span class="badge badge--skip">Notary attestation</span></td>
+        <th scope="row">Cryptographic Signing</th>
+        <td class="comparison-highlight-col" data-label="WRL"><span class="badge badge--pass">Ed25519 (every capture)</span></td>
+        <td data-label="Wayback Machine"><span class="badge badge--fail">No</span></td>
+        <td data-label="PageFreezer"><span class="badge badge--skip">SHA-256 signing</span></td>
+        <td data-label="Hanzo"><span class="badge badge--skip">Not documented</span></td>
+        <td data-label="Page Vault"><span class="badge badge--skip">SHA-256 hashing</span></td>
+        <td data-label="MirrorWeb"><span class="badge badge--skip">SHA-1 per docs</span></td>
+        <td data-label="Stillio"><span class="badge badge--fail">No</span></td>
+        <td data-label="Archive-It"><span class="badge badge--fail">Checksums only</span></td>
+        <td data-label="Webrecorder"><span class="badge badge--skip">WACZ-Auth spec (not default)</span></td>
+        <td data-label="Manual Screenshots + Notarization"><span class="badge badge--skip">Notary attestation</span></td>
       </tr>
       <tr>
-        <th scope="row" class="comparison-sticky-col">Independent Timestamps</th>
-        <td class="comparison-highlight-col" data-tool="WRL"><span class="badge badge--pass">RFC 3161 (DigiCert TSA)</span></td>
-        <td data-tool="Wayback Machine"><span class="badge badge--fail">Crawl timestamps only</span></td>
-        <td data-tool="PageFreezer"><span class="badge badge--skip">Stratum-1 clock (not RFC 3161)</span></td>
-        <td data-tool="Hanzo"><span class="badge badge--skip">Not documented</span></td>
-        <td data-tool="Page Vault"><span class="badge badge--skip">Internal timestamps</span></td>
-        <td data-tool="MirrorWeb"><span class="badge badge--skip">Timestamped (not RFC 3161)</span></td>
-        <td data-tool="Stillio"><span class="badge badge--fail">Metadata only</span></td>
-        <td data-tool="Archive-It"><span class="badge badge--fail">Crawl timestamps</span></td>
-        <td data-tool="Webrecorder"><span class="badge badge--skip">RFC 3161 in spec (not default)</span></td>
-        <td data-tool="Manual + Notary"><span class="badge badge--skip">Notary timestamp</span></td>
+        <th scope="row">Independent Timestamps</th>
+        <td class="comparison-highlight-col" data-label="WRL"><span class="badge badge--pass">RFC 3161 (DigiCert TSA)</span></td>
+        <td data-label="Wayback Machine"><span class="badge badge--fail">Crawl timestamps only</span></td>
+        <td data-label="PageFreezer"><span class="badge badge--skip">Stratum-1 clock (not RFC 3161)</span></td>
+        <td data-label="Hanzo"><span class="badge badge--skip">Not documented</span></td>
+        <td data-label="Page Vault"><span class="badge badge--skip">Internal timestamps</span></td>
+        <td data-label="MirrorWeb"><span class="badge badge--skip">Timestamped (not RFC 3161)</span></td>
+        <td data-label="Stillio"><span class="badge badge--fail">Metadata only</span></td>
+        <td data-label="Archive-It"><span class="badge badge--fail">Crawl timestamps</span></td>
+        <td data-label="Webrecorder"><span class="badge badge--skip">RFC 3161 in spec (not default)</span></td>
+        <td data-label="Manual Screenshots + Notarization"><span class="badge badge--skip">Notary timestamp</span></td>
       </tr>
       <tr>
-        <th scope="row" class="comparison-sticky-col">Public Verification</th>
-        <td class="comparison-highlight-col" data-tool="WRL"><span class="badge badge--pass">Yes (no account needed)</span></td>
-        <td data-tool="Wayback Machine"><span class="badge badge--skip">Public access (no crypto)</span></td>
-        <td data-tool="PageFreezer"><span class="badge badge--fail">No (platform-only)</span></td>
-        <td data-tool="Hanzo"><span class="badge badge--fail">No</span></td>
-        <td data-tool="Page Vault"><span class="badge badge--skip">Expert witness service</span></td>
-        <td data-tool="MirrorWeb"><span class="badge badge--fail">No (platform-only)</span></td>
-        <td data-tool="Stillio"><span class="badge badge--fail">No</span></td>
-        <td data-tool="Archive-It"><span class="badge badge--skip">Public access (no crypto)</span></td>
-        <td data-tool="Webrecorder"><span class="badge badge--skip">Validator tools exist</span></td>
-        <td data-tool="Manual + Notary"><span class="badge badge--skip">Via notary records</span></td>
+        <th scope="row">Public Verification</th>
+        <td class="comparison-highlight-col" data-label="WRL"><span class="badge badge--pass">Yes (no account needed)</span></td>
+        <td data-label="Wayback Machine"><span class="badge badge--skip">Public access (no crypto)</span></td>
+        <td data-label="PageFreezer"><span class="badge badge--fail">No (platform-only)</span></td>
+        <td data-label="Hanzo"><span class="badge badge--fail">No</span></td>
+        <td data-label="Page Vault"><span class="badge badge--skip">Expert witness service</span></td>
+        <td data-label="MirrorWeb"><span class="badge badge--fail">No (platform-only)</span></td>
+        <td data-label="Stillio"><span class="badge badge--fail">No</span></td>
+        <td data-label="Archive-It"><span class="badge badge--skip">Public access (no crypto)</span></td>
+        <td data-label="Webrecorder"><span class="badge badge--skip">Validator tools exist</span></td>
+        <td data-label="Manual Screenshots + Notarization"><span class="badge badge--skip">Via notary records</span></td>
       </tr>
       <tr>
-        <th scope="row" class="comparison-sticky-col">eIDAS Qualified</th>
-        <td class="comparison-highlight-col" data-tool="WRL"><span class="badge badge--pass">Optional</span></td>
-        <td data-tool="Wayback Machine"><span class="badge badge--fail">No</span></td>
-        <td data-tool="PageFreezer"><span class="badge badge--fail">No</span></td>
-        <td data-tool="Hanzo"><span class="badge badge--fail">No</span></td>
-        <td data-tool="Page Vault"><span class="badge badge--fail">No</span></td>
-        <td data-tool="MirrorWeb"><span class="badge badge--fail">No</span></td>
-        <td data-tool="Stillio"><span class="badge badge--fail">No</span></td>
-        <td data-tool="Archive-It"><span class="badge badge--fail">No</span></td>
-        <td data-tool="Webrecorder"><span class="badge badge--fail">No</span></td>
-        <td data-tool="Manual + Notary"><span class="badge badge--skip">Separate framework</span></td>
+        <th scope="row">eIDAS Qualified Timestamps</th>
+        <td class="comparison-highlight-col" data-label="WRL"><span class="badge badge--pass">Optional</span></td>
+        <td data-label="Wayback Machine"><span class="badge badge--fail">No</span></td>
+        <td data-label="PageFreezer"><span class="badge badge--fail">No</span></td>
+        <td data-label="Hanzo"><span class="badge badge--fail">No</span></td>
+        <td data-label="Page Vault"><span class="badge badge--fail">No</span></td>
+        <td data-label="MirrorWeb"><span class="badge badge--fail">No</span></td>
+        <td data-label="Stillio"><span class="badge badge--fail">No</span></td>
+        <td data-label="Archive-It"><span class="badge badge--fail">No</span></td>
+        <td data-label="Webrecorder"><span class="badge badge--fail">No</span></td>
+        <td data-label="Manual Screenshots + Notarization"><span class="badge badge--skip">Separate framework</span></td>
       </tr>
       <tr>
-        <th scope="row" class="comparison-sticky-col">API Access</th>
-        <td class="comparison-highlight-col" data-tool="WRL"><span class="badge badge--pass">REST API, MCP</span></td>
-        <td data-tool="Wayback Machine"><span class="badge badge--skip">Yes (rate-limited)</span></td>
-        <td data-tool="PageFreezer"><span class="badge badge--skip">Partner API</span></td>
-        <td data-tool="Hanzo"><span class="badge badge--fail">No</span></td>
-        <td data-tool="Page Vault"><span class="badge badge--fail">No</span></td>
-        <td data-tool="MirrorWeb"><span class="badge badge--skip">Limited API</span></td>
-        <td data-tool="Stillio"><span class="badge badge--skip">Basic API</span></td>
-        <td data-tool="Archive-It"><span class="badge badge--pass">Yes (WASAPI)</span></td>
-        <td data-tool="Webrecorder"><span class="badge badge--pass">Browsertrix API</span></td>
-        <td data-tool="Manual + Notary"><span class="badge badge--fail">No</span></td>
+        <th scope="row">Open Standard Format</th>
+        <td class="comparison-highlight-col" data-label="WRL"><span class="badge badge--pass">WACZ</span></td>
+        <td data-label="Wayback Machine"><span class="badge badge--pass">WARC</span></td>
+        <td data-label="PageFreezer"><span class="badge badge--fail">PDF</span></td>
+        <td data-label="Hanzo"><span class="badge badge--pass">WARC</span></td>
+        <td data-label="Page Vault"><span class="badge badge--fail">Proprietary / PDF</span></td>
+        <td data-label="MirrorWeb"><span class="badge badge--pass">WARC</span></td>
+        <td data-label="Stillio"><span class="badge badge--fail">PNG / JPEG</span></td>
+        <td data-label="Archive-It"><span class="badge badge--pass">WARC</span></td>
+        <td data-label="Webrecorder"><span class="badge badge--pass">WACZ + WARC</span></td>
+        <td data-label="Manual Screenshots + Notarization"><span class="badge badge--fail">N/A</span></td>
       </tr>
       <tr>
-        <th scope="row" class="comparison-sticky-col">Standard Format</th>
-        <td class="comparison-highlight-col" data-tool="WRL"><span class="badge badge--pass">WACZ</span></td>
-        <td data-tool="Wayback Machine"><span class="badge badge--pass">WARC</span></td>
-        <td data-tool="PageFreezer"><span class="badge badge--fail">PDF</span></td>
-        <td data-tool="Hanzo"><span class="badge badge--pass">WARC</span></td>
-        <td data-tool="Page Vault"><span class="badge badge--fail">Proprietary / PDF</span></td>
-        <td data-tool="MirrorWeb"><span class="badge badge--pass">WARC</span></td>
-        <td data-tool="Stillio"><span class="badge badge--fail">PNG / JPEG</span></td>
-        <td data-tool="Archive-It"><span class="badge badge--pass">WARC</span></td>
-        <td data-tool="Webrecorder"><span class="badge badge--pass">WACZ + WARC</span></td>
-        <td data-tool="Manual + Notary"><span class="badge badge--fail">N/A</span></td>
+        <th scope="row">API Access</th>
+        <td class="comparison-highlight-col" data-label="WRL"><span class="badge badge--pass">REST API, MCP</span></td>
+        <td data-label="Wayback Machine"><span class="badge badge--skip">Yes (rate-limited)</span></td>
+        <td data-label="PageFreezer"><span class="badge badge--skip">Partner API</span></td>
+        <td data-label="Hanzo"><span class="badge badge--fail">No</span></td>
+        <td data-label="Page Vault"><span class="badge badge--fail">No</span></td>
+        <td data-label="MirrorWeb"><span class="badge badge--skip">Limited API</span></td>
+        <td data-label="Stillio"><span class="badge badge--skip">Basic API</span></td>
+        <td data-label="Archive-It"><span class="badge badge--pass">Yes (WASAPI)</span></td>
+        <td data-label="Webrecorder"><span class="badge badge--pass">Browsertrix API</span></td>
+        <td data-label="Manual Screenshots + Notarization"><span class="badge badge--fail">No</span></td>
       </tr>
       <tr>
-        <th scope="row" class="comparison-sticky-col">Source Available</th>
-        <td class="comparison-highlight-col" data-tool="WRL"><span class="badge badge--pass">PolyForm Shield</span></td>
-        <td data-tool="Wayback Machine"><span class="badge badge--skip">Partial (some tools)</span></td>
-        <td data-tool="PageFreezer"><span class="badge badge--fail">No</span></td>
-        <td data-tool="Hanzo"><span class="badge badge--fail">No</span></td>
-        <td data-tool="Page Vault"><span class="badge badge--fail">No</span></td>
-        <td data-tool="MirrorWeb"><span class="badge badge--fail">No</span></td>
-        <td data-tool="Stillio"><span class="badge badge--fail">No</span></td>
-        <td data-tool="Archive-It"><span class="badge badge--fail">No</span></td>
-        <td data-tool="Webrecorder"><span class="badge badge--pass">Yes</span></td>
-        <td data-tool="Manual + Notary"><span class="badge badge--fail">N/A</span></td>
+        <th scope="row">Source Available</th>
+        <td class="comparison-highlight-col" data-label="WRL"><span class="badge badge--pass">PolyForm Shield</span></td>
+        <td data-label="Wayback Machine"><span class="badge badge--skip">Partial (some tools)</span></td>
+        <td data-label="PageFreezer"><span class="badge badge--fail">No</span></td>
+        <td data-label="Hanzo"><span class="badge badge--fail">No</span></td>
+        <td data-label="Page Vault"><span class="badge badge--fail">No</span></td>
+        <td data-label="MirrorWeb"><span class="badge badge--fail">No</span></td>
+        <td data-label="Stillio"><span class="badge badge--fail">No</span></td>
+        <td data-label="Archive-It"><span class="badge badge--fail">No</span></td>
+        <td data-label="Webrecorder"><span class="badge badge--pass">Yes</span></td>
+        <td data-label="Manual Screenshots + Notarization"><span class="badge badge--fail">N/A</span></td>
       </tr>
     </tbody>
   </table>

--- a/site/css/docs.css
+++ b/site/css/docs.css
@@ -267,9 +267,8 @@ body {
   box-sizing: border-box;
 }
 
-/* Wide content modifier — used by compare page to let the table breathe */
 .docs-content--wide {
-  max-width: calc(100vw - 240px - var(--space-12));
+  max-width: none;
 }
 
 @media (max-width: 767px) {
@@ -277,9 +276,6 @@ body {
     padding: var(--space-4) var(--space-4);
   }
 
-  .docs-content--wide {
-    max-width: 100%;
-  }
 }
 
 /* ------------------------------------------------------------------ */
@@ -552,8 +548,8 @@ pre:focus-within .copy-btn {
 
 .comparison-table {
   width: 100%;
-  min-width: 800px;
-  border-collapse: collapse;
+  border-collapse: separate;
+  border-spacing: 0;
 }
 
 .comparison-table th[scope="col"] {
@@ -582,39 +578,28 @@ pre:focus-within .copy-btn {
   font-size: var(--text-sm);
 }
 
-/* Row highlight (old tools-as-rows orientation) */
-.comparison-highlight {
-  background: var(--color-surface-muted);
-}
-
-.comparison-highlight td,
-.comparison-highlight th {
-  font-weight: var(--weight-medium);
-}
-
-/* Column highlight (features-as-rows orientation) */
 .comparison-highlight-col {
   background: var(--color-surface-muted);
   font-weight: var(--weight-medium);
 }
 
-/* Sticky first column — feature names stay visible during horizontal scroll */
-.comparison-sticky-col {
+/* Sticky feature-name column */
+.comparison-table th[scope="row"],
+.comparison-table thead th:first-child {
   position: sticky;
   left: 0;
   z-index: 1;
   background: var(--color-surface);
 }
 
-thead .comparison-sticky-col {
+.comparison-table thead th:first-child {
   background: var(--color-surface-muted);
   z-index: 2;
 }
 
-/* Card-stack breakpoint raised to 1024px — eliminates dead zone where
-   tablet users see a horizontally-scrolling table that doesn't fit */
+/* Mobile card-stack */
 /* Similar pattern in landing/public/css/landing.css -- contexts differ, do not merge */
-@media (max-width: 1024px) {
+@media (max-width: 1023px) {
   .comparison-table-wrapper {
     margin: var(--space-6) 0;
     padding: 0;
@@ -650,7 +635,7 @@ thead .comparison-sticky-col {
   }
 
   .comparison-table td::before {
-    content: attr(data-tool);
+    content: attr(data-label);
     font-weight: var(--weight-medium);
     font-size: var(--text-xs);
     text-transform: uppercase;
@@ -671,8 +656,8 @@ thead .comparison-sticky-col {
     white-space: normal;
   }
 
-  /* Disable sticky in card-stack mode */
-  .comparison-sticky-col {
-    position: static;
+  .comparison-table td.comparison-highlight-col {
+    background: var(--color-surface-muted);
+    border-radius: var(--radius-sm);
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to #244 (which resolved #233). The landing page comparison table had several gaps from the initial implementation:

- **Card-stack breakpoint not raised**: Landing page was still at 767px while docs was raised to 1024px. Tablets showed a horizontally-scrolling table that didn't fit. Now raised to 1023px.
- **Dead CSS removed**: Old `.comparison-highlight` class (row-based highlight from tools-as-rows era) was unused but still in the stylesheet.
- **`data-tool` → `data-label`**: Landing page used a different attribute name than the docs table. Unified to `data-label` for consistency.
- **Unused class removed**: `comparison-table--flipped` modifier class on the table element had no corresponding CSS rules.
- **WRL highlight in card-stack**: Added subtle background on WRL entries in card-stack mode (matches docs behavior).

Net change: -8 lines (removed dead CSS, cleaned up attribute names).

## Test plan

- [ ] Verify landing comparison table card-stacks at tablet widths (768px-1023px) instead of showing tiny scrollable table
- [ ] Verify card-stack labels still appear (now using `data-label` instead of `data-tool`)
- [ ] Verify WRL entries have subtle highlight in card-stack mode
- [ ] Verify no visual regression at desktop widths
