### PR TITLE
feat(ui): compare any two captures in diff view

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -160,7 +160,7 @@ Deferred items with explicit activation triggers. Revisit when condition is met.
 |------|-----------|--------|
 | [consider] Schedule pause/resume (PATCH endpoint) | Schema supports it (`paused` column); expose when tenants need to pause without deleting | Phase 0059, lucy/margo scope review |
 | [consider] Schedule-specific webhook events | Beyond capture.complete/failed; when schedule monitoring is requested | Phase 0059, out-of-scope |
-| [consider] Change detection between scheduled captures | Diff/comparison of captures from same schedule; when a user requests it | Phase 0059, out-of-scope |
+| ~~[consider] Change detection between scheduled captures~~ | ~~Diff/comparison of captures from same schedule; when a user requests it~~ -- DONE (Phase 0106): UI capture picker for comparing any two captures of same URL, changeSummary/scheduleId surfaced in API (Issue #236) | Phase 0059, out-of-scope |
 
 ### Billing (R29 shipped -- extensions)
 

--- a/docs/evolution/0106-diff-view-any-two-captures/decisions.md
+++ b/docs/evolution/0106-diff-view-any-two-captures/decisions.md
@@ -1,0 +1,71 @@
+# Decisions
+
+## Root cause: changeSummary never surfaced in API
+
+The `changeSummary` field was computed and stored in D1 during scheduled
+captures, but `handleGetCapture` never included it in the response body.
+The existing "Compare with previous capture" link in the UI was therefore
+dead code -- it relied on `data.changeSummary.previousCaptureId` which was
+always undefined. Both frontend-minion and feature-dev:code-explorer
+independently identified this gap.
+
+**Decision**: Surface `changeSummary` and `scheduleId` in the GET capture
+response. Also add `scheduleId` to the list projection so the picker can
+show a "Scheduled" badge.
+
+## Single-selection vs two-selection model
+
+**Alternatives considered**:
+1. Two independent dropdowns (pick base and target separately)
+2. Current capture = implicit target, user picks a base (single-selection)
+3. Full comparison matrix page
+
+**Decision**: Option 2. The user is already viewing a capture detail page,
+so the current capture is the natural implicit target. Single-selection
+reduces cognitive load and avoids the "compare capture with itself" mistake.
+The diff URL ordering (older=base, newer=target) is handled automatically.
+
+## Inline picker vs modal/dropdown
+
+**Alternatives considered**:
+1. Modal dialog with capture list
+2. Native `<select>` dropdown
+3. Inline expandable section with toggle button
+
+**Decision**: Option 3 (inline picker). A modal would break flow in a
+single-page app. A `<select>` can't show rich information (dates, badges).
+The inline section with a toggle follows the existing disclosure pattern
+used elsewhere in the UI (e.g., accordion sections).
+
+## Accessibility approach
+
+**Alternatives considered**:
+1. Full ARIA listbox pattern with `role="listbox"`, `role="option"`,
+   keyboard arrow navigation
+2. Plain semantic HTML (`<ul>/<li>/<a>`)
+
+**Decision**: Option 2. Both margo and accessibility-minion agreed that a
+plain list of links is semantically correct (each item navigates to a diff
+page) and requires no custom keyboard handling. The ARIA listbox pattern is
+for selection widgets, not navigation lists. The toggle button uses
+`aria-expanded` and `aria-controls` for disclosure semantics.
+
+## Client-side exact URL filtering
+
+The `GET /v1/captures` endpoint uses `LIKE` prefix matching on URLs. When
+the picker fetches captures for a URL, prefix matches from other URLs
+could appear (e.g., `example.com/page` matching `example.com/page/sub`).
+
+**Decision**: Apply client-side exact URL filtering:
+`captures.filter(c => c.url === url)`. This keeps the API generic while
+ensuring the picker only shows captures of the exact same URL. The
+performance cost is negligible since the API already filters by URL prefix.
+
+## "Scheduled" badge on captures
+
+The picker shows which captures came from a schedule (vs manual submission).
+This helps users identify the automated monitoring context vs one-off
+captures.
+
+**Decision**: Show a "Scheduled" badge when `cap.scheduleId` is truthy.
+Uses the existing accent color design token.

--- a/docs/evolution/0106-diff-view-any-two-captures/outcome.md
+++ b/docs/evolution/0106-diff-view-any-two-captures/outcome.md
@@ -1,0 +1,71 @@
+# Outcome
+
+## What was built
+
+Users can now compare any two captures of the same URL from the capture
+detail page, not just the latest scheduled pair. The feature has two parts:
+
+### Backend: API response enrichment
+
+- `GET /v1/captures/{id}` now includes `changeSummary` (when present) and
+  `scheduleId` (when present) in the response body
+- `GET /v1/captures` list projection now includes `scheduleId` for complete
+  captures with a schedule
+
+These fields were already stored in D1 but never surfaced through the API.
+
+### Frontend: Capture comparison picker
+
+The dead "Changes" section on the capture detail page was replaced with a
+working "Compare Captures" section:
+
+- **Quick-compare link**: When `changeSummary.previousCaptureId` exists,
+  shows a direct link to compare with the previous scheduled capture
+- **Capture picker**: Toggle button expands an inline list of all captures
+  of the same URL, with lazy loading (20 per page) and pagination
+- **Date-ordered diff links**: Older capture is always the base (id1),
+  newer is the target (id2)
+- **"Scheduled" badge**: Captures from schedules show a visual indicator
+- **Current capture**: Shown but disabled (greyed out with "(current)")
+- **Accessibility**: `aria-expanded` toggle, `aria-live` status region,
+  Escape key closes picker, semantic `<ul>/<li>/<a>` markup
+- **Empty state**: If only one capture exists, the picker section hides
+
+### OpenAPI spec
+
+Added `changeSummary` schema to `CaptureRecord` component. The field was
+being returned but undocumented.
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `src/index.js` | Surface changeSummary and scheduleId in API responses |
+| `src/ui/ui-detail.js` | Replace dead Changes section with capture picker |
+| `src/ui/ui-css.js` | Styles for capture picker component |
+| `openapi.yaml` | Add changeSummary to CaptureRecord schema |
+| `test/fixtures.js` | Add changeSummary parameter to seedCapture |
+| `test/capture-retrieval.test.js` | Tests for changeSummary/scheduleId in responses |
+| `test/list-captures.test.js` | Test for scheduleId in list projection |
+
+## Test results
+
+All 1668 tests pass (65 test files). Three new tests added:
+- changeSummary presence in detail response
+- changeSummary/scheduleId absence when not set
+- scheduleId in list projection for scheduled captures
+
+## Surface consistency
+
+| Surface | Action |
+|---------|--------|
+| OpenAPI spec | Updated: added `changeSummary` to CaptureRecord schema |
+| Docs site | No update needed: no dashboard documentation page exists |
+| Landing page | No update needed: feature enhancement, not new capability |
+| MCP server | No update needed: `diff_captures` already accepts arbitrary IDs |
+| Legal pages | No update needed: no new data collection or processing |
+
+## Backlog changes
+
+- Marked done: "Change detection between scheduled captures" parking lot
+  item (Phase 0059 origin)

--- a/docs/evolution/0106-diff-view-any-two-captures/process.md
+++ b/docs/evolution/0106-diff-view-any-two-captures/process.md
@@ -1,0 +1,94 @@
+# Process: Phase 0106 -- Diff View for Any Two Captures
+
+## TL;DR
+
+Five specialist agents planned the feature in ~3 minutes, four reviewers
+approved with one ADVISE note, and execution produced 4 commits across
+7 files. The core discovery: `changeSummary` was already stored in D1 but
+never surfaced in the API, making the existing "Compare with previous"
+link dead code. The fix was backend-trivial (2 conditional fields in
+responses) but required a new UI component (capture picker with lazy
+loading, pagination, and accessibility). All 1668 tests pass.
+
+## Team
+
+### Phase 2 Specialists (Planning)
+
+- **frontend-minion**: Designed the capture picker UI component. Proposed
+  the inline expandable pattern over modal/dropdown, identified the need
+  for client-side exact URL filtering since the API uses prefix matching.
+
+- **feature-dev:code-explorer**: Deep-dived the existing codebase. Found
+  that `changeSummary` was computed and stored in D1 but never included in
+  API responses. Mapped the data flow from `computeChangeSummary` through
+  `db.js` `rowToCapture` to the missing projection in `handleGetCapture`.
+  This finding shaped the entire backend approach.
+
+- **accessibility-minion**: Provided ARIA guidance. Initially suggested
+  full listbox pattern (`role="listbox"`, `role="option"`, arrow key
+  navigation) but this was simplified during synthesis.
+
+- **ux-strategy-minion**: Recommended the single-selection model (current
+  capture = implicit target, user picks base). This resolved the "how do
+  users pick two captures?" question elegantly.
+
+- **api-spec-minion**: Flagged that `changeSummary` needed to be added to
+  the OpenAPI spec since it was being returned but undocumented.
+
+### Phase 3.5 Reviewers
+
+- **lucy**: APPROVE. Confirmed plan matches issue intent.
+- **margo**: ADVISE. Pushed back on the ARIA listbox pattern as
+  over-engineering -- a plain list of links is semantically correct for
+  navigation. This was adopted.
+- **gru**: APPROVE. No technology concerns.
+- **security-minion**: APPROVE. Confirmed no injection vectors since all
+  DOM is built via createElement/textContent.
+
+## Key Disagreements and Resolutions
+
+### ARIA listbox vs plain links
+
+accessibility-minion proposed `role="listbox"` with arrow key navigation.
+margo argued this was over-engineering since each item is a navigation
+link, not a selection widget. Synthesis sided with margo: plain
+`<ul>/<li>/<a>` is semantically correct and requires no custom keyboard
+handling. The toggle button still uses `aria-expanded`/`aria-controls`
+for the disclosure pattern.
+
+### Quick-compare link placement
+
+frontend-minion wanted the quick-compare link inside the picker. Synthesis
+placed it outside (above the toggle) so it's always visible without
+expanding the full list. This serves the common case (compare with
+previous scheduled capture) without requiring the picker.
+
+## Code Review Findings
+
+The code-reviewer agent found three issues:
+
+1. **Edge case: only current capture after filtering** (fixed). When all
+   captures in the response match the current ID, the picker showed "0
+   captures available" but left the toggle visible. Added a post-filter
+   check to hide the section.
+
+2. **Missing .catch() on res.json()** (fixed). The JSON parse promise had
+   no error handler, violating the "fail loudly" principle. Added a catch
+   that shows "Could not load captures."
+
+3. **Non-canonical schedule ID in test** (fixed). The test used
+   `'sched_test123'` which doesn't match the `sch_[a-f0-9]{32}` pattern
+   and also violated the FK constraint. Fixed by seeding a proper schedule
+   record first.
+
+## Human Interventions
+
+This phase ran in fully autonomous mode with no human intervention.
+Lucy agent handled all gate decisions.
+
+## Where to Read More
+
+- Specialist contributions: scratch directory (session-local, cleaned up)
+- Evolution log: `docs/evolution/0106-diff-view-any-two-captures/`
+- Backlog update: `docs/backlog.md` (line 163, scheduled capture
+  change detection marked done)

--- a/docs/evolution/0106-diff-view-any-two-captures/prompt.md
+++ b/docs/evolution/0106-diff-view-any-two-captures/prompt.md
@@ -1,0 +1,7 @@
+## Problem
+
+The diff view in the dashboard UI appears to only be available for the most recent scheduled capture run. Users should be able to compare any two captures of the same URL, not just the latest.
+
+## Expected
+
+Allow selecting any two captures for diff comparison, not just the latest scheduled run.

--- a/docs/evolution/README.md
+++ b/docs/evolution/README.md
@@ -112,3 +112,4 @@ software development.
 | [0103-swgde-docs-alignment](0103-swgde-docs-alignment/) | SWGDE Best Practices alignment mapping page and cross-references for forensic web capture documentation (Issue #259) |
 | [0104-segment-faq-landing-page](0104-segment-faq-landing-page/) | Segment-targeted FAQ expansion: 12 questions across legal, OSINT, compliance, brand protection with FAQPage JSON-LD (Issue #255) |
 | [0105-auto-investigate-coralogix-alerts](0105-auto-investigate-coralogix-alerts/) | Automated Coralogix alert investigation via webhook receiver, GitHub Actions, and Claude Code (Issue #139) |
+| [0106-diff-view-any-two-captures](0106-diff-view-any-two-captures/) | Compare any two captures of the same URL from the dashboard, not just the latest scheduled pair (Issue #236) |

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -629,6 +629,33 @@ components:
         scheduleId:
           type: ['string', 'null']
           description: ID of the schedule that triggered this capture, if any. Null for manually submitted captures.
+        changeSummary:
+          type: object
+          description: >
+            Summary of what changed compared to the previous scheduled capture of
+            the same URL. Present only on captures produced by a schedule that has
+            a prior capture to compare against.
+          properties:
+            changed:
+              type: boolean
+              description: True if any artifact changed.
+            previousCaptureId:
+              $ref: '#/components/schemas/CaptureId'
+            html:
+              type: object
+              properties:
+                changed:
+                  type: boolean
+            screenshot:
+              type: object
+              properties:
+                changed:
+                  type: boolean
+            headers:
+              type: object
+              properties:
+                changed:
+                  type: boolean
 
     CaptureSummary:
       type: object

--- a/src/index.js
+++ b/src/index.js
@@ -1573,6 +1573,7 @@ async function handleListCaptures(request, env, ctx) {
     if (r.status === 'complete') {
       summary.completedAt = r.completedAt;
       summary.renderQuality = r.renderQuality ?? 'full';
+      if (r.scheduleId) summary.scheduleId = r.scheduleId;
       if (r.wacz) {
         summary.timestamps = {
           standard: r.wacz.timestampStatus === 'present',
@@ -1743,6 +1744,9 @@ async function handleGetCapture(request, env, ctx, match) {
   if (record.captureSettings) {
     body.captureSettings = record.captureSettings;
   }
+
+  if (record.changeSummary) body.changeSummary = record.changeSummary;
+  if (record.scheduleId) body.scheduleId = record.scheduleId;
 
   if (record.wacz) {
     body.wacz = {

--- a/src/ui/ui-css.js
+++ b/src/ui/ui-css.js
@@ -1637,6 +1637,82 @@ input, select, textarea {
   border-radius: var(--radius-sm);
 }
 
+/* Compare captures picker */
+
+.compare-toggle {
+  display: block;
+  margin-top: var(--space-2);
+  font-size: var(--text-sm);
+}
+
+.compare-picker {
+  margin-top: var(--space-3);
+}
+
+.compare-picker-status {
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+  margin-bottom: var(--space-2);
+}
+
+.compare-picker-list {
+  list-style: none;
+  max-height: 320px;
+  overflow-y: auto;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+}
+
+.compare-picker-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--text-sm);
+  color: var(--color-text);
+  text-decoration: none;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.compare-picker-list li:last-child .compare-picker-item {
+  border-bottom: none;
+}
+
+a.compare-picker-item:hover {
+  background: var(--color-surface-hover);
+}
+
+a.compare-picker-item:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: -2px;
+  border-radius: var(--radius-sm);
+}
+
+.compare-picker-item--current {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.compare-picker-item-date {
+  flex: 1;
+}
+
+.compare-picker-item-badge {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  margin-left: var(--space-3);
+  white-space: nowrap;
+}
+
+.compare-picker-item-badge--scheduled {
+  color: var(--color-accent);
+}
+
+.compare-picker-more {
+  margin-top: var(--space-2);
+  font-size: var(--text-sm);
+}
+
 /* Polling row */
 
 .detail-poll-row {
@@ -1716,6 +1792,10 @@ input, select, textarea {
 
   .detail-section {
     padding: var(--space-4) var(--space-4);
+  }
+
+  .compare-picker-list {
+    max-height: 240px;
   }
 }
 

--- a/src/ui/ui-detail.js
+++ b/src/ui/ui-detail.js
@@ -161,6 +161,232 @@ function buildMetadataSection(data) {
 }
 
 // ---------------------------------------------------------------------------
+// Compare captures -- inline picker for arbitrary diff comparison
+// ---------------------------------------------------------------------------
+
+function buildCompareSection(currentId, data) {
+  var section = document.createElement('section');
+  section.className = 'section detail-section compare-section';
+
+  var h2 = document.createElement('h2');
+  h2.textContent = 'Compare Captures';
+  section.appendChild(h2);
+
+  // Quick-compare link (when changeSummary exists from scheduled capture)
+  if (data.changeSummary && data.changeSummary.previousCaptureId) {
+    var quickLink = document.createElement('a');
+    quickLink.href = '#/diff/' + data.changeSummary.previousCaptureId + '/' + currentId;
+    quickLink.className = 'detail-url-link';
+    quickLink.textContent = data.changeSummary.changed === true
+      ? 'Compare with previous capture (changes detected)'
+      : 'Compare with previous capture (no changes)';
+    section.appendChild(quickLink);
+  }
+
+  // Toggle button for the picker
+  var pickerId = 'compare-picker-' + currentId;
+  var toggleBtn = document.createElement('button');
+  toggleBtn.type = 'button';
+  toggleBtn.className = 'btn btn--ghost compare-toggle';
+  toggleBtn.textContent = 'Compare with another capture\u2026';
+  toggleBtn.setAttribute('aria-expanded', 'false');
+  toggleBtn.setAttribute('aria-controls', pickerId);
+  section.appendChild(toggleBtn);
+
+  // Picker container (hidden by default)
+  var picker = document.createElement('div');
+  picker.id = pickerId;
+  picker.className = 'compare-picker';
+  picker.hidden = true;
+
+  // Status region for screen readers
+  var statusRegion = document.createElement('div');
+  statusRegion.className = 'compare-picker-status';
+  statusRegion.setAttribute('aria-live', 'polite');
+  statusRegion.setAttribute('role', 'status');
+  picker.appendChild(statusRegion);
+
+  // Capture list
+  var list = document.createElement('ul');
+  list.className = 'compare-picker-list';
+  list.setAttribute('aria-label', 'Captures of this URL');
+  picker.appendChild(list);
+
+  // Load more button
+  var moreBtn = document.createElement('button');
+  moreBtn.type = 'button';
+  moreBtn.className = 'btn btn--ghost compare-picker-more';
+  moreBtn.textContent = 'Load more';
+  moreBtn.hidden = true;
+  picker.appendChild(moreBtn);
+
+  section.appendChild(picker);
+
+  // State
+  var loaded = false;
+  var cursor = null;
+
+  toggleBtn.addEventListener('click', function() {
+    var expanded = picker.hidden;
+    picker.hidden = !expanded;
+    toggleBtn.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+
+    if (expanded && !loaded) {
+      loaded = true;
+      loadCaptures(data.url, currentId, data.createdAt, list, moreBtn, statusRegion, null);
+    }
+
+    if (expanded) {
+      // Focus first non-current link in the list
+      setTimeout(function() {
+        var first = list.querySelector('a.compare-picker-item:not(.compare-picker-item--current)');
+        if (first) first.focus();
+      }, 0);
+    }
+  });
+
+  // Escape key closes the picker
+  picker.addEventListener('keydown', function(e) {
+    if (e.key === 'Escape') {
+      picker.hidden = true;
+      toggleBtn.setAttribute('aria-expanded', 'false');
+      toggleBtn.focus();
+    }
+  });
+
+  moreBtn.addEventListener('click', function() {
+    if (cursor) {
+      loadCaptures(data.url, currentId, data.createdAt, list, moreBtn, statusRegion, cursor);
+    }
+  });
+
+  // Store cursor setter on moreBtn for loadCaptures to update
+  moreBtn._setCursor = function(c) { cursor = c; };
+
+  return section;
+}
+
+function loadCaptures(url, currentId, currentCreatedAt, list, moreBtn, statusRegion, cursorParam) {
+  // Show loading state
+  if (!cursorParam) {
+    statusRegion.textContent = 'Loading captures\u2026';
+    var spinner = document.createElement('div');
+    spinner.className = 'detail-spinner';
+    spinner.setAttribute('aria-hidden', 'true');
+    list.parentNode.insertBefore(spinner, list);
+  }
+
+  var apiUrl = '/v1/captures?url=' + encodeURIComponent(url)
+    + '&status=complete&limit=20&sort=-created_at';
+  if (cursorParam) {
+    apiUrl += '&cursor=' + encodeURIComponent(cursorParam);
+  }
+
+  apiFetch(apiUrl).then(function(res) {
+    // Remove spinner if present
+    var sp = list.parentNode.querySelector('.detail-spinner');
+    if (sp) sp.remove();
+
+    if (!res || !res.ok) {
+      statusRegion.textContent = 'Could not load captures.';
+      return;
+    }
+    res.json().then(function(body) {
+      var captures = body.data || [];
+
+      // Client-side exact URL filter (API uses prefix matching)
+      captures = captures.filter(function(c) { return c.url === url; });
+
+      if (!cursorParam && captures.length === 0) {
+        // No other captures -- hide the entire section
+        var section = list.closest('.compare-section');
+        if (section) {
+          // Only hide the toggle and picker, keep quick-compare if present
+          var toggle = section.querySelector('.compare-toggle');
+          if (toggle) toggle.hidden = true;
+          list.parentNode.hidden = true;
+        }
+        statusRegion.textContent = '';
+        return;
+      }
+
+      var count = 0;
+      for (var i = 0; i < captures.length; i++) {
+        var cap = captures[i];
+        var li = document.createElement('li');
+
+        if (cap.id === currentId) {
+          // Current capture -- show but disabled
+          var span = document.createElement('span');
+          span.className = 'compare-picker-item compare-picker-item--current';
+
+          var dateSpan = document.createElement('span');
+          dateSpan.className = 'compare-picker-item-date';
+          dateSpan.textContent = formatDatetime(cap.createdAt);
+          span.appendChild(dateSpan);
+
+          var badge = document.createElement('span');
+          badge.className = 'compare-picker-item-badge';
+          badge.textContent = '(current)';
+          span.appendChild(badge);
+
+          li.appendChild(span);
+        } else {
+          // Selectable capture -- link to diff view
+          var a = document.createElement('a');
+          a.className = 'compare-picker-item';
+
+          // Order by date: base (older) first, target (newer) second
+          var currentDate = new Date(currentCreatedAt);
+          var capDate = new Date(cap.createdAt);
+          if (capDate < currentDate) {
+            a.href = '#/diff/' + cap.id + '/' + currentId;
+          } else {
+            a.href = '#/diff/' + currentId + '/' + cap.id;
+          }
+
+          var aDate = document.createElement('span');
+          aDate.className = 'compare-picker-item-date';
+          aDate.textContent = formatDatetime(cap.createdAt);
+          a.appendChild(aDate);
+
+          if (cap.scheduleId) {
+            var sBadge = document.createElement('span');
+            sBadge.className = 'compare-picker-item-badge compare-picker-item-badge--scheduled';
+            sBadge.textContent = 'Scheduled';
+            a.appendChild(sBadge);
+          }
+
+          li.appendChild(a);
+          count++;
+        }
+
+        list.appendChild(li);
+      }
+
+      // Update status for screen readers
+      if (!cursorParam) {
+        statusRegion.textContent = count + ' capture' + (count !== 1 ? 's' : '') + ' available';
+      } else {
+        statusRegion.textContent = count + ' more capture' + (count !== 1 ? 's' : '') + ' loaded';
+      }
+
+      // Pagination
+      if (body.pagination && body.pagination.hasMore && body.pagination.cursor) {
+        moreBtn.hidden = false;
+        moreBtn._setCursor(body.pagination.cursor);
+      } else {
+        moreBtn.hidden = true;
+      }
+    });
+  }).catch(function() {
+    var sp = list.parentNode.querySelector('.detail-spinner');
+    if (sp) sp.remove();
+    statusRegion.textContent = 'Could not load captures.';
+  });
+}
+
+// ---------------------------------------------------------------------------
 // Full (complete) capture layout
 // ---------------------------------------------------------------------------
 
@@ -277,27 +503,8 @@ function renderDetailComplete(view, id, data) {
   artifactsSection.appendChild(artList);
   card.appendChild(artifactsSection);
 
-  // Compare with previous (only when changeSummary has previousCaptureId)
-  if (data.changeSummary && data.changeSummary.previousCaptureId) {
-    var compareSection = document.createElement('section');
-    compareSection.className = 'section detail-section';
-
-    var compareH2 = document.createElement('h2');
-    compareH2.textContent = 'Changes';
-    compareSection.appendChild(compareH2);
-
-    var compareLink = document.createElement('a');
-    compareLink.href = '#/diff/' + data.changeSummary.previousCaptureId + '/' + id;
-    compareLink.className = 'detail-url-link';
-
-    if (data.changeSummary.changed === true) {
-      compareLink.textContent = 'Compare with previous capture (changes detected)';
-    } else {
-      compareLink.textContent = 'Compare with previous capture (no changes)';
-    }
-    compareSection.appendChild(compareLink);
-    card.appendChild(compareSection);
-  }
+  // Compare captures section
+  card.appendChild(buildCompareSection(id, data));
 
   // Verification link (only when WACZ is present)
   if (data.wacz) {

--- a/src/ui/ui-detail.js
+++ b/src/ui/ui-detail.js
@@ -364,6 +364,18 @@ function loadCaptures(url, currentId, currentCreatedAt, list, moreBtn, statusReg
         list.appendChild(li);
       }
 
+      // If all captures were the current one, hide the picker
+      if (count === 0 && !cursorParam) {
+        var section = list.closest('.compare-section');
+        if (section) {
+          var toggle = section.querySelector('.compare-toggle');
+          if (toggle) toggle.hidden = true;
+          list.parentNode.hidden = true;
+        }
+        statusRegion.textContent = '';
+        return;
+      }
+
       // Update status for screen readers
       if (!cursorParam) {
         statusRegion.textContent = count + ' capture' + (count !== 1 ? 's' : '') + ' available';
@@ -378,6 +390,8 @@ function loadCaptures(url, currentId, currentCreatedAt, list, moreBtn, statusReg
       } else {
         moreBtn.hidden = true;
       }
+    }).catch(function() {
+      statusRegion.textContent = 'Could not load captures.';
     });
   }).catch(function() {
     var sp = list.parentNode.querySelector('.detail-spinner');

--- a/test/capture-retrieval.test.js
+++ b/test/capture-retrieval.test.js
@@ -159,6 +159,32 @@ describe('GET /v1/captures/{id} -- tenant isolation', () => {
     expect(body.ip).toBeUndefined();
   });
 
+  it('response includes changeSummary when present', async () => {
+    const capId = 'cap_' + 'c'.repeat(32);
+    const prevId = 'cap_' + 'd'.repeat(32);
+    const cs = { changed: true, previousCaptureId: prevId, html: { changed: true }, screenshot: { changed: false }, headers: { changed: false } };
+    await seedCapture(env.DB, capId, {
+      tenantId: TENANT_A_ID,
+      status: 'complete',
+      completedAt: new Date().toISOString(),
+      artifacts: { screenshot: `captures/${capId}/screenshot.png`, html: `captures/${capId}/rendered.html` },
+      changeSummary: cs,
+      scheduleId: 'sched_test123',
+    });
+    const res = await SELF.fetch(`https://worker.test/v1/captures/${capId}`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.changeSummary).toEqual(cs);
+    expect(body.scheduleId).toBe('sched_test123');
+  });
+
+  it('response omits changeSummary and scheduleId when absent', async () => {
+    const res = await SELF.fetch(`https://worker.test/v1/captures/${CAP_A}`);
+    const body = await res.json();
+    expect(body.changeSummary).toBeUndefined();
+    expect(body.scheduleId).toBeUndefined();
+  });
+
   it('security headers present on 200', async () => {
     const res = await SELF.fetch(`https://worker.test/v1/captures/${CAP_A}`);
     expect(res.headers.get('Referrer-Policy')).toBe('no-referrer');

--- a/test/capture-retrieval.test.js
+++ b/test/capture-retrieval.test.js
@@ -14,6 +14,7 @@ import {
   cleanDb,
   seedApiKey,
   seedCapture,
+  seedSchedule,
   createTestSession,
   TEST_TENANT_KEY,
   TEST_TENANT_KEY_B,
@@ -160,22 +161,24 @@ describe('GET /v1/captures/{id} -- tenant isolation', () => {
   });
 
   it('response includes changeSummary when present', async () => {
+    const schedId = 'sch_' + 'e'.repeat(32);
     const capId = 'cap_' + 'c'.repeat(32);
     const prevId = 'cap_' + 'd'.repeat(32);
     const cs = { changed: true, previousCaptureId: prevId, html: { changed: true }, screenshot: { changed: false }, headers: { changed: false } };
+    await seedSchedule(env.DB, schedId, { tenantId: TENANT_A_ID });
     await seedCapture(env.DB, capId, {
       tenantId: TENANT_A_ID,
       status: 'complete',
       completedAt: new Date().toISOString(),
       artifacts: { screenshot: `captures/${capId}/screenshot.png`, html: `captures/${capId}/rendered.html` },
       changeSummary: cs,
-      scheduleId: 'sched_test123',
+      scheduleId: schedId,
     });
     const res = await SELF.fetch(`https://worker.test/v1/captures/${capId}`);
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.changeSummary).toEqual(cs);
-    expect(body.scheduleId).toBe('sched_test123');
+    expect(body.scheduleId).toBe(schedId);
   });
 
   it('response omits changeSummary and scheduleId when absent', async () => {

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -440,14 +440,15 @@ export async function seedCapture(db, id, {
   render = null,
   captureSettings = null,
   scheduleId = null,
+  changeSummary = null,
 } = {}) {
   await db.batch([
     db.prepare('INSERT OR IGNORE INTO tenants (id) VALUES (?)').bind(tenantId),
     db.prepare(
       `INSERT OR IGNORE INTO captures
          (id, tenant_id, url, ip, status, created_at, completed_at, failed_at,
-          error, retryable, render_quality, artifacts, wacz, render, capture_settings, schedule_id)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          error, retryable, render_quality, artifacts, wacz, render, capture_settings, schedule_id, change_summary)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     ).bind(
       id, tenantId, url, ip, status, createdAt, completedAt, failedAt,
       error,
@@ -458,6 +459,7 @@ export async function seedCapture(db, id, {
       render ? JSON.stringify(render) : null,
       captureSettings ? JSON.stringify(captureSettings) : null,
       scheduleId,
+      changeSummary ? JSON.stringify(changeSummary) : null,
     ),
   ]);
 }

--- a/test/list-captures.test.js
+++ b/test/list-captures.test.js
@@ -656,4 +656,17 @@ describe('GET /v1/captures -- schedule_id filter', () => {
     const body = await res.json();
     expect(body.detail).toContain('schedule_id');
   });
+
+  it('list projection includes scheduleId for complete captures with a schedule', async () => {
+    await completeCapture(env.DB, CAP_SCHED, {
+      screenshot: `captures/${CAP_SCHED}/screenshot.png`,
+      html: `captures/${CAP_SCHED}/rendered.html`,
+    });
+    const res = await listCaptures({ status: 'complete' });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const item = body.data.find(d => d.id === CAP_SCHED);
+    expect(item).toBeDefined();
+    expect(item.scheduleId).toBe(TEST_SCHEDULE_ID);
+  });
 });


### PR DESCRIPTION
## Summary

- Surface `changeSummary` and `scheduleId` in capture detail and list API responses (fields were stored but never returned)
- Add capture comparison picker on the detail page: users can now compare any two captures of the same URL, not just the latest scheduled pair
- Inline expandable picker with lazy loading, pagination, "Scheduled" badge, and full accessibility (ARIA toggle, screen reader status, Escape to close)
- Add `changeSummary` schema to OpenAPI spec (was undocumented)

## Test plan

- [x] All 1668 tests pass (3 new tests for changeSummary/scheduleId API coverage)
- [ ] Manual: navigate to a capture detail page with scheduled captures, verify "Compare with previous" quick-link works
- [ ] Manual: expand "Compare with another capture" picker, verify lazy-loaded list shows captures with dates and "Scheduled" badges
- [ ] Manual: click a capture in the picker, verify diff view loads correctly with proper base/target ordering
- [ ] Manual: verify picker hides when only one capture exists for the URL

Resolves #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)
