### PR TITLE
feat: Coralogix pageview counter on landing and docs

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -8,6 +8,7 @@ on:
       - 'openapi.yaml'
       - 'src/design-system.css'
       - 'src/pirsch.js'
+      - 'src/log.js'
   workflow_dispatch:
 
 # Note: CLOUDFLARE_API_TOKEN must have Workers Scripts:Edit and Workers Routes:Edit
@@ -72,5 +73,7 @@ jobs:
           command: deploy
           secrets: |
             PIRSCH_ACCESS_KEY
+            CORALOGIX_SEND_KEY
         env:
           PIRSCH_ACCESS_KEY: ${{ secrets.WRL_PIRSCH_ACCESS_KEY }}
+          CORALOGIX_SEND_KEY: ${{ secrets.WRL_CORALOGIX_SEND_KEY }}

--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -8,6 +8,7 @@ on:
       - 'src/design-system.css'
       - 'site/assets/*.svg'
       - 'src/pirsch.js'
+      - 'src/log.js'
   workflow_dispatch:
 
 # Note: CLOUDFLARE_API_TOKEN must have Workers Scripts:Edit and Workers Routes:Edit
@@ -40,5 +41,7 @@ jobs:
           command: deploy
           secrets: |
             PIRSCH_ACCESS_KEY
+            CORALOGIX_SEND_KEY
         env:
           PIRSCH_ACCESS_KEY: ${{ secrets.WRL_PIRSCH_ACCESS_KEY }}
+          CORALOGIX_SEND_KEY: ${{ secrets.WRL_CORALOGIX_SEND_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ docs/history/nefario-reports/2026-03-26-1001*
 test/e2e/.auth-state.json
 test-results/
 playwright-report/
+.worktrees/

--- a/landing/src/index.js
+++ b/landing/src/index.js
@@ -1,5 +1,6 @@
 // tva
 import { trackHit } from '../../src/pirsch.js';
+import { log } from '../../src/log.js';
 
 /**
  * Security headers for the landing site.
@@ -30,6 +31,14 @@ export default {
     }
 
     ctx.waitUntil(trackHit(request, env, { property: 'landing' }) ?? Promise.resolve());
+
+    const { pathname } = new URL(request.url);
+    ctx.waitUntil(log(env, 3, 'pageview', {
+      event: 'pageview',
+      subdomain: 'landing',
+      path: pathname,
+      status: response.status,
+    }) ?? Promise.resolve());
 
     return new Response(response.body, {
       status: response.status,

--- a/landing/wrangler.toml
+++ b/landing/wrangler.toml
@@ -12,6 +12,12 @@ routes = [
   { pattern = "www.webresourceledger.com", custom_domain = true }
 ]
 
+[vars]
+CORALOGIX_ENDPOINT = "https://ingress.eu2.coralogix.com/logs/v1/singles"
+APPLICATION_NAME = "wrl-landing"
+
+# CORALOGIX_SEND_KEY must be set via: wrangler secret put CORALOGIX_SEND_KEY
+
 # Security headers are now applied in src/index.js (Worker fetch handler).
 # Previously these were applied via Cloudflare Transform Rules since pure-asset
 # Workers cannot set response headers. With run_worker_first = true, the Worker

--- a/site/src/index.js
+++ b/site/src/index.js
@@ -1,5 +1,6 @@
 // tva
 import { trackHit } from '../../src/pirsch.js';
+import { log } from '../../src/log.js';
 
 /**
  * Security headers for the docs site.
@@ -29,6 +30,14 @@ export default {
     }
 
     ctx.waitUntil(trackHit(request, env, { property: 'docs' }) ?? Promise.resolve());
+
+    const { pathname } = new URL(request.url);
+    ctx.waitUntil(log(env, 3, 'pageview', {
+      event: 'pageview',
+      subdomain: 'docs',
+      path: pathname,
+      status: response.status,
+    }) ?? Promise.resolve());
 
     return new Response(response.body, {
       status: response.status,

--- a/site/wrangler.toml
+++ b/site/wrangler.toml
@@ -10,3 +10,9 @@ run_worker_first = true
 routes = [
   { pattern = "docs.webresourceledger.com", custom_domain = true }
 ]
+
+[vars]
+CORALOGIX_ENDPOINT = "https://ingress.eu2.coralogix.com/logs/v1/singles"
+APPLICATION_NAME = "wrl-docs"
+
+# CORALOGIX_SEND_KEY must be set via: wrangler secret put CORALOGIX_SEND_KEY


### PR DESCRIPTION
## Summary

- Add request-level Coralogix logging to landing and docs Workers for sanity-checking Pirsch analytics
- Logs `subdomain`, `path`, and `status` on every request via fire-and-forget `ctx.waitUntil()`
- Adds `CORALOGIX_ENDPOINT` and `APPLICATION_NAME` env vars to both wrangler.toml configs
- Injects `CORALOGIX_SEND_KEY` secret via GHA deploy workflows (same pattern as `PIRSCH_ACCESS_KEY`)
- No-op when `CORALOGIX_SEND_KEY` is absent (local dev, tests)

## Human actions required after merge

1. Add `WRL_CORALOGIX_SEND_KEY` as a GitHub Actions repository secret (same value as the API worker's `CORALOGIX_SEND_KEY`)
2. Trigger deploys via workflow_dispatch or wait for next landing/docs change

## Test plan

- [x] All 1643 existing tests pass (0 failures, 2 pre-existing skips)
- [ ] Manual: Verify logs appear in Coralogix under `wrl-landing` / `wrl-docs` application names after deploy
- [ ] Manual: Cross-reference Coralogix pageview counts with Pirsch dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)