### PR TITLE
feat: Stripe-authoritative billing amounts

### DIFF
--- a/.claude/rules/gh-secrets-naming.md
+++ b/.claude/rules/gh-secrets-naming.md
@@ -1,0 +1,14 @@
+GitHub Actions secrets use the `WRL_` prefix (e.g., `WRL_PIRSCH_ACCESS_KEY`),
+matching the variable names in `~/.secrets`. Cloudflare Worker secrets do NOT
+use the prefix (e.g., `PIRSCH_ACCESS_KEY`).
+
+Workflow files map between the two:
+```yaml
+env:
+  PIRSCH_ACCESS_KEY: ${{ secrets.WRL_PIRSCH_ACCESS_KEY }}
+```
+
+When provisioning a new secret, set it in three places:
+1. Cloudflare Worker: `wrangler secret put THING` (no prefix)
+2. GitHub Actions: `gh secret set WRL_THING --env production` (with prefix)
+3. `~/.secrets` / `~/.wrl-keys`: `WRL_THING=...` (with prefix)

--- a/docs/INTERNALS.md
+++ b/docs/INTERNALS.md
@@ -94,6 +94,9 @@ WRL is a single Cloudflare Worker (`src/index.js`) that captures web pages via a
 | `grace_period_end` | TEXT | nullable | ISO 8601. Non-null only when `billing_status = 'grace_period'` |
 | `payment_method_added_at` | TEXT | nullable | ISO 8601. Set once when `checkout.session.completed` fires; never unset |
 | `eidas_qualified` | INTEGER | NOT NULL, default `0` | App-layer 0/1. Per-tenant opt-in for eIDAS qualified timestamps |
