### PR TITLE
fix(pirsch): log non-2xx responses instead of silently swallowing them

### DIFF
--- a/src/pirsch.js
+++ b/src/pirsch.js
@@ -24,6 +24,16 @@ function _send(env, endpoint, body) {
         Authorization: `Bearer ${env.PIRSCH_ACCESS_KEY}`,
       },
       body: JSON.stringify(body),
+    }).then((res) => {
+      // Pirsch returns 200 even when it later drops a hit as bot traffic, so a 2xx
+      // is "accepted" and we stay silent (a bot-drop is not actionable). A non-2xx
+      // is a real failure -- 401 = invalid/rotated access key, 400 = validation,
+      // 429 = rate limit -- which would otherwise silently halt all analytics with
+      // no trace. Fail loudly so a dead key surfaces in Coralogix, not weeks later
+      // via a "no traffic" email.
+      if (!res.ok) {
+        log(env, 4, 'pirsch', { event: 'pirsch.send_rejected', endpoint, status: res.status });
+      }
     }).catch((err) => {
       log(env, 4, 'pirsch', { event: 'pirsch.send_fail', endpoint, errorMessage: String(err?.message ?? '').slice(0, 128) });
     });

--- a/test/pirsch.test.js
+++ b/test/pirsch.test.js
@@ -1,6 +1,7 @@
 import { fetchMock } from 'cloudflare:test';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { trackHit, trackEvent, trackEventRaw } from '../src/pirsch.js';
+import * as logModule from '../src/log.js';
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -162,5 +163,40 @@ describe('pirsch -- error resilience', () => {
 
     // Errors are logged to Coralogix (no-op in test env without CORALOGIX_ENDPOINT)
     await expect(trackHit(mockRequest(), mockEnv, {})).resolves.not.toThrow();
+  });
+
+  it('logs pirsch.send_rejected on a non-2xx response (e.g. 401 dead key)', async () => {
+    const logSpy = vi.spyOn(logModule, 'log').mockImplementation(() => undefined);
+
+    fetchMock
+      .get(PIRSCH_ORIGIN)
+      .intercept({ path: HIT_PATH, method: 'POST' })
+      .reply(401, 'unauthorized');
+
+    await expect(trackHit(mockRequest(), mockEnv, {})).resolves.not.toThrow();
+
+    expect(logSpy).toHaveBeenCalledWith(
+      mockEnv,
+      4,
+      'pirsch',
+      expect.objectContaining({ event: 'pirsch.send_rejected', status: 401 }),
+    );
+
+    logSpy.mockRestore();
+  });
+
+  it('stays silent on a 200 response (bot-drops are not actionable)', async () => {
+    const logSpy = vi.spyOn(logModule, 'log').mockImplementation(() => undefined);
+
+    fetchMock
+      .get(PIRSCH_ORIGIN)
+      .intercept({ path: HIT_PATH, method: 'POST' })
+      .reply(200, 'ok');
+
+    await trackHit(mockRequest(), mockEnv, {});
+
+    expect(logSpy).not.toHaveBeenCalled();
+
+    logSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Why

A Pirsch "no traffic for >1 day" warning email prompted an investigation. Root cause turned out to be benign — `webresourceledger.com` genuinely had **0 human visitors on 2026-06-26** (a single-digit-daily-traffic marketing site; bots are correctly filtered by Pirsch). Tracking was confirmed healthy: access key valid (test hit → HTTP 200), data flowing again on 2026-06-27, June totals 106 visitors / 250 views.

But the investigation surfaced a real latent bug worth fixing.

## What

`src/pirsch.js._send()` used `fetch().catch()`, which only catches **network** errors. An HTTP `401` (rotated/invalid access key), `400` (validation), or `429` (rate limit) resolves successfully and was **never logged**. A dead key would silently halt *all* analytics with no trace — exactly the dangerous failure mode this alert *could* have been, surfacing only weeks later via email.

This change logs `pirsch.send_rejected` (severity 4, subsystem `pirsch`) on any non-2xx response, while staying silent on 2xx — a hit dropped by Pirsch's bot filter still returns 200 and is not actionable. Aligns with the project's hard "fail loudly, degrade intentionally" rule.

## Tests

- Added: logs `pirsch.send_rejected` with `status: 401` on a 401 response.
- Added: stays silent on a 200 response.
- `npx vitest run test/pirsch.test.js` → **9/9 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
