### PR TITLE
fix(deploy): stop CI from silently dropping run_worker_first on landing

### DIFF
--- a/.claude/skills/ops-runbook/SKILL.md
+++ b/.claude/skills/ops-runbook/SKILL.md
@@ -319,6 +319,54 @@ If an issue exists, read its findings before re-investigating.
 
 ---
 
+## Pirsch Analytics
+
+### Query visitor stats (is traffic being recorded?)
+
+The write-only access key (`pa_...`) cannot read stats. Exchange the OAuth
+client credentials for a token first. Domain ID for webresourceledger.com
+is `0DdKAMZgZ2` (also in `~/.secrets` as `WRL_PIRSCH_DOMAIN_ID`).
+
+```bash
+source ~/.secrets
+TOKEN=$(curl -s -X POST https://api.pirsch.io/api/v1/token \
+  -H "Content-Type: application/json" \
+  -d "{\"client_id\":\"$WRL_PIRSCH_CLIENT_ID\",\"client_secret\":\"$WRL_PIRSCH_CLIENT_SECRET\"}" \
+  | jq -r .access_token)
+curl -s "https://api.pirsch.io/api/v1/statistics/visitor?id=$WRL_PIRSCH_DOMAIN_ID&from=2026-07-01&to=2026-07-13" \
+  -H "Authorization: Bearer $TOKEN" | jq -r '.[] | "\(.day[:10]) visitors=\(.visitors) views=\(.views)"'
+```
+
+An error of `"Domain not found."` usually means the `id` parameter was
+empty/wrong, not that the domain is gone — list domains with
+`GET /api/v1/domain` using the same token.
+
+### "Didn't receive any traffic" warning emails
+
+Pirsch sends these twice daily (00:00/12:00 UTC) while the domain records
+zero traffic (threshold: 1 day). Debug order:
+
+1. Check `pirsch` subsystem in Coralogix (all three apps: `wrl`,
+   `wrl-landing`, `wrl-docs`): `pirsch.send_rejected` = Pirsch refused the
+   hit (400 = validation, e.g. bot request without User-Agent; 401 = dead
+   key). No events at all = sends aren't happening.
+2. Check the landing site is actually served BY THE WORKER:
+   `curl -sI https://webresourceledger.com/` must show
+   `content-security-policy` and `cache-control: private`. If instead you
+   see `cf-cache-status: HIT` with `cache-control: public, max-age=0,
+   must-revalidate` and no security headers, the deployed Worker version
+   lost `assets.run_worker_first` and Cloudflare serves assets directly —
+   no tracking, no headers. Root cause July 2026: deploy workflow used
+   wrangler-action's bundled wrangler 3.90.0, which silently drops the
+   field (fixed in PR #289 by `npm ci` + a post-deploy CSP assertion).
+   Verify deployed flag: `GET /accounts/{acct}/workers/scripts/wrl-landing/versions/{id}`
+   → `resources.script_runtime.assets.raw_run_worker_first`.
+3. Remember Pirsch returns 200 and then silently drops hits it considers
+   bot traffic — datacenter IPs and headless UAs never show up in stats.
+   Test recovery with a real browser UA from a residential IP.
+
+---
+
 ## Resend (email)
 
 ### Check recent email deliveries

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -77,3 +77,22 @@ jobs:
         env:
           PIRSCH_ACCESS_KEY: ${{ secrets.WRL_PIRSCH_ACCESS_KEY }}
           CORALOGIX_SEND_KEY: ${{ secrets.WRL_CORALOGIX_SEND_KEY }}
+
+      # Assert the Worker actually fronts the site. If run_worker_first got
+      # dropped (old wrangler, config drift), assets are served straight from
+      # the CDN cache: no CSP header, no tracking -- and nothing fails. This
+      # check turns that silent regression into a red deploy.
+      - name: Verify Worker serves the site
+        run: |
+          for i in 1 2 3 4 5 6; do
+            headers=$(curl -sI --max-time 10 https://docs.webresourceledger.com/ || true)
+            if echo "$headers" | grep -qi '^content-security-policy:'; then
+              echo "OK: Worker security headers present"
+              exit 0
+            fi
+            echo "Attempt $i: CSP header missing, retrying in 10s..."
+            sleep 10
+          done
+          echo "FAIL: Worker is not serving docs.webresourceledger.com (no CSP header)."
+          echo "Likely cause: assets.run_worker_first missing from the deployed version."
+          exit 1

--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -26,6 +26,20 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      # Install the repo-pinned wrangler. Without a local install,
+      # wrangler-action falls back to its bundled wrangler 3.90.0, which does
+      # not know assets.run_worker_first and silently drops it -- deploying
+      # the landing site in serve-directly mode where the Worker (security
+      # headers, Pirsch tracking) never runs. That exact failure shipped on
+      # 2026-03-30 and again on 2026-06-27.
+      - name: Install dependencies (pins wrangler version)
+        run: npm ci
+
       - name: Copy design-system.css
         run: cp src/design-system.css landing/public/css/design-system.css
 
@@ -45,3 +59,22 @@ jobs:
         env:
           PIRSCH_ACCESS_KEY: ${{ secrets.WRL_PIRSCH_ACCESS_KEY }}
           CORALOGIX_SEND_KEY: ${{ secrets.WRL_CORALOGIX_SEND_KEY }}
+
+      # Assert the Worker actually fronts the site. If run_worker_first got
+      # dropped (old wrangler, config drift), assets are served straight from
+      # the CDN cache: no CSP header, no tracking -- and nothing fails. This
+      # check turns that silent regression into a red deploy.
+      - name: Verify Worker serves the site
+        run: |
+          for i in 1 2 3 4 5 6; do
+            headers=$(curl -sI --max-time 10 https://webresourceledger.com/ || true)
+            if echo "$headers" | grep -qi '^content-security-policy:'; then
+              echo "OK: Worker security headers present"
+              exit 0
+            fi
+            echo "Attempt $i: CSP header missing, retrying in 10s..."
+            sleep 10
+          done
+          echo "FAIL: Worker is not serving webresourceledger.com (no CSP header)."
+          echo "Likely cause: assets.run_worker_first missing from the deployed version."
+          exit 1

--- a/landing/wrangler.toml
+++ b/landing/wrangler.toml
@@ -2,15 +2,21 @@ name = "wrl-landing"
 compatibility_date = "2026-03-13"
 main = "src/index.js"
 
-[assets]
-directory = "./public"
-binding = "ASSETS"
-run_worker_first = true
-
+# routes must stay ABOVE the [assets] section: TOML assigns every key after a
+# section header to that section, so placing routes below [assets] turns it
+# into the unknown field assets.routes, which wrangler silently ignores.
 routes = [
   { pattern = "webresourceledger.com", custom_domain = true },
   { pattern = "www.webresourceledger.com", custom_domain = true }
 ]
+
+[assets]
+directory = "./public"
+binding = "ASSETS"
+# run_worker_first is required: without it, requests for existing assets are
+# served directly from Cloudflare's asset cache and the Worker never runs --
+# no security headers, no Cache-Control: private, no Pirsch tracking.
+run_worker_first = true
 
 [vars]
 CORALOGIX_ENDPOINT = "https://ingress.eu2.coralogix.com/logs/v1/singles"

--- a/site/wrangler.toml
+++ b/site/wrangler.toml
@@ -2,14 +2,20 @@ name = "wrl-docs"
 compatibility_date = "2026-03-13"
 main = "src/index.js"
 
-[assets]
-directory = "./_output"
-binding = "ASSETS"
-run_worker_first = true
-
+# routes must stay ABOVE the [assets] section: TOML assigns every key after a
+# section header to that section, so placing routes below [assets] turns it
+# into the unknown field assets.routes, which wrangler silently ignores.
 routes = [
   { pattern = "docs.webresourceledger.com", custom_domain = true }
 ]
+
+[assets]
+directory = "./_output"
+binding = "ASSETS"
+# run_worker_first is required: without it, requests for existing assets are
+# served directly from Cloudflare's asset cache and the Worker never runs --
+# no security headers, no Cache-Control: private, no Pirsch tracking.
+run_worker_first = true
 
 [vars]
 CORALOGIX_ENDPOINT = "https://ingress.eu2.coralogix.com/logs/v1/singles"


### PR DESCRIPTION
## Problem

Pirsch has been sending twice-daily "webresourceledger.com didn't receive any traffic" warnings since 2026-06-27. The traffic exists — but the landing Worker never sees it.

## Root cause

`deploy-landing.yml` never runs `npm ci`, so `wrangler-action` falls back to its **bundled wrangler 3.90.0**. That version predates `assets.run_worker_first`, warns `Unexpected fields found in assets field: "run_worker_first","routes"` in the CI log, drops the field, and deploys the Worker in **serve-directly mode**: any request matching a static asset is served from Cloudflare's asset/CDN cache and the Worker never runs.

Verified against the Cloudflare API (worker version configs):

| wrl-landing version | Deployed by | `run_worker_first` |
|---|---|---|
| 2026-03-30 07:55 (CI) | wrangler 3.90.0 | `false` (broken) |
| 2026-03-30 08:05 (local hotfix) | wrangler 4.x | `true` (working Apr–Jun) |
| 2026-06-27 16:35 (CI, live until now) | wrangler 3.90.0 | `false` (broken again) |

`wrl-docs` was unaffected because its workflow runs `npm ci` (for the 11ty build), so wrangler-action picked up the repo-pinned wrangler 4.73.0.

Observable damage while broken: no Pirsch hits (hence the emails), no Worker security headers (CSP, X-Frame-Options, …), `Cache-Control: public` instead of `private` on HTML, no pageview logs in Coralogix (only cache-missing bot 404s got through to the Worker).

## Fix

- **deploy-landing.yml**: `setup-node` + `npm ci` before wrangler-action, so the repo-pinned wrangler 4.73.0 deploys the config as written.
- **Both deploy workflows**: post-deploy assertion that the live site responds with the Worker-injected `content-security-policy` header. A silent worker-bypass now fails the deploy instead of surfacing weeks later via Pirsch warning emails.
- **Both wrangler.toml files**: moved top-level `routes` above the `[assets]` section. TOML assigns keys after a section header to that section, so `routes` was actually `assets.routes` — ignored by wrangler on every deploy (custom domains only kept working because they persist server-side).

## Verification

- `npx wrangler deploy --dry-run` (wrangler 4.73.0) from `landing/` parses the reordered config with no "Unexpected fields" warnings.
- Both workflow files pass YAML validation.
- Post-merge: the Deploy Landing run's new verify step asserts the CSP header on the live site; Pirsch traffic resumption to be confirmed via dashboard/API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