+| `stripe_invoice_amount_cents` | INTEGER | nullable | Cached Stripe upcoming invoice `amount_due` in cents. Updated hourly by meter reporter |
+| `stripe_invoice_currency` | TEXT | nullable | Cached Stripe invoice currency (e.g. `eur`). Updated with `stripe_invoice_amount_cents` |
+| `stripe_invoice_cached_at` | TEXT | nullable | ISO 8601. When the invoice cache was last refreshed |
 
 #### `captures`
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -168,6 +168,8 @@ Deferred items with explicit activation triggers. Revisit when condition is met.
 |------|-----------|--------|
 | ~~[should] Wire Stripe meter event reporting into capture pipeline~~ | ~~When first paying tenant onboards~~ -- DONE (Phase 0060): hourly batch reporter with idempotency keys, graduated pricing module, billing dashboard endpoint (Issue #108) | Phase 0058 |
 | ~~[consider] Stripe Checkout returnUrl from client config~~ | ~~Partially addressed: Phase 0076 billing UI sets returnUrl to `/ui#/billing`; full configurability not needed~~ | Phase 0058 → 0076 |
+| [consider] Daily full-refresh invoice cache for inactive tenants | When inactive tenants accumulate stale cached amounts that confuse the billing UI | Phase 0107, deferred |
+| [consider] eIDAS charges in invoice cache | When eIDAS line items are broken out separately in Stripe invoices | Phase 0107, deferred |
 
 ### Security
 

--- a/docs/evolution/0107-stripe-authoritative-billing/decisions.md
+++ b/docs/evolution/0107-stripe-authoritative-billing/decisions.md
@@ -1,0 +1,59 @@
+# Decisions -- Phase 0107
+
+## Cache on `tenants` vs `usage_counters`
+
+**Decision**: Cache invoice data on `tenants` table.
+
+The upcoming invoice is per-customer (per-tenant), not per-period. A tenant's
+invoice amount encompasses all usage across periods. Caching on `tenants`
+avoids the question of which period row to use.
+
+## GET param fix in `stripeRequest`
+
+**Decision**: Fix `stripeRequest` to put params in query string for GET
+requests.
+
+`stripeRequest` previously always put params in the request body. Stripe's
+`GET /v1/invoices/upcoming` requires the `customer` param in the query string.
+This is a correctness fix that makes the helper usable for all GET endpoints.
+POST requests continue using form-encoded body.
+
+## Fallback for free tenants
+
+**Decision**: Free tenants and paid tenants without a cached invoice fall
+back to `calculateCharges()`.
+
+The response includes `source: 'stripe'` or `source: 'local'` so the UI can
+annotate estimates with "(estimated)". This is purely cosmetic but helps
+users understand the data freshness.
+
+## Invoice cache refresh timing
+
+**Decision**: Refresh invoice cache in the same hourly cron run as meter
+events, as a second pass after all meter events are pushed.
+
+This ensures the cached amount reflects the latest usage that was just
+reported. Alternatives considered:
+- Separate cron job: unnecessary complexity for a single additional API call
+- On every capture: too many Stripe API calls, would hit rate limits
+- Daily batch: acceptable staleness, but hourly costs nothing extra since
+  the meter reporter already runs hourly
+
+## Stale cache on inactive tenants
+
+**Decision**: Accept stale cache for inactive tenants (no usage in current
+period).
+
+If a tenant has no usage, they don't appear in the meter reporter query, so
+their cache stays unchanged. At early stage this is acceptable -- the cache
+will update as soon as any usage occurs. A future enhancement could add a
+daily full-refresh for all paid tenants.
+
+## Cache cleared on subscription deletion
+
+**Decision**: Clear the invoice cache when a subscription is deleted.
+
+The `customer.subscription.deleted` webhook handler already blocks captures.
+Clearing the cache ensures the UI doesn't show a stale amount for a
+cancelled subscription. The UI falls back to `calculateCharges()` which
+will show EUR 0.00.

--- a/docs/evolution/0107-stripe-authoritative-billing/outcome.md
+++ b/docs/evolution/0107-stripe-authoritative-billing/outcome.md
@@ -1,0 +1,61 @@
+# Outcome -- Phase 0107
+
+## What was built
+
+The billing UI now shows Stripe's actual upcoming invoice amount for paid
+tenants instead of a locally computed estimate. The system works as follows:
+
+1. **Hourly meter reporter** pushes usage events to Stripe, then fetches
+   `GET /v1/invoices/upcoming` per tenant and caches `amount_due` + `currency`
+   on the `tenants` table in D1.
+
+2. **Usage endpoint** (`GET /v1/account/usage`) reads the cached amount for
+   paid tenants and returns it with `source: 'stripe'`. Falls back to
+   `calculateCharges()` with `source: 'local'` for free tenants or when
+   cache is empty.
+
+3. **Subscription deletion webhook** clears the cache so the UI doesn't
+   show stale amounts after cancellation.
+
+4. **UI annotation**: Billing view shows "(estimated)" next to the charges
+   label when `source: 'local'` and tenant has a payment method, indicating
+   the amount hasn't been confirmed by Stripe yet.
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `src/stripe.js` | Fixed GET param handling in `stripeRequest`; added `getUpcomingInvoice` |
+| `src/db.js` | Added `cacheStripeInvoice`, `clearStripeInvoiceCache` |
+| `src/meter-reporter.js` | Added invoice cache refresh pass after meter events |
+| `src/account.js` | Read cache in `handleAccountGetUsage`, return `source` field |
+| `src/billing.js` | Clear cache in `handleSubscriptionDeleted` |
+| `src/ui/ui-billing.js` | "(estimated)" annotation for local-source charges |
+| `migrations/0017_invoice_cache.sql` | 3 new columns on `tenants` table |
+| `test/stripe.test.js` | GET param handling tests |
+| `test/billing.test.js` | Invoice cache DB functions, usage source field, sub deletion cache clear |
+
+## API response change
+
+The `billing.currentCharges` object in `GET /v1/account/usage` now includes
+a `source` field:
+
+```json
+{
+  "billing": {
+    "currentCharges": {
+      "amount": 7.50,
+      "currency": "EUR",
+      "source": "stripe"
+    }
+  }
+}
+```
+
+This is an additive change -- existing clients ignore the new field.
+
+## Backlog changes
+
+- **Deferred**: Daily full-refresh for inactive tenants (acceptable staleness
+  at early stage)
+- **Deferred**: eIDAS invoice caching (not yet broken out in Stripe invoices)

--- a/docs/evolution/0107-stripe-authoritative-billing/prompt.md
+++ b/docs/evolution/0107-stripe-authoritative-billing/prompt.md
@@ -1,0 +1,26 @@
+# Phase 0107: Stripe-Authoritative Billing Amounts
+
+## Task
+
+Make the billing UI show Stripe's actual upcoming invoice amount instead of
+a locally computed estimate.
+
+The billing UI currently computes charges via `calculateCharges(captureCount)`
+in `src/pricing.js`. This is an estimate -- not what Stripe will actually
+invoice. If Stripe applies credits, rounding differs, or pricing drifts
+between `pricing.js` and the Stripe Dashboard, the UI shows the wrong number.
+
+## Approach
+
+After the hourly meter reporter pushes usage events to Stripe, have it also
+pull back the upcoming invoice total via `GET /v1/invoices/upcoming` and cache
+`amount_due` on the `tenants` table. The billing UI then reads the
+Stripe-authoritative amount instead of computing locally. Free tenants (no
+subscription) keep using `calculateCharges()`.
+
+## Prior Work
+
+- Calendar month billing anchor (phase 0102)
+- Draft invoice hold via `invoice.created` webhook
+- `updateInvoice` helper in `stripe.js`
+- Meter reporter pushing usage events to Stripe

--- a/docs/evolution/README.md
+++ b/docs/evolution/README.md
@@ -113,3 +113,4 @@ software development.
 | [0104-segment-faq-landing-page](0104-segment-faq-landing-page/) | Segment-targeted FAQ expansion: 12 questions across legal, OSINT, compliance, brand protection with FAQPage JSON-LD (Issue #255) |
 | [0105-auto-investigate-coralogix-alerts](0105-auto-investigate-coralogix-alerts/) | Automated Coralogix alert investigation via webhook receiver, GitHub Actions, and Claude Code (Issue #139) |
 | [0106-diff-view-any-two-captures](0106-diff-view-any-two-captures/) | Compare any two captures of the same URL from the dashboard, not just the latest scheduled pair (Issue #236) |
+| [0107-stripe-authoritative-billing](0107-stripe-authoritative-billing/) | Stripe-authoritative billing amounts: cache upcoming invoice from Stripe, show actual vs estimated charges |

--- a/migrations/0017_invoice_cache.sql
+++ b/migrations/0017_invoice_cache.sql
@@ -1,0 +1,5 @@
+-- Cache upcoming invoice amounts from Stripe on the tenants table.
+-- Populated by the hourly meter reporter after pushing meter events.
+ALTER TABLE tenants ADD COLUMN stripe_invoice_amount_cents INTEGER;
+ALTER TABLE tenants ADD COLUMN stripe_invoice_currency TEXT;
+ALTER TABLE tenants ADD COLUMN stripe_invoice_cached_at TEXT;

--- a/src/account.js
+++ b/src/account.js
@@ -477,6 +477,8 @@ export async function handleAccountGetUsage(request, env, ctx, _match) {
   }
 
   let hasPaymentMethod, billingStatus, gracePeriodEnd, quota, captureCount, storageBytes, period;
+  let invoiceCacheCents = null;
+  let invoiceCacheCurrency = null;
 
   if (result.allowed) {
     // Common case: under both limits, checkQuota returns full data.
@@ -487,13 +489,24 @@ export async function handleAccountGetUsage(request, env, ctx, _match) {
     captureCount     = result.captureCount;
     storageBytes     = result.storageBytes;
     period           = result.period;
+
+    // Read invoice cache for paid tenants
+    if (hasPaymentMethod) {
+      const cacheRow = await env.DB.prepare(
+        'SELECT stripe_invoice_amount_cents, stripe_invoice_currency FROM tenants WHERE id = ?',
+      ).bind(tenantId).first();
+      invoiceCacheCents    = cacheRow?.stripe_invoice_amount_cents ?? null;
+      invoiceCacheCurrency = cacheRow?.stripe_invoice_currency ?? null;
+    }
   } else {
     // Already over a limit or billing blocked. checkQuota returns a limited shape.
     // Read the tenant + usage rows directly to build a complete response.
     period = result.period ?? computePeriod();
     const [tenantRow, usageRow] = await env.DB.batch([
       env.DB.prepare(
-        'SELECT config, payment_method_added_at, billing_status, grace_period_end FROM tenants WHERE id = ?',
+        `SELECT config, payment_method_added_at, billing_status, grace_period_end,
+                stripe_invoice_amount_cents, stripe_invoice_currency
+         FROM tenants WHERE id = ?`,
       ).bind(tenantId),
       env.DB.prepare(
         'SELECT capture_count, storage_bytes FROM usage_counters WHERE tenant_id = ? AND period = ?',
@@ -504,6 +517,8 @@ export async function handleAccountGetUsage(request, env, ctx, _match) {
     hasPaymentMethod     = tenantData?.payment_method_added_at != null;
     billingStatus        = tenantData?.billing_status ?? 'active';
     gracePeriodEnd       = tenantData?.grace_period_end ?? null;
+    invoiceCacheCents    = tenantData?.stripe_invoice_amount_cents ?? null;
+    invoiceCacheCurrency = tenantData?.stripe_invoice_currency ?? null;
     quota                = getEffectiveQuota(hasPaymentMethod, config);
     const usageData      = usageRow.results?.[0];
     captureCount         = usageData?.capture_count ?? 0;
@@ -522,17 +537,25 @@ export async function handleAccountGetUsage(request, env, ctx, _match) {
     : (quota?.capturesPerMonth ?? null);
 
   const charges = calculateCharges(captureCount);
+
+  // Use Stripe-authoritative amount for paid tenants when cache is available
+  const useStripeCache = hasPaymentMethod && invoiceCacheCents !== null;
+  const chargeAmount   = useStripeCache ? invoiceCacheCents / 100 : charges.amount;
+  const chargeCurrency = useStripeCache ? (invoiceCacheCurrency ?? 'eur').toUpperCase() : charges.currency;
+  const chargeSource   = useStripeCache ? 'stripe' : 'local';
+
   const billing = {
     currentCharges: {
-      amount:   charges.amount,
-      currency: charges.currency,
+      amount:   chargeAmount,
+      currency: chargeCurrency,
+      source:   chargeSource,
     },
     tier:  charges.currentTier,
     tiers: charges.tiers,
     invoiceThreshold: {
       amount:   INVOICE_THRESHOLD_EUR,
       currency: 'EUR',
-      met:      charges.amount >= INVOICE_THRESHOLD_EUR,
+      met:      chargeAmount >= INVOICE_THRESHOLD_EUR,
     },
   };
 

--- a/src/billing.js
+++ b/src/billing.js
@@ -20,6 +20,7 @@ import {
   createPortalSession,
   createCustomer,
   createSubscription,
+  updateInvoice,
 } from './stripe.js';
 import {
   verifyStripeSignature,
@@ -32,6 +33,7 @@ import {
   setPaymentMethodAdded,
   setBillingStatus,
   getTenantByStripeCustomerId,
+  clearStripeInvoiceCache,
 } from './db.js';
 import { dispatchNotification } from './email-dispatch.js';
 import { trackEventRaw } from './pirsch.js';
@@ -109,6 +111,7 @@ export async function handleBillingCheckout(request, env, ctx) {
       customer: customerId,
       mode: 'subscription',
       'line_items[0][price]': env.STRIPE_CAPTURE_PRICE_ID,
+      'subscription_data[billing_cycle_anchor_config][day_of_month]': '1',
       success_url: returnUrl,
       cancel_url: returnUrl,
     });
@@ -283,6 +286,9 @@ async function dispatchWebhookEvent(event, env, ctx) {
     case 'checkout.session.completed':
       await handleCheckoutCompleted(event, env, ctx);
       break;
+    case 'invoice.created':
+      await handleInvoiceCreated(event, env, ctx);
+      break;
     case 'invoice.finalized':
       await handleInvoiceFinalized(event, env, ctx);
       break;
@@ -346,6 +352,30 @@ async function handleCheckoutCompleted(event, env, ctx) {
     event: 'billing.checkout_completed',
     tenantId: tenant.id,
     stripeCustomerId: customerId,
+  }) ?? Promise.resolve());
+}
+
+/**
+ * invoice.created: Stripe has created a draft invoice.
+ * Disable auto_advance so the invoice stays in draft until manually finalized.
+ * This gives us time to review usage and run a final meter flush before charging.
+ */
+async function handleInvoiceCreated(event, env, ctx) {
+  const invoice = event.data?.object;
+  if (!invoice?.id || invoice.status !== 'draft') return;
+
+  const customerId = invoice.customer;
+  if (!customerId) return;
+
+  const tenant = await getTenantByStripeCustomerId(env.DB, customerId);
+  if (!tenant) return;
+
+  await updateInvoice(env, invoice.id, { auto_advance: false });
+
+  ctx.waitUntil(log(env, 3, 'billing', {
+    event: 'billing.invoice_draft_held',
+    tenantId: tenant.id,
+    stripeInvoiceId: invoice.id,
   }) ?? Promise.resolve());
 }
 
@@ -478,6 +508,9 @@ async function handleSubscriptionDeleted(event, env, ctx) {
   if (tenant.billingStatus !== 'blocked') {
     await setBillingStatus(env.DB, tenant.id, 'blocked');
   }
+
+  // Clear cached invoice so UI doesn't show stale amounts
+  await clearStripeInvoiceCache(env.DB, tenant.id);
 
   ctx.waitUntil(log(env, 4, 'billing', {
     event: 'billing.subscription_deleted',

--- a/src/db.js
+++ b/src/db.js
@@ -1060,6 +1060,43 @@ export async function getTenantBilling(db, tenantId) {
 }
 
 /**
+ * Cache the upcoming Stripe invoice amount for a tenant.
+ *
+ * @param {D1Database} db
+ * @param {string} tenantId
+ * @param {number} amountCents  Stripe amount_due in cents
+ * @param {string} currency     e.g. 'eur'
+ * @returns {Promise<void>}
+ */
+export async function cacheStripeInvoice(db, tenantId, amountCents, currency) {
+  const now = new Date().toISOString();
+  await db.prepare(
+    `UPDATE tenants
+     SET stripe_invoice_amount_cents = ?, stripe_invoice_currency = ?,
+         stripe_invoice_cached_at = ?, updated_at = ?
+     WHERE id = ?`,
+  ).bind(amountCents, currency, now, now, tenantId).run();
+}
+
+/**
+ * Clear the cached Stripe invoice data for a tenant.
+ * Used when a subscription is deleted or Stripe returns 404 (no subscription).
+ *
+ * @param {D1Database} db
+ * @param {string} tenantId
+ * @returns {Promise<void>}
+ */
+export async function clearStripeInvoiceCache(db, tenantId) {
+  const now = new Date().toISOString();
+  await db.prepare(
+    `UPDATE tenants
+     SET stripe_invoice_amount_cents = NULL, stripe_invoice_currency = NULL,
+         stripe_invoice_cached_at = NULL, updated_at = ?
+     WHERE id = ?`,
+  ).bind(now, tenantId).run();
+}
+
+/**
  * Set the eidas_qualified flag for a tenant. Creates the tenant row if absent.
  *
  * @param {D1Database} db

--- a/src/meter-reporter.js
+++ b/src/meter-reporter.js
@@ -1,6 +1,6 @@
 // tva
-import { computePeriod } from './db.js';
-import { reportMeterEvent } from './stripe.js';
+import { computePeriod, cacheStripeInvoice, clearStripeInvoiceCache } from './db.js';
+import { reportMeterEvent, getUpcomingInvoice } from './stripe.js';
 import { log } from './log.js';
 
 /**
@@ -168,10 +168,46 @@ export async function reportPendingMeterEvents(env, ctx) {
     }
   }
 
+  // --- Second pass: cache upcoming invoice amounts per customer ---
+  // Collect unique stripeCustomerId → tenantId pairs from processed rows
+  const customerMap = new Map();
+  for (const row of results) {
+    if (row.stripe_customer_id && !customerMap.has(row.stripe_customer_id)) {
+      customerMap.set(row.stripe_customer_id, row.tenant_id);
+    }
+  }
+
+  let invoiceCachedCount = 0;
+  let invoiceFailedCount = 0;
+
+  for (const [customerId, tenantId] of customerMap) {
+    try {
+      const invoice = await getUpcomingInvoice(env, customerId);
+      if (invoice) {
+        await cacheStripeInvoice(env.DB, tenantId, invoice.amount_due, invoice.currency);
+        invoiceCachedCount++;
+      } else {
+        // No active subscription -- clear stale cache
+        await clearStripeInvoiceCache(env.DB, tenantId);
+      }
+    } catch (err) {
+      // Log warning, keep stale cache -- next hourly run retries
+      log(env, 4, 'meter', {
+        event: 'meter.invoice_cache_fail',
+        tenantId,
+        stripeCustomerId: customerId,
+        errorMessage: String(err?.message ?? '').slice(0, 256),
+      });
+      invoiceFailedCount++;
+    }
+  }
+
   log(env, 3, 'meter', {
     event: 'meter.report_cycle_complete',
     reportedCount,
     failedCount,
+    invoiceCachedCount,
+    invoiceFailedCount,
     durationMs: Date.now() - startMs,
     periods,
   });

--- a/src/stripe.js
+++ b/src/stripe.js
@@ -52,16 +52,22 @@ export function flattenParams(obj, prefix = '') {
  * @returns {Promise<object>}
  */
 export async function stripeRequest(env, method, path, params) {
-  const url = `${STRIPE_BASE}${path}`;
+  let url = `${STRIPE_BASE}${path}`;
   const headers = {
     'Authorization': `Bearer ${env.STRIPE_SECRET_KEY}`,
     'Stripe-Version': STRIPE_API_VERSION,
-    'Content-Type': 'application/x-www-form-urlencoded',
   };
 
-  const body = params && Object.keys(params).length > 0
-    ? new URLSearchParams(flattenParams(params)).toString()
-    : undefined;
+  let body;
+  if (params && Object.keys(params).length > 0) {
+    const encoded = new URLSearchParams(flattenParams(params)).toString();
+    if (method === 'GET') {
+      url += `?${encoded}`;
+    } else {
+      headers['Content-Type'] = 'application/x-www-form-urlencoded';
+      body = encoded;
+    }
+  }
 
   const response = await fetch(url, { method, headers, body });
   const data = await response.json();
@@ -112,10 +118,39 @@ export function createSubscription(env, params) {
 }
 
 /**
+ * POST /v1/invoices/:id
+ * @param {{ STRIPE_SECRET_KEY: string }} env
+ * @param {string} invoiceId
+ * @param {object} params
+ */
+export function updateInvoice(env, invoiceId, params) {
+  return stripeRequest(env, 'POST', `/v1/invoices/${invoiceId}`, params);
+}
+
+/**
  * POST /v1/billing/meter_events
  * @param {{ STRIPE_SECRET_KEY: string }} env
  * @param {object} params
  */
 export function reportMeterEvent(env, params) {
   return stripeRequest(env, 'POST', '/v1/billing/meter_events', params);
+}
+
+/**
+ * GET /v1/invoices/upcoming
+ * Returns the upcoming invoice for a customer, or null if no active subscription.
+ *
+ * @param {{ STRIPE_SECRET_KEY: string }} env
+ * @param {string} customerId
+ * @returns {Promise<object|null>}
+ */
+export async function getUpcomingInvoice(env, customerId) {
+  try {
+    return await stripeRequest(env, 'GET', '/v1/invoices/upcoming', {
+      customer: customerId,
+    });
+  } catch (err) {
+    if (err.status === 404) return null;
+    throw err;
+  }
 }

--- a/src/ui/ui-billing.js
+++ b/src/ui/ui-billing.js
@@ -270,9 +270,13 @@ function buildPeriodSummary(usageData) {
 
   // Stat 2: Current charges
   var charges = billing.currentCharges || {};
+  var chargesLabel = 'Current charges';
+  if (charges.source === 'local' && usageData.hasPaymentMethod) {
+    chargesLabel = 'Current charges (estimated)';
+  }
   statsRow.appendChild(buildStatCell(
     formatCurrency(charges.amount != null ? charges.amount : 0),
-    'Current charges'
+    chargesLabel
   ));
 
   // Stat 3: Current tier with sr-only description

--- a/test/billing.test.js
+++ b/test/billing.test.js
@@ -4,7 +4,7 @@
 import { env, SELF } from 'cloudflare:test';
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import { cleanDb, createTestSession, seedGithubUser } from './fixtures.js';
-import { setStripeCustomerId, setPaymentMethodAdded, setBillingStatus } from '../src/db.js';
+import { setStripeCustomerId, setPaymentMethodAdded, setBillingStatus, cacheStripeInvoice, clearStripeInvoiceCache } from '../src/db.js';
 
 beforeEach(async () => {
   await cleanDb(env.DB);
@@ -107,6 +107,11 @@ describe('POST /v1/billing/checkout', () => {
     const stripeCalls = fetch.mock.calls;
     const customerCall = stripeCalls.find(([u]) => String(u).includes('/v1/customers'));
     expect(customerCall).toBeDefined();
+
+    // Verify checkout session includes billing_cycle_anchor_config
+    const checkoutCall = stripeCalls.find(([u]) => String(u).includes('/v1/checkout/sessions'));
+    const checkoutBody = checkoutCall[1]?.body;
+    expect(checkoutBody).toContain('subscription_data%5Bbilling_cycle_anchor_config%5D%5Bday_of_month%5D=1');
   });
 
   it('reuses existing Stripe customer ID', async () => {
@@ -350,6 +355,42 @@ describe('POST /v1/stripe/webhook', () => {
     expect(row.billing_status).toBe('blocked');
   });
 
+  it('handles invoice.created and disables auto_advance on draft invoices', async () => {
+    const session = await setupSessionAndTenant(env.DB, env);
+    await setStripeCustomerId(env.DB, session.tenantId, 'cus_inv_created');
+
+    // Stub fetch to intercept the invoice update call
+    vi.stubGlobal('fetch', vi.fn().mockImplementation(async (url) => {
+      const urlStr = String(url);
+      if (urlStr.includes('api.stripe.com/v1/invoices/in_draft_123')) {
+        return new Response(JSON.stringify({ id: 'in_draft_123', auto_advance: false }), { status: 200 });
+      }
+      // Coralogix, Pirsch, etc.
+      return new Response('{}', { status: 200 });
+    }));
+
+    const event = {
+      id: 'evt_inv_created_1',
+      type: 'invoice.created',
+      data: { object: { id: 'in_draft_123', customer: 'cus_inv_created', status: 'draft' } },
+    };
+    const rawBody = JSON.stringify(event);
+    const { header } = await computeStripeSignature(rawBody, webhookSecret);
+
+    const res = await SELF.fetch('https://wrl.test/v1/stripe/webhook', {
+      method: 'POST',
+      headers: { 'Stripe-Signature': header },
+      body: rawBody,
+    });
+    expect(res.status).toBe(200);
+
+    // Verify the invoice update API was called with auto_advance=false
+    const invoiceCall = fetch.mock.calls.find(([u]) => String(u).includes('/v1/invoices/in_draft_123'));
+    expect(invoiceCall).toBeDefined();
+    const invoiceBody = invoiceCall[1]?.body;
+    expect(invoiceBody).toContain('auto_advance=false');
+  });
+
   it('silently acknowledges unhandled event types', async () => {
     const event = {
       id: 'evt_unhandled_1',
@@ -386,5 +427,119 @@ describe('POST /v1/stripe/webhook', () => {
     });
     // Should NOT be 401 (no session required)
     expect(res.status).toBe(200);
+  });
+
+  it('subscription.deleted clears invoice cache', async () => {
+    const session = await setupSessionAndTenant(env.DB, env);
+    await setStripeCustomerId(env.DB, session.tenantId, 'cus_cache_del');
+    await setPaymentMethodAdded(env.DB, session.tenantId);
+    await cacheStripeInvoice(env.DB, session.tenantId, 1250, 'eur');
+
+    // Verify cache was written
+    const before = await env.DB.prepare(
+      'SELECT stripe_invoice_amount_cents FROM tenants WHERE id = ?',
+    ).bind(session.tenantId).first();
+    expect(before.stripe_invoice_amount_cents).toBe(1250);
+
+    const event = {
+      id: 'evt_cache_del_1',
+      type: 'customer.subscription.deleted',
+      data: { object: { customer: 'cus_cache_del', id: 'sub_cache_del' } },
+    };
+    const rawBody = JSON.stringify(event);
+    const { header } = await computeStripeSignature(rawBody, webhookSecret);
+
+    const res = await SELF.fetch('https://wrl.test/v1/stripe/webhook', {
+      method: 'POST',
+      headers: { 'Stripe-Signature': header },
+      body: rawBody,
+    });
+    expect(res.status).toBe(200);
+
+    const after = await env.DB.prepare(
+      'SELECT stripe_invoice_amount_cents, stripe_invoice_currency, stripe_invoice_cached_at FROM tenants WHERE id = ?',
+    ).bind(session.tenantId).first();
+    expect(after.stripe_invoice_amount_cents).toBeNull();
+    expect(after.stripe_invoice_currency).toBeNull();
+    expect(after.stripe_invoice_cached_at).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Invoice cache DB functions
+// ---------------------------------------------------------------------------
+
+describe('Invoice cache DB functions', () => {
+  it('cacheStripeInvoice writes and reads correctly', async () => {
+    const session = await setupSessionAndTenant(env.DB, env);
+
+    await cacheStripeInvoice(env.DB, session.tenantId, 4200, 'eur');
+
+    const row = await env.DB.prepare(
+      'SELECT stripe_invoice_amount_cents, stripe_invoice_currency, stripe_invoice_cached_at FROM tenants WHERE id = ?',
+    ).bind(session.tenantId).first();
+    expect(row.stripe_invoice_amount_cents).toBe(4200);
+    expect(row.stripe_invoice_currency).toBe('eur');
+    expect(row.stripe_invoice_cached_at).not.toBeNull();
+  });
+
+  it('clearStripeInvoiceCache nulls all columns', async () => {
+    const session = await setupSessionAndTenant(env.DB, env);
+    await cacheStripeInvoice(env.DB, session.tenantId, 1000, 'eur');
+
+    await clearStripeInvoiceCache(env.DB, session.tenantId);
+
+    const row = await env.DB.prepare(
+      'SELECT stripe_invoice_amount_cents, stripe_invoice_currency, stripe_invoice_cached_at FROM tenants WHERE id = ?',
+    ).bind(session.tenantId).first();
+    expect(row.stripe_invoice_amount_cents).toBeNull();
+    expect(row.stripe_invoice_currency).toBeNull();
+    expect(row.stripe_invoice_cached_at).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /v1/account/usage -- source field
+// ---------------------------------------------------------------------------
+
+describe('GET /v1/account/usage source field', () => {
+  it('returns source: stripe when paid tenant has cached invoice', async () => {
+    const session = await setupSessionAndTenant(env.DB, env);
+    await setStripeCustomerId(env.DB, session.tenantId, 'cus_usage_stripe');
+    await setPaymentMethodAdded(env.DB, session.tenantId);
+    await cacheStripeInvoice(env.DB, session.tenantId, 750, 'eur');
+
+    const res = await SELF.fetch('https://wrl.test/v1/account/usage', {
+      headers: { Cookie: session.cookie },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.billing.currentCharges.source).toBe('stripe');
+    expect(body.billing.currentCharges.amount).toBe(7.5);
+    expect(body.billing.currentCharges.currency).toBe('EUR');
+  });
+
+  it('returns source: local for free tenants', async () => {
+    const session = await setupSessionAndTenant(env.DB, env);
+
+    const res = await SELF.fetch('https://wrl.test/v1/account/usage', {
+      headers: { Cookie: session.cookie },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.billing.currentCharges.source).toBe('local');
+  });
+
+  it('returns source: local for paid tenant without cache', async () => {
+    const session = await setupSessionAndTenant(env.DB, env);
+    await setStripeCustomerId(env.DB, session.tenantId, 'cus_no_cache');
+    await setPaymentMethodAdded(env.DB, session.tenantId);
+
+    const res = await SELF.fetch('https://wrl.test/v1/account/usage', {
+      headers: { Cookie: session.cookie },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.billing.currentCharges.source).toBe('local');
   });
 });

--- a/test/stripe.test.js
+++ b/test/stripe.test.js
@@ -89,6 +89,30 @@ describe('stripeRequest', () => {
     expect(opts.body).toBeUndefined();
   });
 
+  it('puts params in query string for GET requests', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ id: 'inv_upcoming' }), { status: 200 }),
+    ));
+
+    await stripeRequest(env, 'GET', '/v1/invoices/upcoming', { customer: 'cus_123' });
+    const [url, opts] = fetch.mock.calls[0];
+    expect(url).toContain('/v1/invoices/upcoming?customer=cus_123');
+    expect(opts.body).toBeUndefined();
+    expect(opts.headers['Content-Type']).toBeUndefined();
+  });
+
+  it('puts params in body for POST requests', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ id: 'cus_new' }), { status: 200 }),
+    ));
+
+    await stripeRequest(env, 'POST', '/v1/customers', { email: 'a@b.com' });
+    const [url, opts] = fetch.mock.calls[0];
+    expect(url).not.toContain('?');
+    expect(opts.body).toContain('email=a%40b.com');
+    expect(opts.headers['Content-Type']).toBe('application/x-www-form-urlencoded');
+  });
+
   it('throws on non-2xx with Stripe error message', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
       new Response(JSON.stringify({


### PR DESCRIPTION
## Summary

- Meter reporter now fetches `GET /v1/invoices/upcoming` after pushing events and caches `amount_due` on the `tenants` table (D1 migration 0017)
- Usage endpoint returns Stripe-authoritative amount (`source: 'stripe'`) for paid tenants, falls back to local `calculateCharges()` (`source: 'local'`) for free tenants or empty cache
- Fixes `stripeRequest` to use query string params for GET requests
- Clears invoice cache on `subscription.deleted` webhook
- UI shows "(estimated)" when using local fallback for paid tenants

## Migration

Already applied to both staging and production D1:
```
migrations/0017_invoice_cache.sql
```

## Test plan

- [x] All existing billing tests pass
- [x] New tests: `cacheStripeInvoice`, `clearStripeInvoiceCache`, usage endpoint `source` field, subscription deletion clears cache, `stripeRequest` GET params
- [ ] Deploy to staging via merge (triggers GH Actions)
- [ ] Verify `stripe_invoice_amount_cents` populates after next hourly cron
- [ ] Hit `GET /v1/account/usage` on staging — verify `billing.currentCharges.source === 'stripe'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
